### PR TITLE
fix: Use full or VO tags only for EVS.

### DIFF
--- a/src/tv2-common/hotkeys/helpers/cutToBox.ts
+++ b/src/tv2-common/hotkeys/helpers/cutToBox.ts
@@ -8,7 +8,7 @@ import {
 	TriggerType
 } from '@tv2media/blueprints-integration'
 import { literal, TRIGGER_HOTKEYS_ON_KEYUP } from 'tv2-common'
-import { AdlibTagCutToBox, AdlibTags } from 'tv2-constants'
+import { AdlibTagCutToBox } from 'tv2-constants'
 
 export function MakeCutToBoxTrigger(
 	id: string,
@@ -16,7 +16,7 @@ export function MakeCutToBoxTrigger(
 	name: string,
 	hotkey: string | undefined,
 	sourceLayerId: string,
-	isVO: boolean,
+	tags: string[],
 	pick: number,
 	box: number
 ) {
@@ -53,7 +53,7 @@ export function MakeCutToBoxTrigger(
 					literal<IAdLibFilterLink>({
 						object: 'adLib',
 						field: 'tag',
-						value: [AdlibTagCutToBox(box), isVO ? AdlibTags.ADLIB_VO_AUDIO_LEVEL : AdlibTags.ADLIB_FULL_AUDIO_LEVEL]
+						value: [AdlibTagCutToBox(box), ...tags]
 					}),
 					literal<IAdLibFilterLink>({
 						object: 'adLib',

--- a/src/tv2-common/hotkeys/helpers/queue.ts
+++ b/src/tv2-common/hotkeys/helpers/queue.ts
@@ -16,7 +16,7 @@ export function MakeQueueTrigger(
 	name: string,
 	hotkey: string | undefined,
 	sourceLayerId: string,
-	isVO: boolean,
+	tags: string[],
 	pick: number
 ) {
 	return literal<IBlueprintTriggeredActions>({
@@ -52,10 +52,7 @@ export function MakeQueueTrigger(
 					literal<IAdLibFilterLink>({
 						object: 'adLib',
 						field: 'tag',
-						value: [
-							AdlibTags.ADLIB_QUEUE_NEXT,
-							isVO ? AdlibTags.ADLIB_VO_AUDIO_LEVEL : AdlibTags.ADLIB_FULL_AUDIO_LEVEL
-						]
+						value: [AdlibTags.ADLIB_QUEUE_NEXT, ...tags]
 					}),
 					literal<IAdLibFilterLink>({
 						object: 'adLib',

--- a/src/tv2-common/hotkeys/helpers/studioSource.ts
+++ b/src/tv2-common/hotkeys/helpers/studioSource.ts
@@ -23,7 +23,7 @@ export function MakeStudioSourceHotkeys(
 	getNextRank: () => number,
 	nameFunc: (source: string) => string,
 	idFunc: (showStyleId: string, sourceLayer: string, hotkeyType: string, index: number) => string,
-	isVO: boolean = false
+	tags: string[] = []
 ): IBlueprintTriggeredActions[] {
 	const directCutHotkeys: IBlueprintTriggeredActions[] = []
 	const queueHotkeys: IBlueprintTriggeredActions[] = []
@@ -58,7 +58,7 @@ export function MakeStudioSourceHotkeys(
 					name,
 					queueHotkey,
 					sourceLayerId,
-					isVO,
+					tags,
 					currentSourceIndex
 				)
 			)
@@ -74,7 +74,7 @@ export function MakeStudioSourceHotkeys(
 						name + ` inp ${box + 1}`,
 						boxHotkey,
 						sourceLayerId,
-						isVO,
+						tags,
 						currentSourceIndex,
 						box
 					)

--- a/src/tv2-common/hotkeys/local.ts
+++ b/src/tv2-common/hotkeys/local.ts
@@ -1,4 +1,5 @@
 import { IBlueprintTriggeredActions } from '@tv2media/blueprints-integration'
+import { AdlibTags } from 'tv2-constants'
 import { localSourceFullAudioName, localSourceVoAudioName } from '../helpers'
 import { MakeStudioSourceHotkeys, SourceHotkeyTriggers } from './helpers'
 
@@ -30,7 +31,7 @@ export function MakeLocalSourceHotkeys(
 		getNextRank,
 		localSourceFullAudioName,
 		localSourceFullAudioHotkeyId,
-		false
+		[AdlibTags.ADLIB_FULL_AUDIO_LEVEL]
 	)
 
 	const voAudioKeys = MakeStudioSourceHotkeys(
@@ -41,7 +42,7 @@ export function MakeLocalSourceHotkeys(
 		getNextRank,
 		localSourceVoAudioName,
 		localSourceVoAudioHotkeyId,
-		true
+		[AdlibTags.ADLIB_VO_AUDIO_LEVEL]
 	)
 
 	return [...fullAudioKeys, ...voAudioKeys]

--- a/src/tv2-common/hotkeys/server.ts
+++ b/src/tv2-common/hotkeys/server.ts
@@ -49,7 +49,7 @@ export function MakeServerHotkeys(
 						name + ` inp ${box + 1}`,
 						boxHotkey,
 						sourceLayerId,
-						false,
+						[],
 						currentSourceIndex,
 						box
 					)

--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -687,7 +687,7 @@ function getGlobalAdlibActionsAFVD(_context: IStudioUserContext, config: Bluepri
 						sourceLayerId: SourceLayer.PgmServer,
 						outputLayerId: SharedOutputLayers.SEC,
 						content: {},
-						tags: [AdlibTagCutToBox(box), AdlibTags.ADLIB_FULL_AUDIO_LEVEL]
+						tags: [AdlibTagCutToBox(box)]
 					}
 				})
 			)


### PR DESCRIPTION
live and server was also filtered by either full_audio_level or vo_audio_level, without having the tags.