### PR TITLE
fix: back-time valid only when on first continuity

### DIFF
--- a/src/inews-mixins/__tests__/playlist.spec.ts
+++ b/src/inews-mixins/__tests__/playlist.spec.ts
@@ -1,0 +1,88 @@
+import {
+	BlueprintResultRundown,
+	ExtendedIngestRundown,
+	IngestSegment,
+	PlaylistTimingType
+} from '@sofie-automation/blueprints-integration'
+import { getRundownWithBackTime } from 'inews-mixins'
+import { ShowStyleUserContext } from '../../__mocks__/context'
+import { parseConfig as parseShowStyleConfig } from '../../tv2_afvd_showstyle/helpers/config'
+import { parseConfig as parseStudioConfig } from '../../tv2_afvd_studio/helpers/config'
+import mappingsDefaults from '../../tv2_afvd_studio/migrations/mappings-defaults'
+import { makeSegmentWithTime } from './rundownDuration.spec'
+
+const RUNDOWN_ID = 'test_rundown'
+const RUNDOWN_NAME = 'Rundown 1'
+const SEGMENT_ID = 'test_segment'
+const PART_ID = 'test_part'
+
+function getMockContext() {
+	return new ShowStyleUserContext(
+		RUNDOWN_NAME,
+		mappingsDefaults,
+		parseStudioConfig,
+		parseShowStyleConfig,
+		RUNDOWN_ID,
+		SEGMENT_ID,
+		PART_ID
+	)
+}
+
+function getMockResult(): BlueprintResultRundown {
+	return {
+		rundown: {
+			externalId: RUNDOWN_ID,
+			name: RUNDOWN_NAME,
+			timing: {
+				type: PlaylistTimingType.None
+			}
+		},
+		globalAdLibPieces: [],
+		baseline: {
+			timelineObjects: []
+		}
+	}
+}
+
+function getMockRundown(segments: IngestSegment[]): ExtendedIngestRundown {
+	return {
+		externalId: RUNDOWN_ID,
+		name: RUNDOWN_NAME,
+		type: 'mock',
+		payload: {},
+		segments,
+		coreData: undefined
+	}
+}
+describe('Rundown BackTime', () => {
+	it('Discards back time if not on the first continuty', () => {
+		const segments = [
+			makeSegmentWithTime('test-segment_1', 1, 0, {}),
+			makeSegmentWithTime('test-segment_2', 1, 1, { floated: true }),
+			makeSegmentWithTime('test-segment_3', 1, 1, {}),
+			makeSegmentWithTime('continuity', 2, 2, { untimed: true }),
+			makeSegmentWithTime('test-segment_4', 2, 3, { untimed: true }),
+			makeSegmentWithTime('continuity', 2, 4, { untimed: true, backTimeInHours: 2 }),
+			makeSegmentWithTime('test-segment_5', 3, 5, { untimed: true })
+		]
+
+		const result = getRundownWithBackTime(getMockContext(), getMockRundown(segments), getMockResult())
+		expect(result.rundown.timing.type).toEqual(PlaylistTimingType.None)
+	})
+
+	it('Takes back time if on the first continuty', () => {
+		const segments = [
+			makeSegmentWithTime('test-segment_1', 1, 0, { floated: true }),
+			makeSegmentWithTime('test-segment_2', 1, 1, { floated: true }),
+			makeSegmentWithTime('test-segment_3', 1, 1, {}),
+			makeSegmentWithTime('continuity', 2, 2, { untimed: true, backTimeInHours: 2 }),
+			makeSegmentWithTime('test-segment_4', 2, 3, { untimed: true }),
+			makeSegmentWithTime('continuity', 2, 4, { untimed: true }),
+			makeSegmentWithTime('test-segment_5', 3, 5, { untimed: true })
+		]
+
+		const result = getRundownWithBackTime(getMockContext(), getMockRundown(segments), getMockResult())
+		expect(result.rundown.timing.type).toEqual(PlaylistTimingType.BackTime)
+		// @todo test for correct endTime value after merging the midnight fix
+	})
+})

--- a/src/inews-mixins/__tests__/rundownDuration.spec.ts
+++ b/src/inews-mixins/__tests__/rundownDuration.spec.ts
@@ -2,7 +2,7 @@ import { IngestSegment } from '@sofie-automation/blueprints-integration'
 import { literal } from 'tv2-common'
 import { getRundownDuration } from '../rundownDuration'
 
-function makeSegmentWithoutTime(externalId: string, rank: number): IngestSegment {
+export function makeSegmentWithoutTime(externalId: string, rank: number): IngestSegment {
 	return literal<IngestSegment>({
 		externalId,
 		name: externalId,
@@ -11,20 +11,22 @@ function makeSegmentWithoutTime(externalId: string, rank: number): IngestSegment
 	})
 }
 
-function makeSegmentWithTime(
+export function makeSegmentWithTime(
 	externalId: string,
 	time: number,
 	rank: number,
 	options: {
 		floated?: boolean
 		untimed?: boolean
+		backTimeInHours?: number
 	}
 ): IngestSegment {
 	const segment = makeSegmentWithoutTime(externalId, rank)
 	segment.payload = {
 		iNewsStory: {
 			fields: {
-				totalTime: time
+				totalTime: time,
+				backTime: options.backTimeInHours ? `@${options.backTimeInHours * 3600}` : undefined
 			},
 			meta: {
 				float: options.floated ? 'float' : undefined

--- a/src/inews-mixins/playlist.ts
+++ b/src/inews-mixins/playlist.ts
@@ -35,16 +35,14 @@ function getRundownWithINewsPlaylist(
 	return manifest
 }
 
-function getRundownWithBackTime(
+export function getRundownWithBackTime(
 	_context: IShowStyleUserContext,
 	ingestRundown: ExtendedIngestRundown,
 	manifest: BlueprintResultRundown
 ): BlueprintResultRundown {
 	const sortedSegments = ingestRundown.segments.sort((a, b) => a.rank - b.rank)
-	const backTimeStory = sortedSegments.find(
-		segment => segment.name.match(/^\s*continuity\s*$/i) && segment.payload.iNewsStory.fields.backTime
-	)
-	const backTime = backTimeStory ? backTimeStory.payload.iNewsStory.fields.backTime : undefined
+	const firstContinuityStory = sortedSegments.find(segment => segment.name.match(/^\s*continuity\s*$/i))
+	const backTime = firstContinuityStory ? firstContinuityStory.payload.iNewsStory.fields.backTime : undefined
 
 	let expectedEnd: number | undefined
 	const expectedDuration = getRundownDuration(ingestRundown.segments)


### PR DESCRIPTION
Makes it work as specified in SOF-549: the rundown is back-timed only if the first Continuity has back-time.
Note: unit testing `getRundownWithBackTime` is not perfect and we already have tests for `getRundownDuration`, but I think it might be better to revisit this when enabling breaks because I expect more changes.