### PR TITLE
fix: delay WALL graphics when part has preroll

### DIFF
--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -426,7 +426,19 @@ function executeActionSelectServerClip<
 			p.sourceLayerId === settings.SelectedAdlibs.SourceLayer.VO
 	)
 
+	let part = basePart.part.part
+
 	const grafikPieces: IBlueprintPiece[] = []
+	const effektPieces: IBlueprintPiece[] = []
+
+	part = {
+		...part,
+		...CreateEffektForPartBase(context, config, partDefinition, effektPieces, {
+			sourceLayer: settings.SourceLayers.Effekt,
+			sisyfosLayer: settings.LLayer.Sisyfos.Effekt,
+			casparLayer: settings.LLayer.Caspar.Effekt
+		})
+	}
 
 	settings.EvaluateCues(
 		(context as unknown) as SegmentContext,
@@ -451,18 +463,6 @@ function executeActionSelectServerClip<
 
 	if (activeServerPiece.content && activeServerPiece.content.timelineObjects) {
 		settings.postProcessPieceTimelineObjects(context, config, activeServerPiece, false)
-	}
-
-	let part = basePart.part.part
-
-	const effektPieces: IBlueprintPiece[] = []
-	part = {
-		...part,
-		...CreateEffektForPartBase(context, config, partDefinition, effektPieces, {
-			sourceLayer: settings.SourceLayers.Effekt,
-			sisyfosLayer: settings.LLayer.Sisyfos.Effekt,
-			casparLayer: settings.LLayer.Caspar.Effekt
-		})
 	}
 
 	context.queuePart(part, [

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -1428,10 +1428,10 @@ function applyPrerollToWallGraphics<
 	}
 	const enable = GetEnableForWall(partProps)
 	for (const pieceInstance of wallPieces) {
-		const newPieceProps = {
-			content: pieceInstance.piece.content as GraphicsContent | undefined
-		}
-		if (newPieceProps.content?.timelineObjects) {
+		if (pieceInstance.piece.content?.timelineObjects && !pieceInstance.infinite?.fromPreviousPart) {
+			const newPieceProps = {
+				content: pieceInstance.piece.content as GraphicsContent
+			}
 			const timelineObjectsToUpdate = newPieceProps.content.timelineObjects.filter(
 				timelineObject =>
 					timelineObject.layer === GraphicLLayer.GraphicLLayerWall &&

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -1,6 +1,7 @@
 import {
 	ActionExecutionContext,
 	ActionUserData,
+	GraphicsContent,
 	HackPartMediaObjectSubscription,
 	IBlueprintActionManifest,
 	IBlueprintAdLibPiece,
@@ -69,7 +70,7 @@ import {
 } from 'tv2-constants'
 import _ = require('underscore')
 import { EnableServer } from '../content'
-import { CreateFullDataStore, PilotGeneratorSettings } from '../helpers'
+import { CreateFullDataStore, GetEnableForWall, PilotGeneratorSettings } from '../helpers'
 import { GetJinglePartPropertiesFromTableValue } from '../jinglePartProperties'
 import { CreateEffektForPartBase, CreateEffektForPartInner, CreateMixForPartInner } from '../parts'
 import {
@@ -138,6 +139,7 @@ export interface ActionExecutionSettings<
 		EVS?: string
 		/** Ident visual representation layer *not* the infinite layer */
 		Ident: string
+		Wall: string
 	}
 	LLayer: {
 		Caspar: {
@@ -1373,6 +1375,77 @@ function executeActionCutSourceToBox<
 	}
 }
 
+interface PiecesBySourceLayer {
+	[key: string]: IBlueprintPieceInstance[]
+}
+
+function groupPiecesBySourceLayer(pieceInstances: IBlueprintPieceInstance[]): PiecesBySourceLayer {
+	const piecesBySourceLayer: PiecesBySourceLayer = {}
+	pieceInstances.forEach(piece => {
+		if (!piecesBySourceLayer[piece.piece.sourceLayerId]) {
+			piecesBySourceLayer[piece.piece.sourceLayerId] = []
+		}
+		piecesBySourceLayer[piece.piece.sourceLayerId].push(piece)
+	})
+	return piecesBySourceLayer
+}
+
+function findPrimaryPieceUsingPriority<
+	StudioConfig extends TV2StudioConfigBase,
+	ShowStyleConfig extends TV2BlueprintConfigBase<StudioConfig>
+>(settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>, piecesBySourceLayer: PiecesBySourceLayer) {
+	const sourceLayersOrderedByPriority = [
+		settings.SourceLayers.Cam,
+		settings.SourceLayers.DVE,
+		settings.SourceLayers.DVEAdLib,
+		settings.SourceLayers.Live,
+		settings.SourceLayers.Server,
+		settings.SourceLayers.VO,
+		...(settings.SourceLayers.EVS ? [settings.SourceLayers.EVS] : []),
+		settings.SourceLayers.Effekt,
+		settings.SourceLayers.Continuity
+	]
+	for (const layer of sourceLayersOrderedByPriority) {
+		if (layer && piecesBySourceLayer[layer]) {
+			return piecesBySourceLayer[layer][0]
+		}
+	}
+	return undefined
+}
+
+function applyPrerollToWallGraphics<
+	StudioConfig extends TV2StudioConfigBase,
+	ShowStyleConfig extends TV2BlueprintConfigBase<StudioConfig>
+>(
+	context: ActionExecutionContext,
+	settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>,
+	piecesBySourceLayer: PiecesBySourceLayer,
+	partProps: Partial<IBlueprintPart>
+) {
+	const wallPieces = piecesBySourceLayer[settings.SourceLayers.Wall]
+	if (!wallPieces) {
+		return
+	}
+	const enable = GetEnableForWall(partProps)
+	for (const pieceInstance of wallPieces) {
+		const newPieceProps = {
+			content: pieceInstance.piece.content as GraphicsContent | undefined
+		}
+		if (newPieceProps.content?.timelineObjects) {
+			const timelineObjectsToUpdate = newPieceProps.content.timelineObjects.filter(
+				timelineObject =>
+					timelineObject.layer === GraphicLLayer.GraphicLLayerWall &&
+					(timelineObject.content.deviceType === TSR.DeviceType.VIZMSE ||
+						timelineObject.content.deviceType === TSR.DeviceType.CASPARCG)
+			)
+			timelineObjectsToUpdate.forEach(timelineObject => {
+				timelineObject.enable = enable
+			})
+			context.updatePieceInstance(pieceInstance._id, newPieceProps)
+		}
+	}
+}
+
 function executeActionTakeWithTransition<
 	StudioConfig extends TV2StudioConfigBase,
 	ShowStyleConfig extends TV2BlueprintConfigBase<StudioConfig>
@@ -1385,31 +1458,9 @@ function executeActionTakeWithTransition<
 	const externalId = generateExternalId(context, actionId, [userData.variant.type])
 
 	const nextPieces = context.getPieceInstances('next')
-	const piecesBySourceLayer: { [key: string]: IBlueprintPieceInstance[] } = {}
-	const sourceLayersByPriority = [
-		settings.SourceLayers.Cam,
-		settings.SourceLayers.DVE,
-		settings.SourceLayers.DVEAdLib,
-		settings.SourceLayers.Live,
-		settings.SourceLayers.Server,
-		settings.SourceLayers.VO,
-		...(settings.SourceLayers.EVS ? [settings.SourceLayers.EVS] : []),
-		settings.SourceLayers.Effekt,
-		settings.SourceLayers.Continuity
-	]
-	nextPieces.forEach(piece => {
-		if (!piecesBySourceLayer[piece.piece.sourceLayerId]) {
-			piecesBySourceLayer[piece.piece.sourceLayerId] = []
-		}
-		piecesBySourceLayer[piece.piece.sourceLayerId].push(piece)
-	})
-	let primaryPiece: IBlueprintPieceInstance | undefined
-	for (const layer of sourceLayersByPriority) {
-		if (layer && piecesBySourceLayer[layer]) {
-			primaryPiece = piecesBySourceLayer[layer][0]
-			break
-		}
-	}
+
+	const nextPiecesBySourceLayer = groupPiecesBySourceLayer(nextPieces)
+	const primaryPiece = findPrimaryPieceUsingPriority(settings, nextPiecesBySourceLayer)
 
 	context.takeAfterExecuteAction(userData.takeNow)
 
@@ -1443,6 +1494,8 @@ function executeActionTakeWithTransition<
 		context.removePieceInstances('next', [existingEffektPiece._id])
 	}
 
+	let partProps: Partial<IBlueprintPart> | false = false
+
 	switch (userData.variant.type) {
 		case 'cut':
 			{
@@ -1468,12 +1521,14 @@ function executeActionTakeWithTransition<
 					}
 				}
 
-				context.insertPiece('next', cutTransitionPiece)
-				context.updatePartInstance('next', {
+				partProps = {
 					transitionKeepaliveDuration: undefined,
 					transitionDuration: undefined,
 					transitionPrerollDuration: undefined
-				})
+				}
+
+				context.insertPiece('next', cutTransitionPiece)
+				context.updatePartInstance('next', partProps)
 			}
 			break
 		case 'breaker': {
@@ -1485,7 +1540,7 @@ function executeActionTakeWithTransition<
 
 			const config = settings.getConfig(context)
 			const pieces: IBlueprintPiece[] = []
-			const partProps = CreateEffektForPartInner(
+			partProps = CreateEffektForPartInner(
 				context,
 				config,
 				pieces,
@@ -1519,7 +1574,7 @@ function executeActionTakeWithTransition<
 			context.updatePieceInstance(primaryPiece._id, primaryPiece.piece)
 
 			const pieces: IBlueprintPiece[] = []
-			const partProps = CreateMixForPartInner(pieces, externalId, userData.variant.frames, {
+			partProps = CreateMixForPartInner(pieces, externalId, userData.variant.frames, {
 				sourceLayer: settings.SourceLayers.Effekt,
 				casparLayer: settings.LLayer.Caspar.Effekt,
 				sisyfosLayer: settings.LLayer.Sisyfos.Effekt
@@ -1530,6 +1585,10 @@ function executeActionTakeWithTransition<
 
 			break
 		}
+	}
+
+	if (partProps) {
+		applyPrerollToWallGraphics(context, settings, nextPiecesBySourceLayer, partProps)
 	}
 }
 
@@ -1855,6 +1914,7 @@ function executeActionSelectFull<
 	const fullPiece = CreateFullPiece(
 		config,
 		context,
+		part,
 		externalId,
 		cue,
 		'FULL',
@@ -1868,6 +1928,7 @@ function executeActionSelectFull<
 	const fullDataStore = CreateFullDataStore(
 		config,
 		context,
+		part,
 		settings.pilotGraphicSettings,
 		cue,
 		'FULL',

--- a/src/tv2-common/evaluateCues.ts
+++ b/src/tv2-common/evaluateCues.ts
@@ -35,6 +35,7 @@ export interface EvaluateCuesShowstyleOptions {
 	EvaluateCueGraphic?: (
 		config: TV2BlueprintConfig,
 		context: SegmentContext,
+		part: Readonly<IBlueprintPart>,
 		pieces: IBlueprintPiece[],
 		adlibPieces: IBlueprintAdLibPiece[],
 		actions: IBlueprintActionManifest[],
@@ -111,6 +112,7 @@ export interface EvaluateCuesShowstyleOptions {
 	EvaluateCueTelefon?: (
 		config: TV2BlueprintConfig,
 		context: SegmentContext,
+		part: Readonly<IBlueprintPart>,
 		pieces: IBlueprintPiece[],
 		adlibPieces: IBlueprintAdLibPiece[],
 		actions: IBlueprintActionManifest[],
@@ -212,6 +214,7 @@ export function EvaluateCuesBase(
 						showStyleOptions.EvaluateCueGraphic(
 							config,
 							context,
+							part,
 							pieces,
 							adLibPieces,
 							actions,
@@ -289,6 +292,7 @@ export function EvaluateCuesBase(
 						showStyleOptions.EvaluateCueTelefon(
 							config,
 							context,
+							part,
 							pieces,
 							adLibPieces,
 							actions,

--- a/src/tv2-common/helpers/graphics/caspar/index.ts
+++ b/src/tv2-common/helpers/graphics/caspar/index.ts
@@ -1,6 +1,12 @@
 export * from './slotMappings'
 
-import { GraphicsContent, IBlueprintPiece, NotesContext, TSR } from '@sofie-automation/blueprints-integration'
+import {
+	GraphicsContent,
+	IBlueprintPart,
+	IBlueprintPiece,
+	NotesContext,
+	TSR
+} from '@sofie-automation/blueprints-integration'
 import {
 	CueDefinitionGraphic,
 	GraphicInternal,
@@ -22,6 +28,7 @@ export interface CasparPilotGeneratorSettings {
 
 export function GetInternalGraphicContentCaspar(
 	config: TV2BlueprintConfig,
+	part: Readonly<IBlueprintPart>,
 	engine: GraphicEngine,
 	parsedCue: CueDefinitionGraphic<GraphicInternal>,
 	isIdentGraphic: boolean,
@@ -32,6 +39,7 @@ export function GetInternalGraphicContentCaspar(
 	return {
 		timelineObjects: CasparOverlayTimeline(
 			config,
+			part,
 			engine,
 			parsedCue,
 			isIdentGraphic,
@@ -101,6 +109,7 @@ export function GetPilotGraphicContentCaspar(
 
 function CasparOverlayTimeline(
 	config: TV2BlueprintConfig,
+	part: Readonly<IBlueprintPart>,
 	engine: GraphicEngine,
 	parsedCue: CueDefinitionGraphic<GraphicInternal>,
 	isIdentGrafik: boolean,
@@ -111,7 +120,7 @@ function CasparOverlayTimeline(
 	return [
 		literal<TSR.TimelineObjCCGTemplate>({
 			id: '',
-			enable: GetEnableForGraphic(config, engine, parsedCue, isIdentGrafik, partDefinition, adlib),
+			enable: GetEnableForGraphic(config, part, engine, parsedCue, isIdentGrafik, partDefinition, adlib),
 			priority: 1,
 			layer: GetTimelineLayerForGraphic(config, mappedTemplate),
 			content: CreateHTMLRendererContent(config, mappedTemplate, { ...parsedCue.graphic.textFields })

--- a/src/tv2-common/helpers/graphics/internal/index.ts
+++ b/src/tv2-common/helpers/graphics/internal/index.ts
@@ -1,6 +1,7 @@
 import {
 	IBlueprintActionManifest,
 	IBlueprintAdLibPiece,
+	IBlueprintPart,
 	IBlueprintPiece,
 	PieceLifespan,
 	SegmentContext,
@@ -33,6 +34,7 @@ import { GetInternalGraphicContentVIZ } from '../viz'
 export function CreateInternalGraphic(
 	config: TV2BlueprintConfig,
 	context: SegmentContext,
+	part: Readonly<IBlueprintPart>,
 	pieces: IBlueprintPiece[],
 	adlibPieces: IBlueprintAdLibPiece[],
 	_actions: IBlueprintActionManifest[],
@@ -66,8 +68,26 @@ export function CreateInternalGraphic(
 
 	const content =
 		config.studio.GraphicsType === 'HTML'
-			? GetInternalGraphicContentCaspar(config, engine, parsedCue, isStickyIdent, partDefinition, mappedTemplate, adlib)
-			: GetInternalGraphicContentVIZ(config, engine, parsedCue, isStickyIdent, partDefinition, mappedTemplate, adlib)
+			? GetInternalGraphicContentCaspar(
+					config,
+					part,
+					engine,
+					parsedCue,
+					isStickyIdent,
+					partDefinition,
+					mappedTemplate,
+					adlib
+			  )
+			: GetInternalGraphicContentVIZ(
+					config,
+					part,
+					engine,
+					parsedCue,
+					isStickyIdent,
+					partDefinition,
+					mappedTemplate,
+					adlib
+			  )
 
 	if (adlib) {
 		if (IsTargetingOVL(engine)) {

--- a/src/tv2-common/helpers/graphics/timing.ts
+++ b/src/tv2-common/helpers/graphics/timing.ts
@@ -1,4 +1,4 @@
-import { PieceLifespan, TSR } from '@sofie-automation/blueprints-integration'
+import { IBlueprintPart, PieceLifespan, TSR } from '@sofie-automation/blueprints-integration'
 import {
 	CalculateTime,
 	CreateTimingEnable,
@@ -120,8 +120,22 @@ export function CreateTimingGraphic(
 	return ret
 }
 
+export function GetPartPrerollDuration(part: Readonly<Partial<IBlueprintPart>> | undefined): number {
+	return (part && (part.transitionPrerollDuration || part.prerollDuration)) || 0
+}
+
+export function GetEnableForWall(part: Readonly<Partial<IBlueprintPart>> | undefined): TSR.TSRTimelineObj['enable'] {
+	const partPrerollDuration = GetPartPrerollDuration(part)
+	return partPrerollDuration
+		? { start: partPrerollDuration }
+		: {
+				while: '1'
+		  }
+}
+
 export function GetEnableForGraphic(
 	config: TV2BlueprintConfig,
+	part: Readonly<IBlueprintPart> | undefined,
 	engine: GraphicEngine,
 	cue: CueDefinitionGraphic<GraphicInternalOrPilot>,
 	isStickyIdent: boolean,
@@ -129,9 +143,7 @@ export function GetEnableForGraphic(
 	adlib?: boolean
 ): TSR.TSRTimelineObj['enable'] {
 	if (IsTargetingWall(engine)) {
-		return {
-			while: '1'
-		}
+		return GetEnableForWall(part)
 	}
 
 	if (

--- a/src/tv2-common/helpers/graphics/viz/index.ts
+++ b/src/tv2-common/helpers/graphics/viz/index.ts
@@ -72,7 +72,7 @@ export function GetPilotGraphicContentViz(
 					: {
 							start: 0
 					  },
-				priority: 1,
+				priority: IsTargetingWall(engine) ? 100 : 1,
 				layer: IsTargetingWall(engine)
 					? GraphicLLayer.GraphicLLayerWall
 					: IsTargetingOVL(engine)

--- a/src/tv2-common/helpers/graphics/viz/index.ts
+++ b/src/tv2-common/helpers/graphics/viz/index.ts
@@ -75,11 +75,12 @@ export function GetPilotGraphicContentViz(
 		timelineObjects: [
 			literal<TSR.TimelineObjVIZMSEElementPilot>({
 				id: '',
-				enable: IsTargetingOVL(engine)
-					? GetEnableForGraphic(config, part, engine, parsedCue, false, undefined, adlib)
-					: {
-							start: 0
-					  },
+				enable:
+					IsTargetingOVL(engine) || IsTargetingWall(engine)
+						? GetEnableForGraphic(config, part, engine, parsedCue, false, undefined, adlib)
+						: {
+								start: 0
+						  },
 				priority: 1,
 				layer: IsTargetingWall(engine)
 					? GraphicLLayer.GraphicLLayerWall

--- a/src/tv2-common/helpers/graphics/viz/index.ts
+++ b/src/tv2-common/helpers/graphics/viz/index.ts
@@ -1,4 +1,10 @@
-import { GraphicsContent, IBlueprintPiece, NotesContext, TSR } from '@sofie-automation/blueprints-integration'
+import {
+	GraphicsContent,
+	IBlueprintPart,
+	IBlueprintPiece,
+	NotesContext,
+	TSR
+} from '@sofie-automation/blueprints-integration'
 import {
 	CueDefinitionGraphic,
 	GetEnableForGraphic,
@@ -22,6 +28,7 @@ export interface VizPilotGeneratorSettings {
 
 export function GetInternalGraphicContentVIZ(
 	config: TV2BlueprintConfig,
+	part: Readonly<IBlueprintPart>,
 	engine: GraphicEngine,
 	parsedCue: CueDefinitionGraphic<GraphicInternal>,
 	isIdentGraphic: boolean,
@@ -36,7 +43,7 @@ export function GetInternalGraphicContentVIZ(
 		timelineObjects: literal<TSR.TSRTimelineObj[]>([
 			literal<TSR.TimelineObjVIZMSEElementInternal>({
 				id: '',
-				enable: GetEnableForGraphic(config, engine, parsedCue, isIdentGraphic, partDefinition, adlib),
+				enable: GetEnableForGraphic(config, part, engine, parsedCue, isIdentGraphic, partDefinition, adlib),
 				priority: 1,
 				layer: GetTimelineLayerForGraphic(config, GetFullGraphicTemplateNameFromCue(config, parsedCue)),
 				content: {
@@ -55,6 +62,7 @@ export function GetInternalGraphicContentVIZ(
 
 export function GetPilotGraphicContentViz(
 	config: TV2BlueprintConfig,
+	part: Readonly<IBlueprintPart> | undefined,
 	context: NotesContext,
 	settings: VizPilotGeneratorSettings,
 	parsedCue: CueDefinitionGraphic<GraphicPilot>,
@@ -68,11 +76,11 @@ export function GetPilotGraphicContentViz(
 			literal<TSR.TimelineObjVIZMSEElementPilot>({
 				id: '',
 				enable: IsTargetingOVL(engine)
-					? GetEnableForGraphic(config, engine, parsedCue, false, undefined, adlib)
+					? GetEnableForGraphic(config, part, engine, parsedCue, false, undefined, adlib)
 					: {
 							start: 0
 					  },
-				priority: IsTargetingWall(engine) ? 100 : 1,
+				priority: 1,
 				layer: IsTargetingWall(engine)
 					? GraphicLLayer.GraphicLLayerWall
 					: IsTargetingOVL(engine)

--- a/src/tv2-common/parts/effekt.ts
+++ b/src/tv2-common/parts/effekt.ts
@@ -22,6 +22,7 @@ import { SharedOutputLayers } from 'tv2-constants'
 import { TV2BlueprintConfig } from '../blueprintConfig'
 import { PieceMetaData } from '../onTimelineGenerate'
 
+/** Has to be executed before calling EvaluateCues, as some cues may depend on it */
 export function CreateEffektForPartBase(
 	context: NotesContext,
 	config: TV2BlueprintConfig,

--- a/src/tv2_afvd_showstyle/actions.ts
+++ b/src/tv2_afvd_showstyle/actions.ts
@@ -27,7 +27,8 @@ export function executeActionAFVD(context: ActionExecutionContext, actionId: str
 				Effekt: SourceLayer.PgmJingle,
 				EVS: SourceLayer.PgmLocal,
 				Ident: SourceLayer.PgmGraphicsIdent,
-				Continuity: SourceLayer.PgmContinuity
+				Continuity: SourceLayer.PgmContinuity,
+				Wall: SourceLayer.WallGraphics
 			},
 			LLayer: {
 				Caspar: {

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -2,6 +2,7 @@ import {
 	GraphicsContent,
 	IBlueprintActionManifest,
 	IBlueprintAdLibPiece,
+	IBlueprintPart,
 	IBlueprintPiece,
 	IBlueprintRundownDB,
 	PieceLifespan,
@@ -49,6 +50,11 @@ const dummyPart = literal<PartDefinitionKam>({
 	modified: 0,
 	segmentExternalId: ''
 })
+
+const dummyBlueprintPart: IBlueprintPart = {
+	title: 'Kam 1',
+	externalId: '0001'
+}
 
 const dskEnableObj = literal<TSR.TimelineObjAtemDSK>({
 	id: '',
@@ -101,6 +107,7 @@ describe('grafik piece', () => {
 		EvaluateCueGraphic(
 			config,
 			makeMockContext(),
+			dummyBlueprintPart,
 			pieces,
 			adLibPieces,
 			actions,
@@ -169,6 +176,7 @@ describe('grafik piece', () => {
 		EvaluateCueGraphic(
 			config,
 			makeMockContext(),
+			dummyBlueprintPart,
 			pieces,
 			adLibPieces,
 			actions,
@@ -274,6 +282,7 @@ describe('grafik piece', () => {
 		EvaluateCueGraphic(
 			newConfig,
 			makeMockContext(),
+			dummyBlueprintPart,
 			pieces,
 			adLibPieces,
 			actions,
@@ -379,6 +388,7 @@ describe('grafik piece', () => {
 		EvaluateCueGraphic(
 			config,
 			makeMockContext(),
+			dummyBlueprintPart,
 			pieces,
 			adLibPieces,
 			actions,
@@ -452,6 +462,7 @@ describe('grafik piece', () => {
 		EvaluateCueGraphic(
 			config,
 			makeMockContext(),
+			dummyBlueprintPart,
 			pieces,
 			adLibPieces,
 			actions,
@@ -521,6 +532,7 @@ describe('grafik piece', () => {
 		EvaluateCueGraphic(
 			config,
 			makeMockContext(),
+			dummyBlueprintPart,
 			pieces,
 			adLibPieces,
 			actions,
@@ -614,6 +626,7 @@ describe('grafik piece', () => {
 		EvaluateCueGraphic(
 			config,
 			makeMockContext(),
+			dummyBlueprintPart,
 			pieces,
 			adLibPieces,
 			actions,
@@ -682,6 +695,7 @@ describe('grafik piece', () => {
 		EvaluateCueGraphic(
 			config,
 			makeMockContext(),
+			dummyBlueprintPart,
 			pieces,
 			adLibPieces,
 			actions,

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -8,7 +8,14 @@ import {
 	PieceLifespan,
 	TSR
 } from '@sofie-automation/blueprints-integration'
-import { AtemLLayerDSK, CueDefinitionGraphic, GraphicInternal, literal, PartDefinitionKam } from 'tv2-common'
+import {
+	AtemLLayerDSK,
+	CueDefinitionGraphic,
+	GraphicInternal,
+	GraphicPilot,
+	literal,
+	PartDefinitionKam
+} from 'tv2-common'
 import { AbstractLLayer, AdlibTags, CueType, GraphicLLayer, PartType, SharedOutputLayers } from 'tv2-constants'
 import { SegmentContext } from '../../../../__mocks__/context'
 import { BlueprintConfig } from '../../../../tv2_afvd_studio/helpers/config'
@@ -776,5 +783,99 @@ describe('grafik piece', () => {
 				})
 			})
 		])
+	})
+
+	it('Applies delay to WALL graphics when part has prerollDuration', () => {
+		const partWithPreroll: IBlueprintPart = {
+			title: 'Server',
+			externalId: '0001',
+			prerollDuration: 1000
+		}
+		const cue: CueDefinitionGraphic<GraphicPilot> = {
+			type: CueType.Graphic,
+			target: 'WALL',
+			graphic: {
+				type: 'pilot',
+				name: '',
+				vcpid: 1234567890,
+				continueCount: -1
+			},
+			iNewsCommand: 'GRAFIK'
+		}
+
+		const pieces: IBlueprintPiece[] = []
+		const adLibPieces: IBlueprintAdLibPiece[] = []
+		const actions: IBlueprintActionManifest[] = []
+		const partId = '0000000001'
+
+		EvaluateCueGraphic(
+			config,
+			makeMockContext(),
+			partWithPreroll,
+			pieces,
+			adLibPieces,
+			actions,
+			partId,
+			cue,
+			cue.adlib ? cue.adlib : false,
+			dummyPart,
+			0
+		)
+		const piece = pieces[0]
+		expect(piece).toBeTruthy()
+		const tlObj = (piece.content?.timelineObjects as TSR.TSRTimelineObj[]).find(
+			obj =>
+				obj.content.deviceType === TSR.DeviceType.VIZMSE &&
+				obj.content.type === TSR.TimelineContentTypeVizMSE.ELEMENT_PILOT
+		) as TSR.TimelineObjVIZMSEElementInternal | undefined
+		expect(tlObj).toBeTruthy()
+		expect(tlObj?.enable).toEqual({ start: 1000 })
+	})
+
+	it('Applies delay to WALL graphics when part has transitionPrerollDuration', () => {
+		const partWithPreroll: IBlueprintPart = {
+			title: 'Kam 1',
+			externalId: '0001',
+			transitionPrerollDuration: 2000
+		}
+		const cue: CueDefinitionGraphic<GraphicPilot> = {
+			type: CueType.Graphic,
+			target: 'WALL',
+			graphic: {
+				type: 'pilot',
+				name: '',
+				vcpid: 1234567890,
+				continueCount: -1
+			},
+			iNewsCommand: 'GRAFIK'
+		}
+
+		const pieces: IBlueprintPiece[] = []
+		const adLibPieces: IBlueprintAdLibPiece[] = []
+		const actions: IBlueprintActionManifest[] = []
+		const partId = '0000000001'
+
+		EvaluateCueGraphic(
+			config,
+			makeMockContext(),
+			partWithPreroll,
+			pieces,
+			adLibPieces,
+			actions,
+			partId,
+			cue,
+			cue.adlib ? cue.adlib : false,
+			dummyPart,
+			0
+		)
+		const piece = pieces[0]
+		expect(piece).toBeTruthy()
+		const tlObj = (piece.content?.timelineObjects as TSR.TSRTimelineObj[]).find(
+			obj =>
+				obj.content.deviceType === TSR.DeviceType.VIZMSE &&
+				obj.content.type === TSR.TimelineContentTypeVizMSE.ELEMENT_PILOT
+		) as TSR.TimelineObjVIZMSEElementInternal | undefined
+		expect(tlObj).toBeTruthy()
+		expect(tlObj?.enable).toEqual({ start: 2000 })
 	})
 })

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -2,6 +2,7 @@ import {
 	GraphicsContent,
 	IBlueprintActionManifest,
 	IBlueprintAdLibPiece,
+	IBlueprintPart,
 	IBlueprintPiece,
 	PieceLifespan,
 	TSR
@@ -51,6 +52,11 @@ const dummyPart = literal<PartDefinitionKam>({
 	segmentExternalId: ''
 })
 
+const dummyBlueprintPart: IBlueprintPart = {
+	title: 'Kam 1',
+	externalId: '0001'
+}
+
 describe('telefon', () => {
 	test('telefon with vizObj', () => {
 		const cue: CueDefinitionTelefon = {
@@ -87,6 +93,7 @@ describe('telefon', () => {
 				dsk: defaultDSKConfig
 			},
 			mockContext,
+			dummyBlueprintPart,
 			pieces,
 			adLibPieces,
 			actions,

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphic.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphic.ts
@@ -1,6 +1,7 @@
 import {
 	IBlueprintActionManifest,
 	IBlueprintAdLibPiece,
+	IBlueprintPart,
 	IBlueprintPiece,
 	SegmentContext
 } from '@sofie-automation/blueprints-integration'
@@ -19,6 +20,7 @@ import { EvaluateCueRouting } from './routing'
 export function EvaluateCueGraphic(
 	config: BlueprintConfig,
 	context: SegmentContext,
+	part: Readonly<IBlueprintPart>,
 	pieces: IBlueprintPiece[],
 	adlibPieces: IBlueprintAdLibPiece[],
 	actions: IBlueprintActionManifest[],
@@ -33,11 +35,24 @@ export function EvaluateCueGraphic(
 	}
 
 	if (GraphicIsInternal(parsedCue)) {
-		CreateInternalGraphic(config, context, pieces, adlibPieces, actions, partId, parsedCue, adlib, partDefinition, rank)
+		CreateInternalGraphic(
+			config,
+			context,
+			part,
+			pieces,
+			adlibPieces,
+			actions,
+			partId,
+			parsedCue,
+			adlib,
+			partDefinition,
+			rank
+		)
 	} else if (GraphicIsPilot(parsedCue)) {
 		EvaluateCueGraphicPilot(
 			config,
 			context,
+			part,
 			pieces,
 			adlibPieces,
 			actions,

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphicPilot.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphicPilot.ts
@@ -1,6 +1,7 @@
 import {
 	IBlueprintActionManifest,
 	IBlueprintAdLibPiece,
+	IBlueprintPart,
 	IBlueprintPiece,
 	NotesContext,
 	SegmentContext,
@@ -30,6 +31,7 @@ export const pilotGeneratorSettingsAFVD: PilotGeneratorSettings = {
 export function EvaluateCueGraphicPilot(
 	config: BlueprintConfig,
 	context: SegmentContext,
+	part: Readonly<IBlueprintPart>,
 	pieces: IBlueprintPiece[],
 	adlibPieces: IBlueprintAdLibPiece[],
 	actions: IBlueprintActionManifest[],
@@ -42,6 +44,7 @@ export function EvaluateCueGraphicPilot(
 	CreatePilotGraphic(
 		config,
 		context,
+		part,
 		pieces,
 		adlibPieces,
 		actions,

--- a/src/tv2_afvd_showstyle/helpers/pieces/telefon.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/telefon.ts
@@ -1,6 +1,7 @@
 import {
 	IBlueprintActionManifest,
 	IBlueprintAdLibPiece,
+	IBlueprintPart,
 	IBlueprintPiece,
 	SegmentContext,
 	TSR
@@ -19,6 +20,7 @@ import { EvaluateCueGraphic } from './graphic'
 export function EvaluateTelefon(
 	config: BlueprintConfig,
 	context: SegmentContext,
+	part: Readonly<IBlueprintPart>,
 	pieces: IBlueprintPiece[],
 	adlibPieces: IBlueprintAdLibPiece[],
 	actions: IBlueprintActionManifest[],
@@ -32,6 +34,7 @@ export function EvaluateTelefon(
 		EvaluateCueGraphic(
 			config,
 			context,
+			part,
 			pieces,
 			adlibPieces,
 			actions,

--- a/src/tv2_afvd_showstyle/parts/cueonly.ts
+++ b/src/tv2_afvd_showstyle/parts/cueonly.ts
@@ -45,9 +45,10 @@ export function CreatePartCueOnly(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
+	part = { ...part, ...GetJinglePartProperties(context, config, partDefinitionWithID) }
+
 	EvaluateCues(context, config, part, pieces, adLibPieces, actions, mediaSubscriptions, [cue], partDefinitionWithID, {})
 	AddScript(partDefinitionWithID, pieces, partTime, SourceLayer.PgmScript)
-	part = { ...part, ...GetJinglePartProperties(context, config, partDefinitionWithID) }
 
 	if (makeAdlibs) {
 		EvaluateCues(context, config, part, pieces, adLibPieces, actions, mediaSubscriptions, [cue], partDefinitionWithID, {

--- a/src/tv2_afvd_showstyle/parts/cueonly.ts
+++ b/src/tv2_afvd_showstyle/parts/cueonly.ts
@@ -47,6 +47,15 @@ export function CreatePartCueOnly(
 
 	part = { ...part, ...GetJinglePartProperties(context, config, partDefinitionWithID) }
 
+	if (
+		partDefinition.cues.filter(c => c.type === CueType.Graphic && GraphicIsPilot(c) && c.target === 'FULL').length &&
+		!partDefinition.cues.filter(c => c.type === CueType.Jingle).length
+	) {
+		ApplyFullGraphicPropertiesToPart(config, part)
+	} else if (partDefinition.cues.filter(c => c.type === CueType.DVE).length) {
+		part.prerollDuration = config.studio.CasparPrerollDuration
+	}
+
 	EvaluateCues(context, config, part, pieces, adLibPieces, actions, mediaSubscriptions, [cue], partDefinitionWithID, {})
 	AddScript(partDefinitionWithID, pieces, partTime, SourceLayer.PgmScript)
 
@@ -57,15 +66,6 @@ export function CreatePartCueOnly(
 	}
 
 	part.hackListenToMediaObjectUpdates = mediaSubscriptions
-
-	if (
-		partDefinition.cues.filter(c => c.type === CueType.Graphic && GraphicIsPilot(c) && c.target === 'FULL').length &&
-		!partDefinition.cues.filter(c => c.type === CueType.Jingle).length
-	) {
-		ApplyFullGraphicPropertiesToPart(config, part)
-	} else if (partDefinition.cues.filter(c => c.type === CueType.DVE).length) {
-		part.prerollDuration = config.studio.CasparPrerollDuration
-	}
 
 	if (pieces.length === 0 && adLibPieces.length === 0) {
 		part.invalid = true

--- a/src/tv2_afvd_showstyle/parts/grafik.ts
+++ b/src/tv2_afvd_showstyle/parts/grafik.ts
@@ -30,6 +30,8 @@ export function CreatePartGrafik(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
+	ApplyFullGraphicPropertiesToPart(config, part)
+
 	EvaluateCues(
 		context,
 		config,
@@ -45,8 +47,6 @@ export function CreatePartGrafik(
 		}
 	)
 	AddScript(partDefinition, pieces, partTime, SourceLayer.PgmScript)
-
-	ApplyFullGraphicPropertiesToPart(config, part)
 
 	part.hackListenToMediaObjectUpdates = mediaSubscriptions
 

--- a/src/tv2_afvd_showstyle/parts/grafik.ts
+++ b/src/tv2_afvd_showstyle/parts/grafik.ts
@@ -7,7 +7,15 @@ import {
 	IBlueprintPiece,
 	SegmentContext
 } from '@sofie-automation/blueprints-integration'
-import { AddScript, ApplyFullGraphicPropertiesToPart, literal, PartDefinition, PartTime } from 'tv2-common'
+import {
+	AddScript,
+	ApplyFullGraphicPropertiesToPart,
+	GraphicIsPilot,
+	literal,
+	PartDefinition,
+	PartTime
+} from 'tv2-common'
+import { CueType } from 'tv2-constants'
 import { BlueprintConfig } from '../helpers/config'
 import { EvaluateCues } from '../helpers/pieces/evaluateCues'
 import { SourceLayer } from '../layers'
@@ -30,7 +38,9 @@ export function CreatePartGrafik(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
-	ApplyFullGraphicPropertiesToPart(config, part)
+	if (partDefinition.cues.filter(c => c.type === CueType.Graphic && GraphicIsPilot(c) && c.target === 'FULL').length) {
+		ApplyFullGraphicPropertiesToPart(config, part)
+	}
 
 	EvaluateCues(
 		context,

--- a/src/tv2_afvd_showstyle/parts/intro.ts
+++ b/src/tv2_afvd_showstyle/parts/intro.ts
@@ -72,6 +72,11 @@ export function CreatePartIntro(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
+	part = {
+		...part,
+		...GetJinglePartProperties(context, config, partDefinition)
+	}
+
 	EvaluateCues(
 		context,
 		config,
@@ -87,7 +92,6 @@ export function CreatePartIntro(
 	AddScript(partDefinition, pieces, partTime, SourceLayer.PgmScript)
 	part = {
 		...part,
-		...GetJinglePartProperties(context, config, partDefinition),
 		hackListenToMediaObjectUpdates: mediaSubscriptions
 	}
 

--- a/src/tv2_afvd_showstyle/parts/unknown.ts
+++ b/src/tv2_afvd_showstyle/parts/unknown.ts
@@ -44,6 +44,7 @@ export function CreatePartUnknown(
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
 	part = { ...part, ...CreateEffektForpart(context, config, partDefinition, pieces) }
+	part = { ...part, ...GetJinglePartProperties(context, config, partDefinition) }
 
 	EvaluateCues(
 		context,
@@ -62,7 +63,6 @@ export function CreatePartUnknown(
 	if (!asAdlibs) {
 		AddScript(partDefinition, pieces, partTime, SourceLayer.PgmScript)
 	}
-	part = { ...part, ...GetJinglePartProperties(context, config, partDefinition) }
 
 	if (
 		partDefinition.cues.some(cue => cue.type === CueType.Graphic && GraphicIsPilot(cue) && cue.target === 'FULL') &&

--- a/src/tv2_afvd_showstyle/parts/unknown.ts
+++ b/src/tv2_afvd_showstyle/parts/unknown.ts
@@ -46,6 +46,15 @@ export function CreatePartUnknown(
 	part = { ...part, ...CreateEffektForpart(context, config, partDefinition, pieces) }
 	part = { ...part, ...GetJinglePartProperties(context, config, partDefinition) }
 
+	if (
+		partDefinition.cues.some(cue => cue.type === CueType.Graphic && GraphicIsPilot(cue) && cue.target === 'FULL') &&
+		!partDefinition.cues.filter(c => c.type === CueType.Jingle).length
+	) {
+		ApplyFullGraphicPropertiesToPart(config, part)
+	} else if (partDefinition.cues.filter(cue => cue.type === CueType.DVE).length) {
+		part.prerollDuration = config.studio.CasparPrerollDuration
+	}
+
 	EvaluateCues(
 		context,
 		config,
@@ -62,15 +71,6 @@ export function CreatePartUnknown(
 	)
 	if (!asAdlibs) {
 		AddScript(partDefinition, pieces, partTime, SourceLayer.PgmScript)
-	}
-
-	if (
-		partDefinition.cues.some(cue => cue.type === CueType.Graphic && GraphicIsPilot(cue) && cue.target === 'FULL') &&
-		!partDefinition.cues.filter(c => c.type === CueType.Jingle).length
-	) {
-		ApplyFullGraphicPropertiesToPart(config, part)
-	} else if (partDefinition.cues.filter(cue => cue.type === CueType.DVE).length) {
-		part.prerollDuration = config.studio.CasparPrerollDuration
 	}
 
 	if (pieces.length === 0) {

--- a/src/tv2_afvd_studio/__tests__/graphics.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/graphics.spec.ts
@@ -274,7 +274,7 @@ describe('Graphics', () => {
 			t =>
 				t.content.deviceType === TSR.DeviceType.VIZMSE && t.content.type === TSR.TimelineContentTypeVizMSE.ELEMENT_PILOT
 		)! as TSR.TimelineObjVIZMSEElementPilot
-		expect(vizObj.enable).toEqual({ start: 0 })
+		expect(vizObj.enable).toEqual({ while: '1' })
 		expect(vizObj.layer).toEqual(GraphicLLayer.GraphicLLayerWall)
 		expect(vizObj.content.channelName).toBe('WALL1') // TODO: OVL1: Enum / Type
 		expect(vizObj.content.templateVcpId).toBe(1234567890)

--- a/src/tv2_offtube_showstyle/actions.ts
+++ b/src/tv2_offtube_showstyle/actions.ts
@@ -38,7 +38,8 @@ export function executeActionOfftube(
 				Live: OfftubeSourceLayer.PgmLive,
 				Effekt: OfftubeSourceLayer.PgmJingle,
 				Ident: OfftubeSourceLayer.PgmGraphicsIdent,
-				Continuity: OfftubeSourceLayer.PgmContinuity
+				Continuity: OfftubeSourceLayer.PgmContinuity,
+				Wall: OfftubeSourceLayer.WallGraphics
 			},
 			LLayer: {
 				Caspar: {

--- a/src/tv2_offtube_showstyle/cues/OfftubeGraphics.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeGraphics.ts
@@ -1,6 +1,7 @@
 import {
 	IBlueprintActionManifest,
 	IBlueprintAdLibPiece,
+	IBlueprintPart,
 	IBlueprintPiece,
 	NotesContext,
 	SegmentContext,
@@ -34,6 +35,7 @@ export const pilotGeneratorSettingsOfftube: PilotGeneratorSettings = {
 export function OfftubeEvaluateGrafikCaspar(
 	config: OfftubeShowstyleBlueprintConfig,
 	context: SegmentContext,
+	part: Readonly<IBlueprintPart>,
 	pieces: IBlueprintPiece[],
 	adlibPieces: IBlueprintAdLibPiece[],
 	actions: IBlueprintActionManifest[],
@@ -47,6 +49,7 @@ export function OfftubeEvaluateGrafikCaspar(
 		CreatePilotGraphic(
 			config,
 			context,
+			part,
 			pieces,
 			adlibPieces,
 			actions,
@@ -58,7 +61,19 @@ export function OfftubeEvaluateGrafikCaspar(
 			partDefinition.segmentExternalId
 		)
 	} else if (GraphicIsInternal(parsedCue)) {
-		CreateInternalGraphic(config, context, pieces, adlibPieces, actions, partId, parsedCue, adlib, partDefinition, rank)
+		CreateInternalGraphic(
+			config,
+			context,
+			part,
+			pieces,
+			adlibPieces,
+			actions,
+			partId,
+			parsedCue,
+			adlib,
+			partDefinition,
+			rank
+		)
 	}
 }
 

--- a/src/tv2_offtube_showstyle/parts/OfftubeDVE.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeDVE.ts
@@ -31,6 +31,11 @@ export function OfftubeCreatePartDVE(
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
+
+	if (partDefinition.cues.filter(cue => cue.type === CueType.DVE).length) {
+		part.prerollDuration = config.studio.CasparPrerollDuration
+	}
+
 	OfftubeEvaluateCues(
 		context,
 		config,
@@ -45,10 +50,6 @@ export function OfftubeCreatePartDVE(
 			adlib: true
 		}
 	)
-
-	if (partDefinition.cues.filter(cue => cue.type === CueType.DVE).length) {
-		part.prerollDuration = config.studio.CasparPrerollDuration
-	}
 
 	if (pieces.length === 0) {
 		part.invalid = true

--- a/src/tv2_offtube_showstyle/parts/OfftubeGrafik.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeGrafik.ts
@@ -33,6 +33,8 @@ export function OfftubeCreatePartGrafik(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
+	ApplyFullGraphicPropertiesToPart(config, part)
+
 	OfftubeEvaluateCues(
 		context,
 		config,
@@ -48,8 +50,6 @@ export function OfftubeCreatePartGrafik(
 		}
 	)
 	AddScript(partDefinition, pieces, partTime, OfftubeSourceLayer.PgmScript)
-
-	ApplyFullGraphicPropertiesToPart(config, part)
 
 	part.hackListenToMediaObjectUpdates = mediaSubscriptions
 

--- a/src/tv2_offtube_showstyle/parts/OfftubeUnknown.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeUnknown.ts
@@ -42,6 +42,8 @@ export function CreatePartUnknown(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
+	part = { ...part, ...GetJinglePartProperties(context, config, partDefinition) }
+
 	OfftubeEvaluateCues(
 		context,
 		config,
@@ -56,7 +58,6 @@ export function CreatePartUnknown(
 			adlib: asAdlibs
 		}
 	)
-	part = { ...part, ...GetJinglePartProperties(context, config, partDefinition) }
 
 	if (
 		partDefinition.cues.some(cue => cue.type === CueType.Graphic && GraphicIsPilot(cue) && cue.target === 'FULL') &&

--- a/src/tv2_offtube_showstyle/parts/OfftubeUnknown.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeUnknown.ts
@@ -44,6 +44,15 @@ export function CreatePartUnknown(
 
 	part = { ...part, ...GetJinglePartProperties(context, config, partDefinition) }
 
+	if (
+		partDefinition.cues.some(cue => cue.type === CueType.Graphic && GraphicIsPilot(cue) && cue.target === 'FULL') &&
+		!partDefinition.cues.filter(c => c.type === CueType.Jingle).length
+	) {
+		ApplyFullGraphicPropertiesToPart(config, part)
+	} else if (partDefinition.cues.filter(cue => cue.type === CueType.DVE).length) {
+		part.prerollDuration = config.studio.CasparPrerollDuration
+	}
+
 	OfftubeEvaluateCues(
 		context,
 		config,
@@ -58,15 +67,6 @@ export function CreatePartUnknown(
 			adlib: asAdlibs
 		}
 	)
-
-	if (
-		partDefinition.cues.some(cue => cue.type === CueType.Graphic && GraphicIsPilot(cue) && cue.target === 'FULL') &&
-		!partDefinition.cues.filter(c => c.type === CueType.Jingle).length
-	) {
-		ApplyFullGraphicPropertiesToPart(config, part)
-	} else if (partDefinition.cues.filter(cue => cue.type === CueType.DVE).length) {
-		part.prerollDuration = config.studio.CasparPrerollDuration
-	}
 
 	AddScript(partDefinition, pieces, partTime, OfftubeSourceLayer.PgmScript)
 


### PR DESCRIPTION
When taking a server part, the cut to the server input is delayed by `CasparPrerollDuration` ms.  The server part also has that value applied as `prerollDuration`, to keep previous timeline objects alive during that period. Unfortunately when the server part features an `SS=SC-LOOP` cue, and we're cutting from a part that had pilot graphics on the WALL, the WALL cuts immediately, not waiting the preroll duration.
~~This PR solves the issue by setting a higher priority on Pilot graphics targeting WALL, so that the timeline object is still alive and on top during `prerollDuration`.~~
This PR solves the issue by setting a `start` equal to `prerollDuration` or `transitionPrerollDuration` in the WALL's timelineObject. It also updates this value when executing the take-with-transition adlib action.