### PR TITLE
fix: Remove Reload Browser (Ctrl+R) custom hotkey label.

### DIFF
--- a/shelf-layouts/AFVD_Default_showstyle_hotkeys.json
+++ b/shelf-layouts/AFVD_Default_showstyle_hotkeys.json
@@ -642,12 +642,5 @@
         "label": "serv til inp 1",
         "sourceLayerType": 2,
         "platformKey": "shift+t"
-    },
-    {
-        "_id": "6gREn5sKmuyE8dN8h",
-        "key": "ctrl+r",
-        "label": "Reload Browser",
-        "platformKey": "ctrl+r",
-        "buttonColor": "#95a5a6"
     }
 ]


### PR DESCRIPTION
The key combo is now used for EVS adlibbing.