### PR TITLE
fix: Use cue source for ekstern part name

### DIFF
--- a/src/tv2-common/cues/ekstern.ts
+++ b/src/tv2-common/cues/ekstern.ts
@@ -59,7 +59,8 @@ export function EvaluateEksternBase<
 	adlib?: boolean,
 	rank?: number
 ) {
-	const eksternProps = parsedCue.source.match(/^(?:LIVE|SKYPE|FEED) ?([^\s]+)(?: (.+))?$/i)
+	const matchesEksternSource = /^(?:LIVE|SKYPE|FEED) ?([^\s]+)(?: (.+))?$/i
+	const eksternProps = parsedCue.source.match(matchesEksternSource)
 	if (!eksternProps) {
 		context.notifyUserWarning(`No source entered for EKSTERN`)
 		part.invalid = true

--- a/src/tv2-common/cues/ekstern.ts
+++ b/src/tv2-common/cues/ekstern.ts
@@ -59,10 +59,7 @@ export function EvaluateEksternBase<
 	adlib?: boolean,
 	rank?: number
 ) {
-	const eksternProps = parsedCue.source
-		.replace(/\s+/i, ' ')
-		.trim()
-		.match(/^(?:LIVE|SKYPE|FEED) ?([^\s]+)(?: (.+))?$/i)
+	const eksternProps = parsedCue.source.match(/^(?:LIVE|SKYPE|FEED) ?([^\s]+)(?: (.+))?$/i)
 	if (!eksternProps) {
 		context.notifyUserWarning(`No source entered for EKSTERN`)
 		part.invalid = true

--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -21,6 +21,7 @@ export interface PartDefinitionBase {
 	storyName: string
 	segmentExternalId: string
 	endWords?: string
+	/** Title set based on the primary cue for the following PartTypes: Grafik, DVE, Ekstern, Telefon, Unknown */
 	title?: string
 }
 

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -407,7 +407,7 @@ function parseEkstern(cue: string[]): CueDefinitionEkstern | undefined {
 		const transitionProperties = getTransitionProperties(cue[0])
 		return literal<CueDefinitionEkstern>({
 			type: CueType.Ekstern,
-			source: eksternSource[1],
+			source: eksternSource[1].replace(/\s+/i, ' ').trim(),
 			iNewsCommand: 'EKSTERN',
 			transition: transitionProperties
 		})

--- a/src/tv2_afvd_showstyle/parts/live.ts
+++ b/src/tv2_afvd_showstyle/parts/live.ts
@@ -23,7 +23,7 @@ export function CreatePartLive(
 	const partTime = PartTime(config, partDefinition, totalWords, false)
 	let part = literal<IBlueprintPart>({
 		externalId: partDefinition.externalId,
-		title: partDefinition.type + ' - ' + partDefinition.rawType,
+		title: partDefinition.title || 'Ekstern',
 		metaData: {},
 		expectedDuration: partTime > 0 ? partTime : 0
 	})


### PR DESCRIPTION
Use the title coming from the primary cue's source for Ekstern parts. It will say ‘LIVE 1’, ‘FEED 1’, ‘SKYPE 1’ etc.