### PR TITLE
feat: MINUSKAM cue

### DIFF
--- a/src/tv2-common/cues/ekstern.ts
+++ b/src/tv2-common/cues/ekstern.ts
@@ -116,7 +116,8 @@ export function EvaluateEksternBase<
 										: TSR.AtemTransitionStyle.CUT,
 									transitionSettings: TransitionSettings(partDefinition)
 								}
-							}
+							},
+							classes: [ControlClasses.LiveSourceOnAir]
 						}),
 
 						...GetSisyfosTimelineObjForEkstern(context, config.sources, parsedCue.source, GetLayersForEkstern),

--- a/src/tv2-common/cues/index.ts
+++ b/src/tv2-common/cues/index.ts
@@ -1,3 +1,4 @@
 export * from './dve'
 export * from './ekstern'
 export * from './lyd'
+export * from './mixMinus'

--- a/src/tv2-common/cues/mixMinus.ts
+++ b/src/tv2-common/cues/mixMinus.ts
@@ -56,7 +56,7 @@ function MixMinusContent(atemInput: number): WithTimeline<BaseContent> {
 				},
 				layer: SharedATEMLLayer.AtemAuxVideoMixMinus,
 				id: '',
-				priority: 1
+				priority: 0.5
 			})
 		])
 	})

--- a/src/tv2-common/cues/mixMinus.ts
+++ b/src/tv2-common/cues/mixMinus.ts
@@ -8,7 +8,7 @@ import {
 	WithTimeline
 } from '@sofie-automation/blueprints-integration'
 import { CueDefinitionMixMinus, FindSourceByName, literal, PartDefinition } from 'tv2-common'
-import { SharedATEMLLayer, SharedOutputLayers, SharedSourceLayers } from 'tv2-constants'
+import { ControlClasses, SharedATEMLLayer, SharedOutputLayers, SharedSourceLayers } from 'tv2-constants'
 import { TV2BlueprintConfig } from '../blueprintConfig'
 
 export function EvaluateCueMixMinus(
@@ -52,11 +52,11 @@ function MixMinusContent(atemInput: number): WithTimeline<BaseContent> {
 					}
 				},
 				enable: {
-					start: 0
+					while: ControlClasses.LiveSourceOnAir
 				},
 				layer: SharedATEMLLayer.AtemAuxVideoMixMinus,
 				id: '',
-				priority: 0.5
+				priority: 1
 			})
 		])
 	})

--- a/src/tv2-common/cues/mixMinus.ts
+++ b/src/tv2-common/cues/mixMinus.ts
@@ -1,0 +1,63 @@
+import {
+	BaseContent,
+	IBlueprintPiece,
+	IShowStyleUserContext,
+	PieceLifespan,
+	TimelineObjectCoreExt,
+	TSR,
+	WithTimeline
+} from '@sofie-automation/blueprints-integration'
+import { CueDefinitionMixMinus, FindSourceByName, literal, PartDefinition } from 'tv2-common'
+import { SharedATEMLLayer, SharedOutputLayers, SharedSourceLayers } from 'tv2-constants'
+import { TV2BlueprintConfig } from '../blueprintConfig'
+
+export function EvaluateCueMixMinus(
+	context: IShowStyleUserContext,
+	config: TV2BlueprintConfig,
+	pieces: IBlueprintPiece[],
+	part: PartDefinition,
+	parsedCue: CueDefinitionMixMinus
+) {
+	const sourceInfoMixMinus = FindSourceByName(context, config.sources, parsedCue.source)
+	if (sourceInfoMixMinus === undefined) {
+		context.notifyUserWarning(`${parsedCue.source} does not exist in this studio (MINUSKAM)`)
+		return
+	}
+	const atemInput = sourceInfoMixMinus.port
+
+	pieces.push(
+		literal<IBlueprintPiece>({
+			externalId: part.externalId,
+			name: `MixMinus: ${parsedCue.source}`,
+			enable: {
+				start: 0
+			},
+			lifespan: PieceLifespan.OutOnShowStyleEnd,
+			sourceLayerId: SharedSourceLayers.AuxMixMinus,
+			outputLayerId: SharedOutputLayers.AUX,
+			content: MixMinusContent(atemInput)
+		})
+	)
+}
+
+function MixMinusContent(atemInput: number): WithTimeline<BaseContent> {
+	return literal<WithTimeline<BaseContent>>({
+		timelineObjects: literal<TimelineObjectCoreExt[]>([
+			literal<TSR.TimelineObjAtemAUX>({
+				content: {
+					deviceType: TSR.DeviceType.ATEM,
+					type: TSR.TimelineContentTypeAtem.AUX,
+					aux: {
+						input: atemInput
+					}
+				},
+				enable: {
+					start: 0
+				},
+				layer: SharedATEMLLayer.AtemAuxVideoMixMinus,
+				id: '',
+				priority: 1
+			})
+		])
+	})
+}

--- a/src/tv2-common/cues/mixMinus.ts
+++ b/src/tv2-common/cues/mixMinus.ts
@@ -52,7 +52,7 @@ function MixMinusContent(atemInput: number): WithTimeline<BaseContent> {
 					}
 				},
 				enable: {
-					while: ControlClasses.LiveSourceOnAir
+					while: `.${ControlClasses.LiveSourceOnAir}`
 				},
 				layer: SharedATEMLLayer.AtemAuxVideoMixMinus,
 				id: '',

--- a/src/tv2-common/evaluateCues.ts
+++ b/src/tv2-common/evaluateCues.ts
@@ -25,6 +25,7 @@ import {
 	CueDefinitionBackgroundLoop,
 	CueDefinitionGraphic,
 	CueDefinitionGraphicDesign,
+	CueDefinitionMixMinus,
 	CueDefinitionPgmClean,
 	CueDefinitionRouting,
 	GraphicInternalOrPilot,
@@ -158,6 +159,13 @@ export interface EvaluateCuesShowstyleOptions {
 		pieces: IBlueprintPiece[],
 		partId: string,
 		parsedCue: CueDefinitionPgmClean
+	) => void
+	EvaluateCueMixMinus?: (
+		context: ISegmentUserContext,
+		config: TV2BlueprintConfig,
+		pieces: IBlueprintPiece[],
+		part: PartDefinition,
+		parsedCue: CueDefinitionMixMinus
 	) => void
 	/** TODO: Profile -> Change the profile as defined in VIZ device settings */
 	EvaluateCueProfile?: () => void
@@ -387,6 +395,11 @@ export function EvaluateCuesBase(
 				case CueType.PgmClean:
 					if (showStyleOptions.EvaluateCuePgmClean) {
 						showStyleOptions.EvaluateCuePgmClean(context, config, pieces, partDefinition.externalId, cue)
+					}
+					break
+				case CueType.MixMinus:
+					if (showStyleOptions.EvaluateCueMixMinus) {
+						showStyleOptions.EvaluateCueMixMinus(context, config, pieces, partDefinition, cue)
 					}
 					break
 				case CueType.UNPAIRED_TARGET:

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -79,6 +79,11 @@ export interface CueDefinitionClearGrafiks extends CueDefinitionBase {
 	type: CueType.ClearGrafiks
 }
 
+export interface CueDefinitionMixMinus extends CueDefinitionBase {
+	type: CueType.MixMinus
+	source: string
+}
+
 // If unpaired when evaluated, throw warning. If target === 'FULL' create invalid part.
 export interface CueDefinitionUnpairedTarget extends CueDefinitionBase {
 	type: CueType.UNPAIRED_TARGET
@@ -160,6 +165,7 @@ export type CueDefinition =
 	| CueDefinitionGraphic<GraphicInternalOrPilot>
 	| CueDefinitionRouting
 	| CueDefinitionPgmClean
+	| CueDefinitionMixMinus
 
 export function GraphicIsInternal(
 	o: CueDefinitionGraphic<GraphicInternalOrPilot>
@@ -225,6 +231,8 @@ export function ParseCue(cue: UnparsedCue, config: TV2BlueprintConfig): CueDefin
 		return parseJingle(cue)
 	} else if (cue[0].match(/^PGMCLEAN=/i)) {
 		return parsePgmClean(cue)
+	} else if (cue[0].match(/^MINUSKAM\s*=/i)) {
+		return parseMixMinus(cue)
 	}
 
 	return literal<CueDefinitionUnknown>({
@@ -747,6 +755,18 @@ export function parsePgmClean(cue: string[]): CueDefinitionPgmClean {
 		pgmCleanCue.source = pgmSource[1].toString().toUpperCase()
 	}
 	return pgmCleanCue
+}
+
+export function parseMixMinus(cue: string[]): CueDefinitionMixMinus | undefined {
+	const sourceMatch = cue[0].match(/^MINUSKAM\s*=\s*(?<source>.+)\s*$/i)
+	if (sourceMatch === null) {
+		return undefined
+	}
+	return literal<CueDefinitionMixMinus>({
+		type: CueType.MixMinus,
+		source: sourceMatch.groups!.source.toUpperCase(),
+		iNewsCommand: 'MINUSKAM'
+	})
 }
 
 export function isTime(line: string) {

--- a/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
@@ -17,6 +17,7 @@ import {
 	CueDefinitionJingle,
 	CueDefinitionLYD,
 	CueDefinitionMic,
+	CueDefinitionMixMinus,
 	CueDefinitionPgmClean,
 	CueDefinitionProfile,
 	CueDefinitionTelefon,
@@ -1430,6 +1431,156 @@ describe('Cue parser', () => {
 					seconds: 0
 				},
 				iNewsCommand: 'VCP'
+			})
+		)
+	})
+
+	test('MINUSKAM=KAM 1', () => {
+		const minusKamCue = ['MINUSKAM=KAM 1']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'KAM 1',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM=KAM 2', () => {
+		const minusKamCue = ['MINUSKAM=KAM 2']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'KAM 2',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM=KAMERA 1', () => {
+		const minusKamCue = ['MINUSKAM=KAMERA 1']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'KAMERA 1',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM=KAMERA 2', () => {
+		const minusKamCue = ['MINUSKAM=KAMERA 2']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'KAMERA 2',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM=LIVE 1', () => {
+		const minusKamCue = ['MINUSKAM=LIVE 1']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'LIVE 1',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM=LIVE 2', () => {
+		const minusKamCue = ['MINUSKAM=LIVE 2']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'LIVE 2',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM=SERVER', () => {
+		const minusKamCue = ['MINUSKAM=SERVER']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'SERVER',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM = SERVER', () => {
+		const minusKamCue = ['MINUSKAM = SERVER']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'SERVER',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM = LIVE 1', () => {
+		const minusKamCue = ['MINUSKAM = LIVE 1']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'LIVE 1',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM=LIVE 2 ', () => {
+		const minusKamCue = ['MINUSKAM=LIVE 2 ']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'LIVE 2',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('MINUSKAM=', () => {
+		const minusKamCue = ['MINUSKAM=']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(undefined)
+	})
+
+	test('minuskam=Kam 2', () => {
+		const minusKamCue = ['minuskam=Kam 2']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'KAM 2',
+				iNewsCommand: 'MINUSKAM'
+			})
+		)
+	})
+
+	test('minuskam = Kam 3 ', () => {
+		const minusKamCue = ['minuskam = Kam 3 ']
+		const result = ParseCue(minusKamCue, config)
+		expect(result).toEqual(
+			literal<CueDefinitionMixMinus>({
+				type: CueType.MixMinus,
+				source: 'KAM 3',
+				iNewsCommand: 'MINUSKAM'
 			})
 		)
 	})

--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -31,7 +31,8 @@ export enum CueType {
 	GraphicDesign,
 	Graphic,
 	Routing,
-	PgmClean
+	PgmClean,
+	MixMinus
 }
 
 export const enum PartType {
@@ -146,7 +147,9 @@ export enum AbstractLLayer {
 	AudioBedBaseline = 'audio_bed_baseline'
 }
 
-export enum SharedATEMLLayer {}
+export enum SharedATEMLLayer {
+	AtemAuxVideoMixMinus = 'atem_aux_video_mix_minus'
+}
 
 export enum SharedCasparLLayer {
 	CasparCGLYD = 'casparcg_audio_lyd',
@@ -214,7 +217,10 @@ export enum SharedSourceLayers {
 
 	// Other / sec / manus
 	PgmScript = 'studio0_script',
-	PgmAudioBed = 'studio0_audio_bed'
+	PgmAudioBed = 'studio0_audio_bed',
+
+	// AUX
+	AuxMixMinus = 'studio0_aux_mix_minus'
 }
 
 export enum DSKRoles {

--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -75,6 +75,7 @@ export enum ControlClasses {
 	DVEOnAir = 'dve_on_air',
 	ServerOnAir = 'server_on_air',
 	LYDOnAir = 'lyd_on_air',
+	LiveSourceOnAir = 'live_source_on_air',
 	NOLookahead = 'no_lookahead',
 	CopyMediaPlayerSession = 'copy_media_player_session',
 	AbstractLookahead = 'abstract_lookahead'

--- a/src/tv2_afvd_showstyle/helpers/pieces/evaluateCues.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/evaluateCues.ts
@@ -6,7 +6,14 @@ import {
 	IBlueprintPiece,
 	ISegmentUserContext
 } from '@sofie-automation/blueprints-integration'
-import { CueDefinition, EvaluateCuesBase, EvaluateCuesOptions, EvaluateLYD, PartDefinition } from 'tv2-common'
+import {
+	CueDefinition,
+	EvaluateCueMixMinus,
+	EvaluateCuesBase,
+	EvaluateCuesOptions,
+	EvaluateLYD,
+	PartDefinition
+} from 'tv2-common'
 import { BlueprintConfig } from '../../../tv2_afvd_showstyle/helpers/config'
 import { EvaluateAdLib } from './adlib'
 import { EvaluateClearGrafiks } from './clearGrafiks'
@@ -43,7 +50,8 @@ export function EvaluateCues(
 			EvaluateCueGraphic,
 			EvaluateCueBackgroundLoop,
 			EvaluateCueGraphicDesign: EvaluateCueDesign,
-			EvaluateCueRouting
+			EvaluateCueRouting,
+			EvaluateCueMixMinus
 		},
 		context,
 		config,

--- a/src/tv2_afvd_showstyle/migrations/sourcelayer-defaults.ts
+++ b/src/tv2_afvd_showstyle/migrations/sourcelayer-defaults.ts
@@ -683,6 +683,25 @@ const AUX: ISourceLayer[] = [
 		isHidden: false,
 		allowDisable: false,
 		onPresenterScreen: false
+	},
+	{
+		_id: SourceLayer.AuxMixMinus,
+		_rank: 22,
+		name: 'MixMinus AUX',
+		abbreviation: '',
+		type: SourceLayerType.UNKNOWN,
+		exclusiveGroup: '',
+		isRemoteInput: false,
+		isGuestInput: false,
+		activateKeyboardHotkeys: '',
+		clearKeyboardHotkey: '',
+		assignHotkeysToGlobalAdlibs: true,
+		isSticky: false,
+		activateStickyKeyboardHotkey: '',
+		isQueueable: false,
+		isHidden: true,
+		allowDisable: false,
+		onPresenterScreen: false
 	}
 ]
 

--- a/src/tv2_afvd_studio/layers.ts
+++ b/src/tv2_afvd_studio/layers.ts
@@ -1,4 +1,4 @@
-import { AbstractLLayer, GraphicLLayer, SharedCasparLLayer, SharedSisyfosLLayer } from 'tv2-constants'
+import { AbstractLLayer, GraphicLLayer, SharedATEMLLayer, SharedCasparLLayer, SharedSisyfosLLayer } from 'tv2-constants'
 import * as _ from 'underscore'
 
 export type LLayer = VirtualAbstractLLayer | AtemLLayer | CasparLLayer | SisyfosLLAyer
@@ -22,7 +22,7 @@ export function RealLLayers(): string[] {
 
 export enum VirtualAbstractLLayer {}
 
-export enum AtemLLayer {
+export enum AFVDAtemLLayer {
 	AtemMEProgram = 'atem_me_program',
 	AtemMEClean = 'atem_me_clean',
 	AtemCleanUSKEffect = 'atem_clean_usk_effect',
@@ -40,11 +40,18 @@ export enum AtemLLayer {
 	AtemAuxAR = 'atem_aux_ar',
 	AtemAuxVizOvlIn1 = 'atem_aux_viz_ovl_in_1',
 	// AtemAuxVizFullIn1 = 'atem_aux_viz_full_in_1',
-	AtemAuxVideoMixMinus = 'atem_aux_video_mix_minus',
 	AtemAuxVenue = 'atem_aux_venue',
 	AtemAuxLookahead = 'atem_aux_lookahead',
 	AtemAuxSSrc = 'atem_aux_ssrc'
 }
+
+// tslint:disable-next-line: variable-name
+export const AtemLLayer = {
+	...AFVDAtemLLayer,
+	...SharedATEMLLayer
+}
+
+export type AtemLLayer = AFVDAtemLLayer | SharedATEMLLayer
 
 enum AFVDCasparLLayer {
 	CasparCGDVELoop = 'casparcg_dve_loop',

--- a/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
+++ b/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
@@ -740,6 +740,25 @@ const AUX: ISourceLayer[] = [
 		isHidden: true,
 		allowDisable: false,
 		onPresenterScreen: false
+	},
+	{
+		_id: OfftubeSourceLayer.AuxMixMinus,
+		_rank: 22,
+		name: 'MixMinus AUX',
+		abbreviation: '',
+		type: SourceLayerType.UNKNOWN,
+		exclusiveGroup: '',
+		isRemoteInput: false,
+		isGuestInput: false,
+		activateKeyboardHotkeys: '',
+		clearKeyboardHotkey: '',
+		assignHotkeysToGlobalAdlibs: true,
+		isSticky: false,
+		activateStickyKeyboardHotkey: '',
+		isQueueable: false,
+		isHidden: true,
+		allowDisable: false,
+		onPresenterScreen: false
 	}
 ]
 

--- a/src/tv2_offtube_studio/layers.ts
+++ b/src/tv2_offtube_studio/layers.ts
@@ -1,4 +1,4 @@
-import { AbstractLLayer, GraphicLLayer, SharedCasparLLayer, SharedSisyfosLLayer } from 'tv2-constants'
+import { AbstractLLayer, GraphicLLayer, SharedATEMLLayer, SharedCasparLLayer, SharedSisyfosLLayer } from 'tv2-constants'
 import * as _ from 'underscore'
 
 /** Get all the Real LLayers (map to devices). Note: Does not include some which are dynamically generated */
@@ -43,7 +43,7 @@ enum SisyfosLLayer {
 	SisyfosN1 = 'sisyfos_source_n1'
 }
 
-export enum OfftubeAtemLLayer {
+export enum AtemLLayer {
 	AtemMEClean = 'atem_me_clean',
 	AtemMEProgram = 'atem_me_program',
 	AtemMENext = 'atem_me_next',
@@ -58,6 +58,14 @@ export enum OfftubeAtemLLayer {
 	AtemSSrcBox3 = 'atem_supersource_z_box3',
 	AtemSSrcBox4 = 'atem_supersource_z_box4'
 }
+
+// tslint:disable-next-line: variable-name
+export const OfftubeAtemLLayer = {
+	...AtemLLayer,
+	...SharedATEMLLayer
+}
+
+export type OfftubeAtemLLayer = AtemLLayer | SharedATEMLLayer
 
 enum CasparLLayer {
 	CasparPlayerJingleLookahead = 'casparcg_player_jingle_looakhead',

--- a/src/tv2_offtube_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_offtube_studio/migrations/mappings-defaults.ts
@@ -527,6 +527,12 @@ const MAPPINGS_ATEM: BlueprintMappings = {
 		lookaheadMaxSearchDistance: 1,
 		mappingType: TSR.MappingAtemType.SuperSourceBox,
 		index: 0 // 0 = SS
+	}),
+	// TODO: Future: Mix Minus in Offtubes
+	[OfftubeAtemLLayer.AtemAuxVideoMixMinus]: literal<TSR.MappingAbstract & BlueprintMapping>({
+		device: TSR.DeviceType.ABSTRACT,
+		deviceId: 'abstract0',
+		lookahead: LookaheadMode.NONE
 	})
 }
 


### PR DESCRIPTION
Adds the `MINUSKAM` cue which can be used to set the mix minus source for live sources.

Currently this will only work for AFVD because the QBoxes do not have a mix minus controlled by Sofie. An abstract mapping has been created as a placeholder for future work when a mix minus is required.