### PR TITLE
fix: bum version to avoid version mismatch error message in core

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = env => {
 	// versionIntegration = versionIntegration.replace(/[^\d.]/g, '') || '0.0.0'
 
 	versionTSRTypes = '1.3.0'
-	versionIntegration = '1.16.1'
+	versionIntegration = '1.37.0'
 
 	const entrypoints = env.bundle ? GetEntrypointsForBundle(env.bundle) : BlueprintEntrypoints
 


### PR DESCRIPTION
bump hardcoded version to avoid error messages on blueprints when deploying release 37