### PR TITLE
fix: Remove autoNext from invalid parts

### DIFF
--- a/src/tv2-common/parts/invalid.ts
+++ b/src/tv2-common/parts/invalid.ts
@@ -6,8 +6,7 @@ export function CreatePartInvalid(ingestPart: PartDefinition, externalIdSuffix?:
 		externalId: ingestPart.externalId + (externalIdSuffix ? `_${externalIdSuffix}` : ''),
 		title: ingestPart.rawType || 'Unknown',
 		metaData: {},
-		invalid: true,
-		autoNext: true
+		invalid: true
 	})
 
 	return {


### PR DESCRIPTION
Invlaid parts will no longer mark themselves as autoNext, as core will prevent them from being taken in the first place.