### PR TITLE
fix: Fields from iNews may be undefined causing NaN to appear in UI

### DIFF
--- a/src/inews-mixins/playlist.ts
+++ b/src/inews-mixins/playlist.ts
@@ -13,7 +13,7 @@ import {
 	ShowStyleBlueprintManifest,
 	StudioBlueprintManifest
 } from '@sofie-automation/blueprints-integration'
-import { assertUnreachable, literal } from 'tv2-common'
+import { assertUnreachable, literal, TimeFromINewsField } from 'tv2-common'
 import { getRundownDuration } from './rundownDuration'
 
 interface RundownMetaData {
@@ -50,14 +50,10 @@ function getRundownWithBackTime(
 	const expectedDuration = getRundownDuration(ingestRundown.segments)
 
 	if (backTime) {
-		const backTimeNum = Number(backTime.replace(/^@/, ''))
-		if (!Number.isNaN(backTimeNum)) {
-			const midnightToday = new Date()
-			midnightToday.setHours(0, 0, 0, 0)
-
-			expectedEnd = midnightToday.getTime() + backTimeNum * 1000
-		}
-
+		const backTimeNum = TimeFromINewsField(backTime.replace(/^@/, ''))
+		const midnightToday = new Date()
+		midnightToday.setHours(0, 0, 0, 0)
+		expectedEnd = midnightToday.getTime() + backTimeNum * 1000
 		expectedEnd = expectedEnd
 	}
 

--- a/src/inews-mixins/rundownDuration.ts
+++ b/src/inews-mixins/rundownDuration.ts
@@ -1,5 +1,5 @@
 import { IngestSegment } from '@sofie-automation/blueprints-integration'
-import { INewsPayload } from 'tv2-common'
+import { INewsPayload, TimeFromINewsField } from 'tv2-common'
 
 export function getRundownDuration(segments: IngestSegment[]) {
 	let totalTime = 0
@@ -9,8 +9,7 @@ export function getRundownDuration(segments: IngestSegment[]) {
 			continue
 		}
 
-		const time = payload?.iNewsStory?.fields.totalTime ?? 0
-		totalTime += Number(time)
+		totalTime += TimeFromINewsField(payload?.iNewsStory?.fields.totalTime)
 	}
 
 	return totalTime * 1000

--- a/src/tv2-common/getSegment.ts
+++ b/src/tv2-common/getSegment.ts
@@ -26,7 +26,8 @@ import {
 	PartDefinitionEkstern,
 	PartDefinitionGrafik,
 	PartDefinitionTeknik,
-	PartDefinitionTelefon
+	PartDefinitionTelefon,
+	TimeFromINewsField
 } from './inewsConversion'
 import { PieceMetaData } from './onTimelineGenerate'
 import { CreatePartInvalid, ServerPartProps } from './parts'
@@ -130,7 +131,7 @@ export function getSegmentBase<
 		segment.isHidden = false
 	}
 
-	const totalTimeMs = Number(iNewsStory.fields.totalTime) * 1000
+	const totalTimeMs = TimeFromINewsField(iNewsStory.fields.totalTime) * 1000
 	let blueprintParts: BlueprintResultPart[] = []
 	const parsedParts = ParseBody(
 		config,
@@ -139,7 +140,7 @@ export function getSegmentBase<
 		iNewsStory.body,
 		iNewsStory.cues,
 		iNewsStory.fields,
-		Number(iNewsStory.fields.modifyDate) || Date.now()
+		TimeFromINewsField(iNewsStory.fields.modifyDate) || Date.now()
 	)
 
 	const totalWords = parsedParts.reduce((prev, cur) => {
@@ -158,8 +159,9 @@ export function getSegmentBase<
 	}
 
 	let jingleTime = 0
-	const totalTime = Number(iNewsStory.fields.totalTime) || 0
-	const tapeTime = Number(iNewsStory.fields.tapeTime) || 0
+	const totalTime = TimeFromINewsField(iNewsStory.fields.totalTime)
+	const tapeTime = TimeFromINewsField(iNewsStory.fields.tapeTime)
+
 	for (const part of parsedParts) {
 		// Make orphaned secondary cues into adlibs
 		if (

--- a/src/tv2-common/inewsConversion/index.ts
+++ b/src/tv2-common/inewsConversion/index.ts
@@ -1,2 +1,3 @@
 // export * from './TransformCuesIntoShowstyle'
 export * from './converters'
+export * from './time'

--- a/src/tv2-common/inewsConversion/time.ts
+++ b/src/tv2-common/inewsConversion/time.ts
@@ -1,0 +1,8 @@
+export function TimeFromINewsField(field: string | undefined): number {
+	const time = Number(field)
+	if (isNaN(time)) {
+		return 0
+	}
+
+	return time
+}

--- a/src/tv2-common/time/partTime.ts
+++ b/src/tv2-common/time/partTime.ts
@@ -1,4 +1,4 @@
-import { PartDefinition } from 'tv2-common'
+import { PartDefinition, TimeFromINewsField } from 'tv2-common'
 import { TV2BlueprintConfigBase, TV2StudioConfigBase } from '../blueprintConfig'
 
 export function PartTime<StudioConfig extends TV2StudioConfigBase>(
@@ -7,7 +7,7 @@ export function PartTime<StudioConfig extends TV2StudioConfigBase>(
 	totalWords: number,
 	defaultTime: boolean = true
 ): number {
-	const storyDuration = Number(partDefinition.fields.audioTime) * 1000 || 0
+	const storyDuration = TimeFromINewsField(partDefinition.fields.audioTime) * 1000
 	const partTime = (partDefinition.script.replace(/[\r\n]/g, '').length / totalWords) * storyDuration
 	return Math.min(
 		partTime > 0 ? partTime : defaultTime ? config.studio.DefaultPartDuration : 0,

--- a/src/tv2-common/types/inews.ts
+++ b/src/tv2-common/types/inews.ts
@@ -1,15 +1,15 @@
-interface INewsFields {
-	title: string
-	modifyDate: string // number
+export interface INewsFields {
+	title?: string
+	modifyDate?: string // number
 	pageNumber?: string
-	tapeTime: string // number
-	audioTime: string // number
-	totalTime: string // number
-	cumeTime: string // number
-	backTime?: string // number
+	tapeTime?: string // number
+	audioTime?: string // number
+	totalTime?: string // number
+	cumeTime?: string // number
+	backTime?: string // @number (seconds since midnight)
 }
 
-interface INewsMetaData {
+export interface INewsMetaData {
 	wire?: 'f' | 'b' | 'u' | 'r' | 'o'
 	mail?: 'read' | 'unread'
 	locked?: 'pass' | 'user'
@@ -24,6 +24,7 @@ interface INewsMetaData {
 
 export interface INewsStory {
 	/** Same identifier as the file the story came from */
+	id: string
 	identifier: string
 	locator: string
 	fields: INewsFields

--- a/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
@@ -35,6 +35,7 @@ function makeIngestSegment(cues: UnparsedCue[], body: string) {
 		parts: [],
 		payload: {
 			iNewsStory: literal<INewsStory>({
+				id: '00000000',
 				identifier: '00000000',
 				locator: '01',
 				fields: {

--- a/src/tv2_afvd_showstyle/helpers/time.ts
+++ b/src/tv2_afvd_showstyle/helpers/time.ts
@@ -1,9 +1,9 @@
 import { IBlueprintPart } from '@sofie-automation/blueprints-integration'
-import { INewsStory } from 'tv2-common'
+import { INewsStory, TimeFromINewsField } from 'tv2-common'
 
 export function GetTimeFromPart(story: INewsStory): Partial<IBlueprintPart> {
 	return {
-		expectedDuration: Number(story.fields.audioTime),
+		expectedDuration: TimeFromINewsField(story.fields.audioTime),
 		prerollDuration: 0
 	}
 }

--- a/src/tv2_afvd_showstyle/parts/kam.ts
+++ b/src/tv2_afvd_showstyle/parts/kam.ts
@@ -25,6 +25,7 @@ import {
 	GetSisyfosTimelineObjForCamera,
 	literal,
 	PartDefinitionKam,
+	TimeFromINewsField,
 	TransitionFromString,
 	TransitionSettings
 } from 'tv2-common'
@@ -90,7 +91,7 @@ export function CreatePartKam(
 				})
 			})
 		)
-		part.expectedDuration = Number(partDefinition.fields.totalTime) * 1000 || 0
+		part.expectedDuration = TimeFromINewsField(partDefinition.fields.totalTime) * 1000
 	} else {
 		const sourceInfoCam = FindSourceInfoStrict(context, config.sources, SourceLayerType.CAMERA, partDefinition.rawType)
 		if (sourceInfoCam === undefined) {

--- a/src/tv2_offtube_showstyle/getRundown.ts
+++ b/src/tv2_offtube_showstyle/getRundown.ts
@@ -36,7 +36,8 @@ import {
 	GetTransitionAdLibActions,
 	literal,
 	SourceInfo,
-	t
+	t,
+	TimeFromINewsField
 } from 'tv2-common'
 import {
 	AdlibActionType,
@@ -81,11 +82,11 @@ export function getRundown(context: IShowStyleUserContext, ingestRundown: Ingest
 	// Set start / end times
 	if ('payload' in ingestRundown) {
 		if (ingestRundown.payload.expectedStart) {
-			startTime = Number(ingestRundown.payload.expectedStart)
+			startTime = TimeFromINewsField(ingestRundown.payload.expectedStart)
 		}
 
 		if (ingestRundown.payload.expectedEnd) {
-			endTime = Number(ingestRundown.payload.expectedEnd)
+			endTime = TimeFromINewsField(ingestRundown.payload.expectedEnd)
 		}
 	}
 


### PR DESCRIPTION
This fixes the bug we saw in AFVD where the segment timeline container crashed on the on-air queue. This was caused by the `budgetDuration` of a part being `NaN`. I have copied the typings from Jesper's work in the iNews gateway last week and written a new helper function to convert times from iNews to numbers, falling back to `0` which I think works for all of the cases I've found in blueprints?