### PR TITLE
fix: win shares joining

### DIFF
--- a/src/tv2-common/__tests__/util.spec.ts
+++ b/src/tv2-common/__tests__/util.spec.ts
@@ -131,6 +131,22 @@ const JOIN_ASSET_NETWORK_PATH_TESTS: Array<{
 		assetFile: 'amb',
 		extensiton: '.asset.mp4',
 		result: 'S:\\Sofie\\assets\\amb.asset.mp4'
+	},
+	{
+		name: 'Handles win shares',
+		networkPath: '\\\\Sofie\\\\share',
+		folder: 'assets',
+		assetFile: 'amb',
+		extensiton: '.asset.mp4',
+		result: '\\\\Sofie\\share\\assets\\amb.asset.mp4'
+	},
+	{
+		name: 'Handles win shares #2',
+		networkPath: '\\\\\\Sofie\\share\\',
+		folder: 'assets',
+		assetFile: 'amb',
+		extensiton: '.asset.mp4',
+		result: '\\\\Sofie\\share\\assets\\amb.asset.mp4'
 	}
 ]
 

--- a/src/tv2-common/util.ts
+++ b/src/tv2-common/util.ts
@@ -58,7 +58,12 @@ export function JoinAssetToNetworkPath(
 	// Replace every `\\` with `\`, then replace every `\` with `/`
 	const folderWithForwardSlashes = folder?.replace(/\\\\/g, '/').replace(/\\/g, '/')
 	const assetWithForwardSlashes = assetFile.replace(/\\\\/g, '/').replace(/\\/g, '/')
-	const networkPathWithForwardSlashes = networkPath.replace(/\\\\/g, '/').replace(/\\/g, '/')
+	const networkPathWithForwardSlashes =
+		networkPath[0] +
+		networkPath
+			.slice(1)
+			.replace(/\\\\/g, '/')
+			.replace(/\\/g, '/')
 
 	// Remove trailing/leading slash from folder and leading slash from asset
 	const folderWithoutLeadingTrailingSlashes = folderWithForwardSlashes?.replace(/\/+$/, '').replace(/^\/+/, '')


### PR DESCRIPTION
prevent from removing double backslash at the beginning