### PR TITLE
fix: Add Jingle layers to presenter screen

### DIFF
--- a/src/tv2-common/migrations/forceSourceLayerToDefaultsBase.ts
+++ b/src/tv2-common/migrations/forceSourceLayerToDefaultsBase.ts
@@ -9,11 +9,12 @@ import _ = require('underscore')
 export function forceSourceLayerToDefaultsBase(
 	sourcelayerDefaults: ISourceLayer[],
 	versionStr: string,
+	showStyleId: string,
 	layer: string,
 	overrideSteps?: string[]
 ): MigrationStepShowStyle {
 	return literal<MigrationStepShowStyle>({
-		id: `${versionStr}.sourcelayer.defaults.${layer}.forced`,
+		id: `${versionStr}.${showStyleId}.sourcelayer.defaults.${layer}.forced`,
 		version: versionStr,
 		canBeRunAutomatically: true,
 		overrideSteps,

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -166,9 +166,11 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	 * 1.6.10
 	 * - Remove 'audio/' from soundbed configs
 	 * - Remove 'dve/' from DVE frame/key configs
+	 * - Add PgmJingle to presenter screen
 	 */
 	StripFolderFromAudioBedConfig('1.6.10', 'AFVD'),
 	StripFolderFromDVEConfig('1.6.10', 'AFVD'),
+	forceSourceLayerToDefaults('1.6.10', SourceLayer.PgmJingle),
 
 	// Fill in any layers that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_afvd_showstyle/migrations/sourcelayer-defaults.ts
+++ b/src/tv2_afvd_showstyle/migrations/sourcelayer-defaults.ts
@@ -179,7 +179,7 @@ const JINGLE: ISourceLayer[] = [
 		isQueueable: false,
 		isHidden: false,
 		allowDisable: false,
-		onPresenterScreen: false
+		onPresenterScreen: true
 	}
 ]
 

--- a/src/tv2_afvd_showstyle/migrations/util.ts
+++ b/src/tv2_afvd_showstyle/migrations/util.ts
@@ -48,7 +48,7 @@ export function forceSourceLayerToDefaults(
 	layer: string,
 	overrideSteps?: string[]
 ): MigrationStepShowStyle {
-	return forceSourceLayerToDefaultsBase(SourcelayerDefaults, versionStr, layer, overrideSteps)
+	return forceSourceLayerToDefaultsBase(SourcelayerDefaults, versionStr, 'AFVD', layer, overrideSteps)
 }
 
 export function forceSettingToDefaults(versionStr: string, setting: string): MigrationStepShowStyle {

--- a/src/tv2_offtube_showstyle/migrations/index.ts
+++ b/src/tv2_offtube_showstyle/migrations/index.ts
@@ -206,9 +206,11 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	 * 1.6.10
 	 * - Remove 'audio/' from soundbed configs
 	 * - Remove 'dve/' from DVE frame/key configs
+	 * - Add PgmJingle to presenter screen
 	 */
 	StripFolderFromAudioBedConfig('1.6.10', 'AFVD'),
 	StripFolderFromDVEConfig('1.6.10', 'AFVD'),
+	forceSourceLayerToDefaults('1.6.10', OfftubeSourceLayer.PgmJingle),
 
 	...getSourceLayerDefaultsMigrationSteps(VERSION),
 	...getOutputLayerDefaultsMigrationSteps(VERSION)

--- a/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
+++ b/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
@@ -217,7 +217,7 @@ const JINGLE: ISourceLayer[] = [
 		isQueueable: false,
 		isHidden: false,
 		allowDisable: false,
-		onPresenterScreen: false
+		onPresenterScreen: true
 	}
 ]
 

--- a/src/tv2_offtube_showstyle/migrations/util.ts
+++ b/src/tv2_offtube_showstyle/migrations/util.ts
@@ -135,7 +135,7 @@ export function forceSourceLayerToDefaults(
 	layer: string,
 	overrideSteps?: string[]
 ): MigrationStepShowStyle {
-	return forceSourceLayerToDefaultsBase(SourcelayerDefaults, versionStr, layer, overrideSteps)
+	return forceSourceLayerToDefaultsBase(SourcelayerDefaults, versionStr, 'Offtube', layer, overrideSteps)
 }
 
 export function remapTableColumnValues(


### PR DESCRIPTION
This change allows transition pieces (e.g. Intro / KAM CS 3) to be found by the presenter screen and used as the primary piece. This will make the presenter clock show the correct colour for these kinds of pieces.

This PR requires this work in core: https://github.com/tv2/tv-automation-server-core/pull/97