### PR TITLE
Sof 937/fade audio bed

### DIFF
--- a/src/tv2-common/cues/lyd.ts
+++ b/src/tv2-common/cues/lyd.ts
@@ -72,7 +72,7 @@ export function EvaluateLYD(
 					: fade
 					? Math.max(1000, fadeIn ? TimeFromFrames(fadeIn) : 0)
 					: CreateTimingEnable(parsedCue).enable.duration ?? undefined,
-				content: LydContent(config, file, lydType, fadeIn, fadeOut, fadeTimeInFrames),
+				content: LydContent(config, file, lydType, fadeIn, fadeOut),
 				tags: [AdlibTags.ADLIB_FLOW_PRODUCER]
 			})
 		)
@@ -94,7 +94,7 @@ export function EvaluateLYD(
 				outputLayerId: SharedOutputLayers.MUSIK,
 				sourceLayerId: SharedSourceLayers.PgmAudioBed,
 				lifespan,
-				content: LydContent(config, file, lydType, fadeIn, fadeOut, fadeTimeInFrames)
+				content: LydContent(config, file, lydType, fadeIn, fadeOut)
 			})
 		)
 	}
@@ -105,8 +105,7 @@ function LydContent(
 	file: string,
 	lydType: 'bed' | 'stop' | 'fade',
 	fadeIn?: number,
-	fadeOut?: number,
-	fadeTimeInFrames?: number
+	fadeOut?: number
 ): WithTimeline<BaseContent> {
 	if (lydType === 'stop') {
 		return literal<WithTimeline<BaseContent>>({
@@ -176,8 +175,7 @@ function LydContent(
 				content: {
 					deviceType: TSR.DeviceType.SISYFOS,
 					type: TSR.TimelineContentTypeSisyfos.CHANNEL,
-					isPgm: fadeIn ? 0 : 1,
-					fadeTime: fadeTimeInFrames ? TimeFromFrames(fadeTimeInFrames) : undefined
+					isPgm: 1
 				}
 			})
 		])

--- a/src/tv2-common/cues/lyd.ts
+++ b/src/tv2-common/cues/lyd.ts
@@ -9,7 +9,14 @@ import {
 	TSR,
 	WithTimeline
 } from '@tv2media/blueprints-integration'
-import { CreateTimingEnable, CueDefinitionLYD, literal, PartDefinition, TimeFromFrames } from 'tv2-common'
+import {
+	CreateTimingEnable,
+	CueDefinitionLYD,
+	JoinAssetToFolder,
+	literal,
+	PartDefinition,
+	TimeFromFrames
+} from 'tv2-common'
 import {
 	AbstractLLayer,
 	AdlibTags,
@@ -20,7 +27,6 @@ import {
 	SharedSourceLayers
 } from 'tv2-constants'
 import { TV2BlueprintConfig } from '../blueprintConfig'
-import { JoinAssetToFolder } from '../util'
 
 export function EvaluateLYD(
 	context: IShowStyleUserContext,
@@ -122,7 +128,7 @@ function LydContent(
 		})
 	}
 
-	const filePath = JoinAssetToFolder(config.studio.AudioBedFolder, file)
+	const filePath = lydType === 'fade' ? file : JoinAssetToFolder(config.studio.AudioBedFolder, file)
 
 	return literal<WithTimeline<BaseContent>>({
 		timelineObjects: literal<TimelineObjectCoreExt[]>([


### PR DESCRIPTION
Now blueprints generate LYD fade with the fadetime send to the SisyfosAudioBedLayer.
If there is a fadetime we tell Sisyfos to turn off the channel immediately because Sisyfos won't start fading untill it has been told to turn of the channel.
So if there is a fadetime of 2000ms we tell Sisyfos that isPgm should be 0 and Sisyfos will then start a fade that takes 2000 ms