### PR TITLE
fix: SOF-934 show LYD adlibs in the shelf

### DIFF
--- a/src/tv2-common/cues/lyd.ts
+++ b/src/tv2-common/cues/lyd.ts
@@ -12,6 +12,7 @@ import {
 import { CreateTimingEnable, CueDefinitionLYD, literal, PartDefinition, TimeFromFrames } from 'tv2-common'
 import {
 	AbstractLLayer,
+	AdlibTags,
 	ControlClasses,
 	SharedCasparLLayer,
 	SharedOutputLayers,
@@ -64,7 +65,8 @@ export function EvaluateLYD(
 					: fade
 					? Math.max(1000, fadeIn ? TimeFromFrames(fadeIn) : 0)
 					: CreateTimingEnable(parsedCue).enable.duration ?? undefined,
-				content: LydContent(config, file, lydType, fadeIn, fadeOut)
+				content: LydContent(config, file, lydType, fadeIn, fadeOut),
+				tags: [AdlibTags.ADLIB_FLOW_PRODUCER]
 			})
 		)
 	} else {


### PR DESCRIPTION
Add the Flow Producer tag because we're filtering by it in the "_overlay, graphic, soundbed_" dashboard panel.