### PR TITLE
[SOF-541] fix: Don't create a new part when the server video Id is changed

### DIFF
--- a/src/tv2-common/helpers/postProcessDefinitions.ts
+++ b/src/tv2-common/helpers/postProcessDefinitions.ts
@@ -65,6 +65,7 @@ function getExternalId(segmentId: string, partDefinition: PartDefinition, foundM
 			// No way of uniquely identifying, add some entropy from cues
 			id += `-${partDefinition.rawType}-${partDefinition.variant.name}-${partDefinition.cues.length}`
 			break
+		case PartType.VO:
 		case PartType.Server:
 			// Changing the videoId would result in a new part if videoId is used as part of the ex ternalId
 			// There _should_ only be one server per story so this is safe, however,
@@ -73,10 +74,6 @@ function getExternalId(segmentId: string, partDefinition: PartDefinition, foundM
 		case PartType.Teknik:
 			// Possibly an unused part type, not seen in production - only one example found in original test data
 			id += `-TEKNIK`
-			break
-		case PartType.VO:
-			// Only one video Id per story. Changing the video Id will result in a new part
-			id += `-${partDefinition.fields.videoId}`
 			break
 		case PartType.Grafik:
 		case PartType.DVE:

--- a/src/tv2-common/helpers/postProcessDefinitions.ts
+++ b/src/tv2-common/helpers/postProcessDefinitions.ts
@@ -66,8 +66,9 @@ function getExternalId(segmentId: string, partDefinition: PartDefinition, foundM
 			id += `-${partDefinition.rawType}-${partDefinition.variant.name}-${partDefinition.cues.length}`
 			break
 		case PartType.Server:
-			// Only one video Id per story. Changing the video Id will result in a new part
-			id += `-${partDefinition.fields.videoId ? partDefinition.fields.videoId : 'noId'}`
+			// Changing the videoId would result in a new part if videoId is used as part of the ex ternalId
+			// There _should_ only be one server per story so this is safe, however,
+			// if more than one server is present then we'll fall back to the indexing method.
 			break
 		case PartType.Teknik:
 			// Possibly an unused part type, not seen in production - only one example found in original test data


### PR DESCRIPTION
The externalId of the part is tied to the videoId field from iNews. This means that if the videoId changes, a new externalId is created and Sofie creates a new part, leaving an orphaned part instance if the part is set as next.

This PR removes the videoId from the externalId, relying on using the `padId` function applied to all parts to pad the externalId according to the elements position, which was already being done on top of the videoId.

This should be safe, as we only expect one Server per story.