### PR TITLE
Fix/updated offtube sisyfos labels

### DIFF
--- a/src/tv2_offtube_studio/layers.ts
+++ b/src/tv2_offtube_studio/layers.ts
@@ -40,7 +40,9 @@ enum SisyfosLLayer {
 	SisyfosSourceServerA = 'sisyfos_source_server_a',
 	SisyfosSourceServerB = 'sisyfos_source_server_b',
 	// We don't control this layer, just set the label
-	SisyfosN1 = 'sisyfos_source_n1'
+	SisyfosN1 = 'sisyfos_source_n1',
+	SisyfosSourceDisp1 = 'sisyfos_source_disp_1',
+	SisyfosSourceDisp2 = 'sisyfos_source_disp_2'
 }
 
 export enum AtemLLayer {

--- a/src/tv2_offtube_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_offtube_studio/migrations/mappings-defaults.ts
@@ -109,7 +109,7 @@ const MAPPINGS_SISYFOS: BlueprintMappings = {
 	[OfftubeSisyfosLLayer.SisyfosSourceLive_1_Stereo]: literal<TSR.MappingSisyfos & BlueprintMapping>({
 		device: TSR.DeviceType.SISYFOS,
 		deviceId: 'sisyfos0',
-		layerName: 'LIVE 1 Stereo',
+		layerName: 'FEED 1 Stereo',
 		channel: 3,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
@@ -118,7 +118,7 @@ const MAPPINGS_SISYFOS: BlueprintMappings = {
 	[OfftubeSisyfosLLayer.SisyfosSourceLive_1_Surround]: literal<TSR.MappingSisyfos & BlueprintMapping>({
 		device: TSR.DeviceType.SISYFOS,
 		deviceId: 'sisyfos0',
-		layerName: 'LIVE 1 5.1',
+		layerName: 'FEED 1 5.1',
 		channel: 4,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
@@ -127,7 +127,7 @@ const MAPPINGS_SISYFOS: BlueprintMappings = {
 	[OfftubeSisyfosLLayer.SisyfosSourceLive_2_Stereo]: literal<TSR.MappingSisyfos & BlueprintMapping>({
 		device: TSR.DeviceType.SISYFOS,
 		deviceId: 'sisyfos0',
-		layerName: 'LIVE 2 Stereo',
+		layerName: 'FEED 2 Stereo',
 		channel: 5,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
@@ -136,7 +136,7 @@ const MAPPINGS_SISYFOS: BlueprintMappings = {
 	[OfftubeSisyfosLLayer.SisyfosSourceLive_3]: literal<TSR.MappingSisyfos & BlueprintMapping>({
 		device: TSR.DeviceType.SISYFOS,
 		deviceId: 'sisyfos0',
-		layerName: 'LIVE 3 Reporter',
+		layerName: 'LIVE 1 Reporter',
 		channel: 6,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
@@ -181,8 +181,26 @@ const MAPPINGS_SISYFOS: BlueprintMappings = {
 	[OfftubeSisyfosLLayer.SisyfosN1]: literal<TSR.MappingSisyfos & BlueprintMapping>({
 		device: TSR.DeviceType.SISYFOS,
 		deviceId: 'sisyfos0',
-		layerName: 'N-1',
+		layerName: 'MixMinus (N-1)',
 		channel: 10,
+		lookahead: LookaheadMode.NONE,
+		mappingType: TSR.MappingSisyfosType.CHANNEL,
+		setLabelToLayerName: true
+	}),
+	[OfftubeSisyfosLLayer.SisyfosSourceDisp1]: literal<TSR.MappingSisyfos & BlueprintMapping>({
+		device: TSR.DeviceType.SISYFOS,
+		deviceId: 'sisyfos0',
+		layerName: 'Disp 1',
+		channel: 11,
+		lookahead: LookaheadMode.NONE,
+		mappingType: TSR.MappingSisyfosType.CHANNEL,
+		setLabelToLayerName: true
+	}),
+	[OfftubeSisyfosLLayer.SisyfosSourceDisp2]: literal<TSR.MappingSisyfos & BlueprintMapping>({
+		device: TSR.DeviceType.SISYFOS,
+		deviceId: 'sisyfos0',
+		layerName: 'Disp 2',
+		channel: 12,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
 		setLabelToLayerName: true

--- a/src/tv2_offtube_studio/sisyfosChannels.ts
+++ b/src/tv2_offtube_studio/sisyfosChannels.ts
@@ -40,5 +40,11 @@ export const sisyfosChannels: { [key in OfftubeSisyfosLLayer]?: SisyfosChannel }
 	},
 	[OfftubeSisyfosLLayer.SisyfosN1]: {
 		isPgm: 0
+	},
+	[OfftubeSisyfosLLayer.SisyfosSourceDisp1]: {
+		isPgm: 0
+	},
+	[OfftubeSisyfosLLayer.SisyfosSourceDisp1]: {
+		isPgm: 0
 	}
 }

--- a/src/tv2_offtube_studio/sisyfosChannels.ts
+++ b/src/tv2_offtube_studio/sisyfosChannels.ts
@@ -44,7 +44,7 @@ export const sisyfosChannels: { [key in OfftubeSisyfosLLayer]?: SisyfosChannel }
 	[OfftubeSisyfosLLayer.SisyfosSourceDisp1]: {
 		isPgm: 0
 	},
-	[OfftubeSisyfosLLayer.SisyfosSourceDisp1]: {
+	[OfftubeSisyfosLLayer.SisyfosSourceDisp2]: {
 		isPgm: 0
 	}
 }


### PR DESCRIPTION
Labels from QBox 1 is used as reference.

@ianshade Are there anything else I am missing in order to setup these new channels?
And should a migration action be added?