### PR TITLE
SOF-932: Server adlibs and VO parts should have VO-level audio (develop)

### DIFF
--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -139,8 +139,7 @@ function GetServerTimeline(
 			content: {
 				deviceType: TSR.DeviceType.SISYFOS,
 				type: TSR.TimelineContentTypeSisyfos.CHANNEL,
-				// isPgm: voiceOver ? 2 : 1
-				isPgm: 1
+				isPgm: voLevels ? 2 : 1
 			},
 			metaData: {
 				mediaPlayerSession: mediaPlayerSessionId

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -270,7 +270,7 @@ function getServerSelectionBlueprintPiece<
 			userData: userDataElement,
 			sisyfosPersistMetaData: literal<SisyfosPersistMetaData>({
 				sisyfosLayers: [],
-				acceptPersistAudio: props.adLibPix && props.voLayer
+				acceptPersistAudio: props.adLibPix && props.voLevels
 			})
 		}),
 		content: contentServerElement,

--- a/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
@@ -55,7 +55,7 @@ export function EvaluateAdLib(
 				partDefinition,
 				file,
 				false,
-				false,
+				true,
 				{
 					SourceLayer: {
 						PgmServer: SourceLayer.PgmServer,


### PR DESCRIPTION
Same as https://github.com/tv2/sofie-blueprints-inews/pull/103 but targeting develop where audio persistence was rewritten.