### PR TITLE
fix: Removed F5 from custom hotkey labels.

### DIFF
--- a/shelf-layouts/AFVD_Default_showstyle_hotkeys.json
+++ b/shelf-layouts/AFVD_Default_showstyle_hotkeys.json
@@ -453,12 +453,5 @@
         "label": "serv inp 2",
         "sourceLayerType": 2,
         "platformKey": "ctrl+T"
-    },
-    {
-        "_id": "n8nZWWRcHSkrG7GqM",
-        "key": "SHIFT+ctrl+alt+c",
-        "label": "KAM 5",
-        "sourceLayerType": 1,
-        "platformKey": "F5"
     }
 ]


### PR DESCRIPTION
The generated AutoHotKey script broke F5 cut to cam 5 functionality, since it mapped to an unused key combo.