### PR TITLE
fix: Ignore floated segments, count time only until first continuity story

### DIFF
--- a/src/inews-mixins/__tests__/rundownDuration.spec.ts
+++ b/src/inews-mixins/__tests__/rundownDuration.spec.ts
@@ -1,0 +1,123 @@
+import { IngestSegment } from '@sofie-automation/blueprints-integration'
+import { literal } from 'tv2-common'
+import { getRundownDuration } from '../rundownDuration'
+
+function makeSegmentWithoutTime(externalId: string, rank: number): IngestSegment {
+	return literal<IngestSegment>({
+		externalId,
+		name: externalId,
+		rank,
+		parts: []
+	})
+}
+
+function makeSegmentWithTime(externalId: string, time: number, rank: number, floated?: boolean): IngestSegment {
+	const segment = makeSegmentWithoutTime(externalId, rank)
+	segment.payload = {
+		iNewsStory: {
+			fields: {
+				totalTime: time
+			},
+			meta: {
+				float: floated ? 'float' : undefined
+			}
+		}
+	}
+	return segment
+}
+
+describe('Rundown Duration', () => {
+	it('Adds all times in rundown', () => {
+		const segments = [
+			makeSegmentWithTime('test-segment_1', 1, 0),
+			makeSegmentWithTime('test-segment_2', 1, 1),
+			makeSegmentWithTime('test-segment_3', 2, 2),
+			makeSegmentWithTime('test-segment_4', 3, 3)
+		]
+
+		const result = getRundownDuration(segments)
+		expect(result).toEqual(7000)
+	})
+
+	it('Excludes segments after continuity', () => {
+		const segments = [
+			makeSegmentWithTime('test-segment_1', 1, 0),
+			makeSegmentWithTime('test-segment_2', 1, 1),
+			makeSegmentWithTime('test-segment_3', 2, 2),
+			makeSegmentWithTime('continuity', 2, 3),
+			makeSegmentWithTime('test-segment_4', 3, 4)
+		]
+
+		const result = getRundownDuration(segments)
+		expect(result).toEqual(6000)
+	})
+
+	it('Uses the first continuity segment in the rundown as the cutoff', () => {
+		const segments = [
+			makeSegmentWithTime('test-segment_1', 1, 0),
+			makeSegmentWithTime('test-segment_2', 1, 1),
+			makeSegmentWithTime('continuity', 2, 2),
+			makeSegmentWithTime('test-segment_3', 2, 3),
+			makeSegmentWithTime('continuity', 2, 4),
+			makeSegmentWithTime('test-segment_4', 3, 5)
+		]
+
+		const result = getRundownDuration(segments)
+		expect(result).toEqual(4000)
+	})
+
+	it('Does not include floated segments in timing', () => {
+		const segments = [
+			makeSegmentWithTime('test-segment_1', 1, 0, true),
+			makeSegmentWithTime('test-segment_2', 1, 1, true),
+			makeSegmentWithTime('continuity', 2, 2),
+			makeSegmentWithTime('test-segment_3', 2, 3),
+			makeSegmentWithTime('continuity', 2, 4),
+			makeSegmentWithTime('test-segment_4', 3, 5, true)
+		]
+
+		const result = getRundownDuration(segments)
+		expect(result).toEqual(2000)
+	})
+
+	it('Ignores floated continuity segment', () => {
+		const segments = [
+			makeSegmentWithTime('test-segment_1', 1, 0),
+			makeSegmentWithTime('test-segment_2', 1, 1),
+			makeSegmentWithTime('continuity', 2, 2, true),
+			makeSegmentWithTime('test-segment_3', 2, 3),
+			makeSegmentWithTime('continuity', 2, 4),
+			makeSegmentWithTime('test-segment_4', 3, 5)
+		]
+
+		const result = getRundownDuration(segments)
+		expect(result).toEqual(6000)
+	})
+
+	it('Handles segments without payload', () => {
+		// Shouldn't be possible, but we should test that we can accept missing payload data
+		const segments = [
+			makeSegmentWithTime('test-segment_1', 1, 0),
+			makeSegmentWithTime('test-segment_2', 1, 1),
+			makeSegmentWithoutTime('test-segment_3', 2),
+			makeSegmentWithTime('test-segment_4', 3, 3)
+		]
+
+		const result = getRundownDuration(segments)
+		expect(result).toEqual(5000)
+	})
+
+	it('Handles segments arriving out of order', () => {
+		// Tests whether it sorts segments by rank
+		const segments = [
+			makeSegmentWithTime('continuity', 2, 3),
+			makeSegmentWithTime('test-segment_4', 3, 4),
+			makeSegmentWithTime('test-segment_1', 1, 0),
+			makeSegmentWithTime('test-segment_2', 1, 1),
+			makeSegmentWithTime('test-segment_3', 2, 2)
+		]
+
+		const result = getRundownDuration(segments)
+		expect(result).toEqual(6000)
+	})
+})

--- a/src/inews-mixins/__tests__/rundownDuration.spec.ts
+++ b/src/inews-mixins/__tests__/rundownDuration.spec.ts
@@ -39,7 +39,7 @@ describe('Rundown Duration', () => {
 		expect(result).toEqual(7000)
 	})
 
-	it('Excludes segments after continuity', () => {
+	it('Excludes segments after continuity (and continuity timing)', () => {
 		const segments = [
 			makeSegmentWithTime('test-segment_1', 1, 0),
 			makeSegmentWithTime('test-segment_2', 1, 1),
@@ -49,7 +49,7 @@ describe('Rundown Duration', () => {
 		]
 
 		const result = getRundownDuration(segments)
-		expect(result).toEqual(6000)
+		expect(result).toEqual(4000)
 	})
 
 	it('Uses the first continuity segment in the rundown as the cutoff', () => {
@@ -63,21 +63,22 @@ describe('Rundown Duration', () => {
 		]
 
 		const result = getRundownDuration(segments)
-		expect(result).toEqual(4000)
+		expect(result).toEqual(2000)
 	})
 
 	it('Does not include floated segments in timing', () => {
 		const segments = [
 			makeSegmentWithTime('test-segment_1', 1, 0, true),
 			makeSegmentWithTime('test-segment_2', 1, 1, true),
+			makeSegmentWithTime('test-segment_3', 1, 1),
 			makeSegmentWithTime('continuity', 2, 2),
-			makeSegmentWithTime('test-segment_3', 2, 3),
+			makeSegmentWithTime('test-segment_4', 2, 3),
 			makeSegmentWithTime('continuity', 2, 4),
-			makeSegmentWithTime('test-segment_4', 3, 5, true)
+			makeSegmentWithTime('test-segment_5', 3, 5, true)
 		]
 
 		const result = getRundownDuration(segments)
-		expect(result).toEqual(2000)
+		expect(result).toEqual(1000)
 	})
 
 	it('Ignores floated continuity segment', () => {
@@ -91,7 +92,7 @@ describe('Rundown Duration', () => {
 		]
 
 		const result = getRundownDuration(segments)
-		expect(result).toEqual(6000)
+		expect(result).toEqual(4000)
 	})
 
 	it('Handles segments without payload', () => {
@@ -118,6 +119,6 @@ describe('Rundown Duration', () => {
 		]
 
 		const result = getRundownDuration(segments)
-		expect(result).toEqual(6000)
+		expect(result).toEqual(4000)
 	})
 })

--- a/src/inews-mixins/playlist.ts
+++ b/src/inews-mixins/playlist.ts
@@ -14,6 +14,7 @@ import {
 	StudioBlueprintManifest
 } from '@sofie-automation/blueprints-integration'
 import { assertUnreachable, literal } from 'tv2-common'
+import { getRundownDuration } from './rundownDuration'
 
 interface RundownMetaData {
 	rank: number
@@ -46,9 +47,7 @@ function getRundownWithBackTime(
 	const backTime = backTimeStory ? backTimeStory.payload.iNewsStory.fields.backTime : undefined
 
 	let expectedEnd: number | undefined
-	const expectedDuration =
-		ingestRundown.segments.reduce((prev, curr) => prev + Number(curr.payload?.iNewsStory?.fields?.totalTime) ?? 0, 0) *
-		1000
+	const expectedDuration = getRundownDuration(ingestRundown.segments)
 
 	if (backTime) {
 		const backTimeNum = Number(backTime.replace(/^@/, ''))

--- a/src/inews-mixins/rundownDuration.ts
+++ b/src/inews-mixins/rundownDuration.ts
@@ -1,0 +1,21 @@
+import { IngestSegment } from '@sofie-automation/blueprints-integration'
+import { INewsPayload } from 'tv2-common'
+
+export function getRundownDuration(segments: IngestSegment[]) {
+	let totalTime = 0
+	for (const segment of segments.sort((a, b) => a.rank - b.rank)) {
+		const payload = segment.payload as INewsPayload | undefined
+		if (payload?.iNewsStory?.meta?.float === 'float') {
+			continue
+		}
+
+		const time = payload?.iNewsStory?.fields.totalTime ?? 0
+		totalTime += Number(time)
+
+		if (segment.name.match(/continuity/i)) {
+			break
+		}
+	}
+
+	return totalTime * 1000
+}

--- a/src/inews-mixins/rundownDuration.ts
+++ b/src/inews-mixins/rundownDuration.ts
@@ -9,12 +9,12 @@ export function getRundownDuration(segments: IngestSegment[]) {
 			continue
 		}
 
-		const time = payload?.iNewsStory?.fields.totalTime ?? 0
-		totalTime += Number(time)
-
 		if (segment.name.match(/continuity/i)) {
 			break
 		}
+
+		const time = payload?.iNewsStory?.fields.totalTime ?? 0
+		totalTime += Number(time)
 	}
 
 	return totalTime * 1000

--- a/src/tv2-common/getSegment.ts
+++ b/src/tv2-common/getSegment.ts
@@ -8,6 +8,7 @@ import {
 import {
 	assertUnreachable,
 	GetNextPartCue,
+	INewsStory,
 	IsTargetingFull,
 	literal,
 	ParseBody,
@@ -21,7 +22,6 @@ import * as _ from 'underscore'
 import { TV2BlueprintConfigBase, TV2StudioConfigBase } from './blueprintConfig'
 import {
 	CueDefinitionUnpairedTarget,
-	INewsStory,
 	PartDefinitionDVE,
 	PartDefinitionEkstern,
 	PartDefinitionGrafik,

--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -1,40 +1,6 @@
-import { PostProcessDefinitions, TV2BlueprintConfig } from 'tv2-common'
+import { PostProcessDefinitions, TV2BlueprintConfig, UnparsedCue } from 'tv2-common'
 import { CueType, PartType } from 'tv2-constants'
-import { CueDefinition, CueDefinitionUnpairedPilot, ParseCue, UnpairedPilotToGraphic, UnparsedCue } from './ParseCue'
-
-interface INewsFields {
-	title: string
-	modifyDate: string // number
-	pageNumber?: string
-	tapeTime: string // number
-	audioTime: string // number
-	totalTime: string // number
-	cumeTime: string // number
-	backTime: string // number
-}
-
-interface INewsMetaData {
-	wire?: 'f' | 'b' | 'u' | 'r' | 'o'
-	mail?: 'read' | 'unread'
-	locked?: 'pass' | 'user'
-	words?: string // number
-	rate?: string // number
-	break?: string
-	mcserror?: string
-	hold?: string
-	float?: 'float' | undefined
-	delete?: string
-}
-
-export interface INewsStory {
-	/** Same identifier as the file the story came from */
-	identifier: string
-	locator: string
-	fields: INewsFields
-	meta: INewsMetaData
-	cues: Array<UnparsedCue | null>
-	body?: string
-}
+import { CueDefinition, CueDefinitionUnpairedPilot, ParseCue, UnpairedPilotToGraphic } from './ParseCue'
 
 export interface PartTransition {
 	style: string

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -1,8 +1,6 @@
-import { GetInfiniteModeForGraphic, literal, TV2BlueprintConfig } from 'tv2-common'
+import { GetInfiniteModeForGraphic, literal, TV2BlueprintConfig, UnparsedCue } from 'tv2-common'
 import { CueType, GraphicEngine, PartType } from 'tv2-constants'
 import { getTransitionProperties, PartDefinition, PartdefinitionTypes, stripTransitionProperties } from './ParseBody'
-
-export type UnparsedCue = string[] | null
 
 export interface CueTime {
 	frames?: number

--- a/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
@@ -31,9 +31,9 @@ import {
 	CueDefinitionUnpairedPilot,
 	CueDefinitionUnpairedTarget,
 	GraphicInternal,
-	GraphicPilot,
-	UnparsedCue
+	GraphicPilot
 } from '../ParseCue'
+import { UnparsedCue } from 'tv2-common'
 
 const fields = {}
 

--- a/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
@@ -1,4 +1,5 @@
 import { IBlueprintRundownDB, PlaylistTimingType } from '@sofie-automation/blueprints-integration'
+import { UnparsedCue } from 'tv2-common'
 import { CueType, PartType } from 'tv2-constants'
 import { SegmentUserContext } from '../../../../__mocks__/context'
 import { defaultShowStyleConfig, defaultStudioConfig } from '../../../../tv2_afvd_showstyle/__tests__/configs'
@@ -33,7 +34,6 @@ import {
 	GraphicInternal,
 	GraphicPilot
 } from '../ParseCue'
-import { UnparsedCue } from 'tv2-common'
 
 const fields = {}
 

--- a/src/tv2-common/migrations/shortcuts.ts
+++ b/src/tv2-common/migrations/shortcuts.ts
@@ -59,7 +59,7 @@ export function SetSourceLayerNameMigrationStep(
 			context.updateSourceLayer(sourceLayerId, sourceLayer)
 		}
 	})
-} 
+}
 
 export function SetClearShortcutListTransitionStep(
 	versionStr: string,

--- a/src/tv2-common/types/index.ts
+++ b/src/tv2-common/types/index.ts
@@ -1,1 +1,2 @@
 export * from './config'
+export * from './inews'

--- a/src/tv2-common/types/inews.ts
+++ b/src/tv2-common/types/inews.ts
@@ -1,0 +1,39 @@
+interface INewsFields {
+	title: string
+	modifyDate: string // number
+	pageNumber?: string
+	tapeTime: string // number
+	audioTime: string // number
+	totalTime: string // number
+	cumeTime: string // number
+	backTime: string // number
+}
+
+interface INewsMetaData {
+	wire?: 'f' | 'b' | 'u' | 'r' | 'o'
+	mail?: 'read' | 'unread'
+	locked?: 'pass' | 'user'
+	words?: string // number
+	rate?: string // number
+	break?: string
+	mcserror?: string
+	hold?: string
+	float?: 'float' | undefined
+	delete?: string
+}
+
+export interface INewsStory {
+	/** Same identifier as the file the story came from */
+	identifier: string
+	locator: string
+	fields: INewsFields
+	meta: INewsMetaData
+	cues: Array<UnparsedCue | null>
+	body?: string
+}
+
+export interface INewsPayload {
+	iNewsStory?: INewsStory
+}
+
+export type UnparsedCue = string[] | null

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -159,7 +159,7 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	// AUX group
 	SetSourceLayerNameMigrationStep('1.6.9', SourceLayer.VizFullIn1, 'Full Inp 1'),
 	SetSourceLayerNameMigrationStep('1.6.9', SourceLayer.AuxStudioScreen, 'AUX studio screen'),
-	
+
 	// Fill in any layers that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations
 	...getSourceLayerDefaultsMigrationSteps(VERSION),

--- a/src/tv2_offtube_showstyle/migrations/index.ts
+++ b/src/tv2_offtube_showstyle/migrations/index.ts
@@ -161,16 +161,20 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	 * - Renaming source layers
 	 */
 	// OVERLAY group
-	 SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsIdent, 'GFX Ident'),
-	 SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsIdentPersistent, 'GFX Ident Persistent (hidden)'),
-	 SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsTop, 'GFX Top'),
-	 SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsLower, 'GFX Lowerthirds'),
-	 SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsHeadline, 'GFX Headline'),
-	 SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsOverlay, 'GFX Overlay (fallback)'),
-	 SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsTLF, 'GFX Telefon'),
-	 SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsTema, 'GFX Tema'),
-	 SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.WallGraphics, 'GFX Wall'),
-	 SetSourceLayerNameMigrationStep('1.6.9', SharedSourceLayers.PgmPilotOverlay, 'GFX overlay (VCP)(shared)'),
+	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsIdent, 'GFX Ident'),
+	SetSourceLayerNameMigrationStep(
+		'1.6.9',
+		OfftubeSourceLayer.PgmGraphicsIdentPersistent,
+		'GFX Ident Persistent (hidden)'
+	),
+	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsTop, 'GFX Top'),
+	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsLower, 'GFX Lowerthirds'),
+	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsHeadline, 'GFX Headline'),
+	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsOverlay, 'GFX Overlay (fallback)'),
+	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsTLF, 'GFX Telefon'),
+	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmGraphicsTema, 'GFX Tema'),
+	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.WallGraphics, 'GFX Wall'),
+	SetSourceLayerNameMigrationStep('1.6.9', SharedSourceLayers.PgmPilotOverlay, 'GFX overlay (VCP)(shared)'),
 	// PGM group
 	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmCam, 'Camera'),
 	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmDVEAdLib, 'DVE (adlib)'),


### PR DESCRIPTION
The total duration of a rundown will now be calculated as the sum of the total time of all segments up to ~~and including~~ the first continuity story. Floated segments will not be included in the total rundown duration.