### PR TITLE
fix: SOF-938 don't reset video in an on-air DVE

### DIFF
--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -375,11 +375,7 @@ function executeActionSelectServerClip<
 	const externalId = generateExternalId(context, actionId, [file])
 
 	const currentPiece = settings.SelectedAdlibs
-		? context
-				.getPieceInstances('current')
-				.find(
-					p => p.piece.sourceLayerId === (userData.voLayer ? settings.SourceLayers.VO : settings.SourceLayers.Server)
-				)
+		? context.getPieceInstances('current').find(p => isServerOnPgm(p, settings, userData.voLayer))
 		: undefined
 
 	const basePart = CreatePartServerBase(
@@ -494,6 +490,21 @@ function dveContainsServer(sources: DVESources) {
 		sources.INP2?.match(/SERVER/i) ||
 		sources.INP3?.match(/SERVER/i) ||
 		sources.INP4?.match(/SERVER/i)
+	)
+}
+
+function isServerOnPgm<
+	StudioConfig extends TV2StudioConfigBase,
+	ShowStyleConfig extends TV2BlueprintConfigBase<StudioConfig>
+>(
+	pieceInstance: IBlueprintPieceInstance,
+	settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>,
+	voLayer: boolean
+) {
+	return (
+		pieceInstance.piece.sourceLayerId === (voLayer ? settings.SourceLayers.VO : settings.SourceLayers.Server) ||
+		(pieceInstance.piece.sourceLayerId === settings.SourceLayers.DVEAdLib &&
+			dveContainsServer((pieceInstance.piece.metaData as DVEPieceMetaData).sources))
 	)
 }
 


### PR DESCRIPTION
When selecting another server, the current server-selection piece has to be preserved during DVE AdLibs containing servers, because we need its timeline object.