### PR TITLE
fix: SOF-936 don't clear PgmGraphicsTLF layer

### DIFF
--- a/src/tv2-common/helpers/graphics/internal/index.ts
+++ b/src/tv2-common/helpers/graphics/internal/index.ts
@@ -58,9 +58,7 @@ export function CreateInternalGraphic(
 
 	const engine = parsedCue.target
 
-	const sourceLayerId = IsTargetingTLF(engine)
-		? SharedSourceLayers.PgmGraphicsTLF
-		: GetSourceLayerForGraphic(config, mappedTemplate, isStickyIdent)
+	const sourceLayerId = GetSourceLayerForGraphic(config, mappedTemplate, isStickyIdent)
 
 	const outputLayerId = IsTargetingWall(engine) ? SharedOutputLayers.SEC : SharedOutputLayers.OVERLAY
 

--- a/src/tv2-common/hotkeys/hotkey-defaults.ts
+++ b/src/tv2-common/hotkeys/hotkey-defaults.ts
@@ -42,8 +42,7 @@ export const defaultHotkeys: TV2Hotkeys = {
 					SharedSourceLayers.PgmGraphicsHeadline,
 					SharedSourceLayers.PgmGraphicsTema,
 					SharedSourceLayers.PgmGraphicsOverlay,
-					SharedSourceLayers.PgmPilotOverlay,
-					SharedSourceLayers.PgmGraphicsTLF
+					SharedSourceLayers.PgmPilotOverlay
 				],
 				key: 'KeyQ',
 				name: 'overlay ALT UD'

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -106,7 +106,7 @@ describe('telefon', () => {
 					start: 0
 				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
-				sourceLayerId: SourceLayer.PgmGraphicsTLF,
+				sourceLayerId: SourceLayer.PgmGraphicsLower,
 				lifespan: PieceLifespan.WithinPart,
 				content: literal<WithTimeline<GraphicsContent>>({
 					fileName: 'bund',

--- a/src/tv2_afvd_showstyle/helpers/pieces/clearGrafiks.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/clearGrafiks.ts
@@ -30,8 +30,7 @@ export function EvaluateClearGrafiks(
 		SourceLayer.PgmGraphicsLower,
 		SourceLayer.PgmGraphicsHeadline,
 		SourceLayer.PgmGraphicsTema,
-		SourceLayer.PgmGraphicsOverlay,
-		SourceLayer.PgmGraphicsTLF
+		SourceLayer.PgmGraphicsOverlay
 	].forEach(sourceLayerId => {
 		pieces.push({
 			externalId: partId,


### PR DESCRIPTION
Clearing this layer using a piece caused a primary piece from a different layer to be cleared as well, due to this layer sharing the _me1_ exclusivity group.
Internal graphics or overlays cannot appear on this layer. It is meant only for fullscreen Pilot graphics for TLF sources, hence the exclusivity group. (rare case, probably never used in Sports)