### PR TITLE
fix: duplicate migration step id

### DIFF
--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -223,7 +223,7 @@ export function StripFolderFromShowStyleConfig(
 	regex: RegExp
 ): MigrationStepShowStyle {
 	return literal<MigrationStepShowStyle>({
-		id: `${versionStr}.normalizeSoundbedConfig.${studio}`,
+		id: `${versionStr}.normalizeFolders.${studio}.${configId}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
 		validate: (context: MigrationContextShowStyle) => {


### PR DESCRIPTION
This runs for multiple tables, so we need to make the ids different, otherwise Core complains.