### PR TITLE
fix: Ignore continuity without backTime

### DIFF
--- a/src/inews-mixins/playlist.ts
+++ b/src/inews-mixins/playlist.ts
@@ -42,7 +42,7 @@ function getRundownWithBackTime(
 ): BlueprintResultRundown {
 	const sortedSegments = ingestRundown.segments.sort((a, b) => a.rank - b.rank)
 	const backTimeStory = sortedSegments.find(
-		segment => segment.name.match(/^continuity$/i) && segment.payload.iNewsStory.fields.backTime
+		segment => segment.name.match(/^\s*continuity\s*$/i) && segment.payload.iNewsStory.fields.backTime
 	)
 	const backTime = backTimeStory ? backTimeStory.payload.iNewsStory.fields.backTime : undefined
 

--- a/src/inews-mixins/rundownDuration.ts
+++ b/src/inews-mixins/rundownDuration.ts
@@ -9,7 +9,7 @@ export function getRundownDuration(segments: IngestSegment[]) {
 			continue
 		}
 
-		if (segment.name.match(/continuity/i)) {
+		if (segment.name.match(/^\s*continuity\s*$/i) && payload?.iNewsStory?.fields?.backTime?.match(/^@\d+$/)) {
 			break
 		}
 

--- a/src/tv2-common/getSegment.ts
+++ b/src/tv2-common/getSegment.ts
@@ -149,7 +149,7 @@ export function getSegmentBase<
 		return prev + cur.script.replace(/\n/g, '').replace(/\r/g, '').length
 	}, 0)
 
-	if (segment.name && segment.name.trim().match(/^CONTINUITY$/i)) {
+	if (segment.name && segment.name.trim().match(/^\s*continuity\s*$/i)) {
 		blueprintParts.push(showStyleOptions.CreatePartContinuity(config, ingestSegment))
 		return {
 			segment,

--- a/src/tv2-common/types/inews.ts
+++ b/src/tv2-common/types/inews.ts
@@ -6,7 +6,7 @@ interface INewsFields {
 	audioTime: string // number
 	totalTime: string // number
 	cumeTime: string // number
-	backTime: string // number
+	backTime?: string // number
 }
 
 interface INewsMetaData {


### PR DESCRIPTION
Fixes the calculation of rundown duration to not treat a continuity story as the end of timed content if it doesn't have a back time set