### PR TITLE
Fix(SOF-762): migrations failing

### DIFF
--- a/src/tv2-common/migrations/shortcuts.ts
+++ b/src/tv2-common/migrations/shortcuts.ts
@@ -1,36 +1,6 @@
 import { ISourceLayer, MigrationContextShowStyle, MigrationStepShowStyle } from '@tv2media/blueprints-integration'
 import { literal } from 'tv2-common'
 
-export function SetShortcutListMigrationStep(
-	versionStr: string,
-	sourceLayerId: string,
-	newValue: string
-): MigrationStepShowStyle {
-	return literal<MigrationStepShowStyle>({
-		id: `${versionStr}.remapShortcuts.${sourceLayerId}`,
-		version: versionStr,
-		canBeRunAutomatically: true,
-		validate: (context: MigrationContextShowStyle) => {
-			const sourceLayer = context.getSourceLayer(sourceLayerId)
-
-			if (!sourceLayer) {
-				return `Sourcelayer ${sourceLayerId} does not exists`
-			}
-
-			// @ts-ignore: old property
-			return sourceLayer.activateKeyboardHotkeys !== newValue
-		},
-		migrate: (context: MigrationContextShowStyle) => {
-			const sourceLayer = context.getSourceLayer(sourceLayerId) as ISourceLayer
-
-			// @ts-ignore: old property
-			sourceLayer.activateKeyboardHotkeys = newValue
-
-			context.updateSourceLayer(sourceLayerId, sourceLayer)
-		}
-	})
-}
-
 export function SetSourceLayerNameMigrationStep(
 	versionStr: string,
 	sourceLayerId: string,
@@ -57,36 +27,4 @@ export function SetSourceLayerNameMigrationStep(
 			context.updateSourceLayer(sourceLayerId, sourceLayer)
 		}
 	})
-}
-
-export function SetClearShortcutListTransitionStep(
-	versionStr: string,
-	sourceLayerId: string,
-	newValue: string
-): MigrationStepShowStyle[] {
-	return [
-		literal<MigrationStepShowStyle>({
-			id: `${versionStr}.remapClearShortcuts.${sourceLayerId}`,
-			version: versionStr,
-			canBeRunAutomatically: true,
-			validate: (context: MigrationContextShowStyle) => {
-				const sourceLayer = context.getSourceLayer(sourceLayerId)
-
-				if (!sourceLayer) {
-					return `Sourcelayer ${sourceLayerId} does not exists`
-				}
-
-				// @ts-ignore: old property
-				return sourceLayer.clearKeyboardHotkey !== newValue
-			},
-			migrate: (context: MigrationContextShowStyle) => {
-				const sourceLayer = context.getSourceLayer(sourceLayerId) as ISourceLayer
-
-				// @ts-ignore: old property
-				sourceLayer.clearKeyboardHotkey = newValue
-
-				context.updateSourceLayer(sourceLayerId, sourceLayer)
-			}
-		})
-	]
 }

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -6,7 +6,6 @@ import {
 	literal,
 	RemoveOldShortcuts,
 	removeSourceLayer,
-	SetShortcutListMigrationStep,
 	SetShowstyleTransitionMigrationStep,
 	SetSourceLayerNameMigrationStep,
 	StripFolderFromAudioBedConfig,
@@ -30,10 +29,6 @@ import { getCreateVariantMigrationSteps } from './variants-defaults'
 
 declare const VERSION: string // Injected by webpack
 
-/** Migrations overriden later */
-// 1.3.1
-const jingle131 = SetShortcutListMigrationStep('1.3.1', SourceLayer.PgmJingle, 'NumpadDivide,NumpadSubtract,NumpadAdd')
-
 const SHOW_STYLE_ID = 'tv2_afvd_showstyle'
 
 /**
@@ -51,23 +46,11 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 
 	/**
 	 * 1.3.1
-	 * - Shortcuts for Jingle layer (transition buttons)
 	 * - Set default transition
 	 * - Populate transition table
 	 */
-	jingle131,
 	SetShowstyleTransitionMigrationStep('1.3.1', '/ NBA WIPE'),
 	...UpsertValuesIntoTransitionTable('1.3.1', [{ Transition: 'MIX8' }, { Transition: 'MIX25' }]),
-
-	/**
-	 * 1.3.3
-	 * - Shortcuts for DVE Box 1
-	 */
-	SetShortcutListMigrationStep(
-		'1.3.3',
-		'studio0_dve_box1',
-		'shift+f1,shift+f2,shift+f3,shift+f4,shift+f5,shift+1,shift+2,shift+3,shift+4,shift+5,shift+6,shift+7,shift+8,shift+9,shift+0,shift+e,shift+d,shift+i,shift+u,shift+t'
-	),
 
 	// 1.3.7 - Unhide wall layer
 	forceSourceLayerToDefaults('1.3.7', SourceLayer.WallGraphics),
@@ -94,7 +77,7 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	 * 1.5.2
 	 * - Remove PgmJingle shortcuts, moved to JingleAdlib layer
 	 */
-	forceSourceLayerToDefaults('1.5.2', SourceLayer.PgmJingle, [jingle131.id]),
+	forceSourceLayerToDefaults('1.5.2', SourceLayer.PgmJingle),
 
 	AddGraphicToGFXTable('1.5.4', 'AFVD', {
 		VizTemplate: 'locators',
@@ -149,10 +132,6 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	SetSourceLayerNameMigrationStep('1.6.9', SourceLayer.PgmVoiceOver, 'VO'),
 	SetSourceLayerNameMigrationStep('1.6.9', SourceLayer.PgmPilot, 'GFX FULL (VCP)'),
 	SetSourceLayerNameMigrationStep('1.6.9', SourceLayer.PgmContinuity, 'Continuity'),
-	SetSourceLayerNameMigrationStep('1.6.9', 'studio0_dve_box1', 'DVE Inp 1'),
-	SetSourceLayerNameMigrationStep('1.6.9', 'studio0_dve_box2', 'DVE Inp 2'),
-	SetSourceLayerNameMigrationStep('1.6.9', 'studio0_dve_box3', 'DVE Inp 3'),
-	SetSourceLayerNameMigrationStep('1.6.9', 'studio0_dve_box4', 'DVE Inp 4'),
 	// MUSIK group
 	SetSourceLayerNameMigrationStep('1.6.9', SourceLayer.PgmAudioBed, 'Audiobed (shared)'),
 	// SEC group

--- a/src/tv2_offtube_showstyle/migrations/index.ts
+++ b/src/tv2_offtube_showstyle/migrations/index.ts
@@ -7,7 +7,6 @@ import {
 	RemoveOldShortcuts,
 	removeSourceLayer,
 	renameSourceLayer,
-	SetShortcutListMigrationStep,
 	SetShowstyleTransitionMigrationStep,
 	StripFolderFromAudioBedConfig,
 	StripFolderFromDVEConfig,
@@ -63,14 +62,6 @@ export const remapVizLLayer: Map<string, string> = new Map([
 
 export const remapVizDOvl: Map<string, string> = new Map([['viz-d-ovl', 'OVL1']])
 
-/** Migrations overriden later */
-// 1.3.1
-const jingle131 = SetShortcutListMigrationStep(
-	'1.3.1',
-	OfftubeSourceLayer.PgmJingle,
-	'NumpadDivide,NumpadSubtract,NumpadAdd'
-)
-
 const SHOW_STYLE_ID = 'tv2_offtube_showstyle'
 
 /**
@@ -87,19 +78,11 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 
 	/**
 	 * 1.3.1
-	 * - Shortcuts for Jingle layer (transition buttons)
 	 * - Set default transition
 	 * - Populate transition table
 	 */
-	jingle131,
 	SetShowstyleTransitionMigrationStep('1.3.1', '/ NBA WIPE'),
 	...UpsertValuesIntoTransitionTable('1.3.1', [{ Transition: 'MIX8' }, { Transition: 'MIX25' }]),
-
-	/**
-	 * 1.3.3
-	 * - Shortcuts for DVE Box 1
-	 */
-	SetShortcutListMigrationStep('1.3.3', 'studio0_dve_box1', 'shift+f1,shift+1,shift+2,shift+3,shift+t'),
 
 	/**
 	 * 1.3.8
@@ -112,7 +95,7 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	 * - Create Design layer
 	 */
 	forceSourceLayerToDefaults('1.3.9', OfftubeSourceLayer.PgmDesign),
-	forceSourceLayerToDefaults('1.3.9', OfftubeSourceLayer.PgmJingle, [jingle131.id]),
+	forceSourceLayerToDefaults('1.3.9', OfftubeSourceLayer.PgmJingle),
 
 	/**
 	 * 1.4.6
@@ -189,10 +172,6 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmVoiceOver, 'VO'),
 	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmPilot, 'GFX FULL (VCP)'),
 	SetSourceLayerNameMigrationStep('1.6.9', OfftubeSourceLayer.PgmContinuity, 'Continuity'),
-	SetSourceLayerNameMigrationStep('1.6.9', 'studio0_dve_box1', 'DVE Inp 1'),
-	SetSourceLayerNameMigrationStep('1.6.9', 'studio0_dve_box2', 'DVE Inp 2'),
-	SetSourceLayerNameMigrationStep('1.6.9', 'studio0_dve_box3', 'DVE Inp 3'),
-	SetSourceLayerNameMigrationStep('1.6.9', 'studio0_dve_box4', 'DVE Inp 4'),
 	// MUSIK group
 	SetSourceLayerNameMigrationStep('1.6.9', SharedSourceLayers.PgmAudioBed, 'Audiobed (shared)'),
 	// SEC group

--- a/src/tv2_system/migrations/hotkeys.ts
+++ b/src/tv2_system/migrations/hotkeys.ts
@@ -1,8 +1,8 @@
 import {
 	ClientActions,
 	IBlueprintTriggeredActions,
-	MigrationContextShowStyle,
-	MigrationStepShowStyle,
+	MigrationContextSystem,
+	MigrationStepSystem,
 	PlayoutActions,
 	TriggerType
 } from '@tv2media/blueprints-integration'
@@ -11,22 +11,27 @@ import { literal } from 'tv2-common'
 export function RemoveDefaultCoreShortcuts(versionStr: string) {
 	const defaultTriggerIds = DEFAULT_CORE_TRIGGERS.map(trigger => trigger._id)
 
-	return literal<MigrationStepShowStyle>({
-		id: `${versionStr}.removeCoreDefaultTriggers`,
+	return literal<MigrationStepSystem>({
+		id: `${versionStr}.disableCoreDefaultTriggers`,
 		version: versionStr,
 		canBeRunAutomatically: true,
-		validate: (context: MigrationContextShowStyle) => {
+		validate: (context: MigrationContextSystem) => {
 			for (const coreTrigger of DEFAULT_CORE_TRIGGERS) {
-				if (context.getTriggeredAction(coreTrigger._id)) {
+				const defaultTrigger = context.getTriggeredAction(coreTrigger._id)
+				if (defaultTrigger && defaultTrigger.triggers.length) {
 					return true
 				}
 			}
 
 			return false
 		},
-		migrate: (context: MigrationContextShowStyle) => {
+		migrate: (context: MigrationContextSystem) => {
 			for (const trigger of defaultTriggerIds) {
-				context.removeTriggeredAction(trigger)
+				const defaultTrigger = context.getTriggeredAction(trigger)
+				if (defaultTrigger) {
+					defaultTrigger.triggers = []
+					context.setTriggeredAction(defaultTrigger)
+				}
 			}
 		}
 	})


### PR DESCRIPTION
Disable default system-wide triggers instead of removing them, so that the core and system migrations don't fight with each other.
Remove stale migrations that could cause errors because of referencing non-existent properties and layers.