### PR TITLE
fix: exception in remapTableColumnValues migration

### DIFF
--- a/src/tv2_offtube_showstyle/migrations/util.ts
+++ b/src/tv2_offtube_showstyle/migrations/util.ts
@@ -153,12 +153,8 @@ export function remapTableColumnValues(
 			validate: (context: MigrationContextShowStyle) => {
 				const table = context.getBaseConfig(tableId) as TableConfigItemValue | undefined
 
-				if (!table) {
-					return `Table "${tableId}" does not exist`
-				}
-
-				if (!table.length) {
-					// No values, nothing to remap
+				if (!table || !table.length) {
+					// No table or no values, nothing to remap
 					return false
 				}
 


### PR DESCRIPTION
Fixes exception in migration thrown when some tables are empty.
Return `false` if there's no table, otherwise it will try to migrate and throw on `table.map()` inside `remapTableColumnValuesInner`.