### PR TITLE
fix: create parent class for VOs

### DIFF
--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -833,6 +833,7 @@ export function PartToParentClass(studio: string, partDefinition: PartDefinition
 		case PartType.Kam:
 			return CameraParentClass(studio, partDefinition.variant.name)
 		case PartType.Server:
+		case PartType.VO:
 			const clip = partDefinition.fields.videoId
 
 			if (clip) {


### PR DESCRIPTION
Fixes a bug where timed graphics did not show in VO parts. The pieces were created, but parent class used in the timelineObjects was not generated in VO parts, so `enable` on the graphic pieces had this condition `while: ".undefined & !.adlib_deparent & !.full"`.