### PR TITLE
fix: rundown duration calculation with untimed segments

### DIFF
--- a/src/inews-mixins/rundownDuration.ts
+++ b/src/inews-mixins/rundownDuration.ts
@@ -5,12 +5,8 @@ export function getRundownDuration(segments: IngestSegment[]) {
 	let totalTime = 0
 	for (const segment of segments.sort((a, b) => a.rank - b.rank)) {
 		const payload = segment.payload as INewsPayload | undefined
-		if (payload?.iNewsStory?.meta?.float === 'float') {
+		if (payload?.iNewsStory?.meta?.float === 'float' || payload?.untimed) {
 			continue
-		}
-
-		if (segment.name.match(/^\s*continuity\s*$/i) && payload?.iNewsStory?.fields?.backTime?.match(/^@\d+$/)) {
-			break
 		}
 
 		const time = payload?.iNewsStory?.fields.totalTime ?? 0

--- a/src/tv2-common/types/inews.ts
+++ b/src/tv2-common/types/inews.ts
@@ -34,6 +34,7 @@ export interface INewsStory {
 
 export interface INewsPayload {
 	iNewsStory?: INewsStory
+	untimed?: boolean
 }
 
 export type UnparsedCue = string[] | null


### PR DESCRIPTION
Assignment of the `untimed` prop is a part of the iNews Gateway logic. Just use it by omitting every segment that has it.