### PR TITLE
fix: Remove graphics from AFVD minishelf

### DIFF
--- a/shelf-layouts/Mini_Shelf_Layout.json
+++ b/shelf-layouts/Mini_Shelf_Layout.json
@@ -4,39 +4,5 @@
 	"icon": "",
 	"iconColor": "#ffffff",
 	"regionId": "mini_shelf_layouts",
-	"filters": [
-		{
-			"_id": "mgFpbcnnCMKxBo5r5",
-			"type": "filter",
-			"name": "New Filter",
-			"currentSegment": false,
-			"displayStyle": "buttons",
-			"rank": 0,
-			"rundownBaseline": false,
-			"showThumbnailsInList": false,
-			"hideDuplicates": false,
-			"default": false,
-			"nextInCurrentPart": false,
-			"oneNextPerSourceLayer": false,
-			"sourceLayerIds": [
-				"studio0_clip",
-				"studio0_graphicsIdent",
-				"studio0_graphicsIdent_persistent",
-				"studio0_graphicsTop",
-				"studio0_graphicsLower",
-				"studio0_graphicsHeadline",
-				"studio0_graphicsTema",
-				"studio0_overlay",
-				"studio0_pilotOverlay"
-			],
-			"includeClearInRundownBaseline": false,
-			"sourceLayerTypes": [
-				2,
-				5
-			],
-			"tags": [
-				"flow_producer"
-			]
-		}
-	]
+	"filters": []
 }


### PR DESCRIPTION
Removes graphics from the minishelf, leaving just the server adlib buttons in the segment list. This essentially means that this layout is no longer needed, but I suggest that we keep it for the sake of config changes at a later date.