### PR TITLE
fix: undefined properties not synced

### DIFF
--- a/src/tv2-common/updatePolicies/partProperties.ts
+++ b/src/tv2-common/updatePolicies/partProperties.ts
@@ -1,27 +1,48 @@
 import {
 	BlueprintSyncIngestNewData,
 	BlueprintSyncIngestPartInstance,
+	IBlueprintMutatablePart,
 	SyncIngestUpdateToPartInstanceContext
 } from '@sofie-automation/blueprints-integration'
 import _ = require('underscore')
+
+type Complete<T> = {
+	[P in keyof Required<T>]: Pick<T, P> extends Required<Pick<T, P>> ? T[P] : T[P] | undefined
+}
+
+const partPropertiesToOmit = [
+	'_id',
+	'externalId',
+	'autoNext',
+	'autoNextOverlap',
+	'prerollDuration',
+	'transitionPrerollDuration',
+	'transitionKeepaliveDuration',
+	'transitionDuration',
+	'disableOutTransition',
+	'shouldNotifyCurrentPlayingPart'
+] as const
+
+const clearedMutatablePart: Complete<Omit<IBlueprintMutatablePart, typeof partPropertiesToOmit[number] | 'title'>> = {
+	metaData: undefined,
+	expectedDuration: undefined,
+	budgetDuration: undefined,
+	holdMode: undefined,
+	classes: undefined,
+	classesForNext: undefined,
+	displayDurationGroup: undefined,
+	displayDuration: undefined,
+	identifier: undefined,
+	hackListenToMediaObjectUpdates: undefined
+}
 
 export function updatePartProperties(
 	context: SyncIngestUpdateToPartInstanceContext,
 	_existingPartInstance: BlueprintSyncIngestPartInstance,
 	newPart: BlueprintSyncIngestNewData
 ) {
-	context.updatePartInstance(
-		_.omit(
-			newPart.part,
-			'_id',
-			'externalId',
-			'autoNext',
-			'autoNextOverlap',
-			'prerollDuration',
-			'transitionPrerollDuration',
-			'transitionKeepaliveDuration',
-			'transitionDuration',
-			'disableOutTransition'
-		)
-	)
+	context.updatePartInstance({
+		...clearedMutatablePart,
+		..._.omit(newPart.part, ...partPropertiesToOmit)
+	})
 }


### PR DESCRIPTION
Some properties were not syncing on `syncIngestUpdateToPartInstance` when from defined they become undefined.
The new part comes from cache/db and loses all properties that were explicitly set to undefined or are no longer defined. 
We need to set them to undefined if we want them unset by `updatePartInstance`.
Complicated types should help spotting issues if `IBlueprintMutatablePart` changes in the future