### PR TITLE
feat: untimed segments

### DIFF
--- a/src/tv2-common/getSegment.ts
+++ b/src/tv2-common/getSegment.ts
@@ -381,6 +381,10 @@ export function getSegmentBase<
 			actualPart.invalid = false
 		}
 
+		if (ingestSegment.payload?.untimed) {
+			actualPart.untimed = true
+		}
+
 		return {
 			...part,
 			part: actualPart

--- a/src/tv2_afvd_showstyle/getSegment.ts
+++ b/src/tv2_afvd_showstyle/getSegment.ts
@@ -57,7 +57,8 @@ export function CreatePartContinuity(config: ShowStyleConfig, ingestSegment: Ing
 	return literal<BlueprintResultPart>({
 		part: {
 			externalId: `${ingestSegment.externalId}-CONTINUITY`,
-			title: 'CONTINUITY'
+			title: 'CONTINUITY',
+			untimed: true
 		},
 		pieces: [
 			literal<IBlueprintPiece>({

--- a/src/tv2_offtube_showstyle/getSegment.ts
+++ b/src/tv2_offtube_showstyle/getSegment.ts
@@ -54,7 +54,8 @@ function CreatePartContinuity(config: OfftubeShowstyleBlueprintConfig, ingestSeg
 	return literal<BlueprintResultPart>({
 		part: {
 			externalId: `${ingestSegment.externalId}-CONTINUITY`,
-			title: 'CONTINUITY'
+			title: 'CONTINUITY',
+			untimed: true
 		},
 		pieces: [
 			literal<IBlueprintPiece>({


### PR DESCRIPTION
Make parts untimed based on the `untimed` property of the segment payload (or if the part is a Continuity part).
Part(s) in Klar on air need it so that only after we leave this segment the rundown/playlist is assigned a startedPlayback timestamp.
Parts in segments after (and including) Continuity need this property in order not to contribute to rundown timing and the diff. 