### PR TITLE
Sof 823/evs 100 percent not working

### DIFF
--- a/src/tv2-common/content/dve.ts
+++ b/src/tv2-common/content/dve.ts
@@ -229,8 +229,6 @@ export function MakeContentDVE2<
 
 		classes.push(`${fromCue.replace(/\s/g, '')}_${dveGeneratorOptions.boxMappings[targetBox - 1]}`)
 
-		let usedServer = false
-
 		if (sources) {
 			const prop = sources[fromCue as keyof DVESources]
 			if (prop?.match(/[K|C]AM(?:era)? ?.*/i)) {
@@ -254,16 +252,14 @@ export function MakeContentDVE2<
 			} else if (prop?.match(/DEFAULT/)) {
 				boxMap[targetBox - 1] = { source: `DEFAULT SOURCE` }
 			} else if (prop) {
-				if (videoId && !usedServer) {
+				if (videoId) {
 					boxMap[targetBox - 1] = { source: `SERVER ${videoId}` }
-					usedServer = true
 				} else {
 					boxMap[targetBox - 1] = { source: prop }
 				}
 			} else {
-				if (videoId && !usedServer) {
+				if (videoId) {
 					boxMap[targetBox - 1] = { source: `SERVER ${videoId}` }
-					usedServer = true
 				} else {
 					context.notifyUserWarning(`Missing mapping for ${targetBox}`)
 					boxMap[targetBox - 1] = { source: '' }
@@ -450,7 +446,7 @@ export function MakeContentDVE2<
 	let frameFile = dveConfig.DVEGraphicsFrame ? dveConfig.DVEGraphicsFrame.toString() : undefined
 
 	if (keyFile) {
-		keyFile = keyFile = JoinAssetToFolder(config.studio.DVEFolder, keyFile)
+		keyFile = JoinAssetToFolder(config.studio.DVEFolder, keyFile)
 	}
 
 	if (frameFile) {

--- a/src/tv2-common/content/dve.ts
+++ b/src/tv2-common/content/dve.ts
@@ -252,11 +252,7 @@ export function MakeContentDVE2<
 			} else if (prop?.match(/DEFAULT/)) {
 				boxMap[targetBox - 1] = { source: `DEFAULT SOURCE` }
 			} else if (prop) {
-				if (videoId) {
-					boxMap[targetBox - 1] = { source: `SERVER ${videoId}` }
-				} else {
-					boxMap[targetBox - 1] = { source: prop }
-				}
+				boxMap[targetBox - 1] = { source: videoId ? `SERVER ${videoId}` : prop }
 			} else {
 				if (videoId) {
 					boxMap[targetBox - 1] = { source: `SERVER ${videoId}` }

--- a/src/tv2-common/sources.ts
+++ b/src/tv2-common/sources.ts
@@ -104,10 +104,7 @@ export function FindSourceInfo(sources: SourceInfo[], type: SourceInfoType, id: 
 				return _.find(sources, s => s.type === type && s.id === `S${remoteName[1]}`)
 			}
 		case SourceLayerType.LOCAL:
-			const dpName = id
-				.replace(/VO/i, '')
-				.replace(/\s/g, '')
-				.match(/^(?:EVS) ?(.+).*$/i)
+			const dpName = id.match(/^(?:EVS)\s*(\d+).*$/i)
 			if (!dpName) {
 				return undefined
 			}


### PR DESCRIPTION
Since the custom hotkey labels were removed from EVS shortcuts, `100%` was removed from labels for keyboard preview.
To re-enable `100%` was added via `localSourceName`.
The logic for converting this into a source id, was not flexible enough to allow for the `100%` so for `EVS 1 100%`, it looked for the source `1100` instead of `1`.