### PR TITLE
fix: SOF-975 make offtube jingles respect LoadFirstFrame setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv2-sofie-blueprints-inews",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "repository": "https://github.com/olzzon/tv2-sofie-blueprints-inews",
   "license": "MIT",
   "private": true,

--- a/src/tv2-common/content/jingle.ts
+++ b/src/tv2-common/content/jingle.ts
@@ -8,7 +8,7 @@ import { JoinAssetToFolder, JoinAssetToNetworkPath, literal } from '../util'
 export interface JingleLayers {
 	Caspar: {
 		PlayerJingle: string
-		PlayerJingleLookahead?: string
+		PlayerJinglePreload?: string
 	}
 	ATEM: {
 		USKCleanEffekt?: string
@@ -63,35 +63,7 @@ export function CreateJingleContentBase<
 	return literal<WithTimeline<VTContent>>({
 		...CreateJingleExpectedMedia(config, file, alphaAtStart, duration, alphaAtEnd),
 		timelineObjects: literal<TimelineObjectCoreExt[]>([
-			literal<TSR.TimelineObjCCGMedia & TimelineBlueprintExt>({
-				id: '',
-				enable: {
-					start: 0
-				},
-				priority: 1,
-				layer: layers.Caspar.PlayerJingle,
-				content: {
-					deviceType: TSR.DeviceType.CASPARCG,
-					type: TSR.TimelineContentTypeCasparCg.MEDIA,
-					file: fileName
-				}
-			}),
-
-			...(loadFirstFrame && layers.Caspar.PlayerJingleLookahead
-				? [
-						literal<TSR.TimelineObjCCGMedia & TimelineBlueprintExt>({
-							id: '',
-							enable: { start: 0 },
-							priority: 1,
-							layer: layers.Caspar.PlayerJingleLookahead,
-							content: {
-								deviceType: TSR.DeviceType.CASPARCG,
-								type: TSR.TimelineContentTypeCasparCg.MEDIA,
-								file: fileName
-							}
-						})
-				  ]
-				: []),
+			CreateJingleCasparTimelineObject(fileName, loadFirstFrame, layers),
 
 			...EnableDSK(config, 'JINGLE', { start: Number(config.studio.CasparPrerollDuration) }),
 
@@ -198,4 +170,25 @@ export function CreateJingleContentBase<
 			})
 		])
 	})
+}
+
+function CreateJingleCasparTimelineObject(
+	fileName: string,
+	loadFirstFrame: boolean,
+	layers: JingleLayers
+): TSR.TimelineObjCCGMedia & TimelineBlueprintExt {
+	return {
+		id: '',
+		enable: { start: 0 },
+		priority: 1,
+		layer:
+			loadFirstFrame && layers.Caspar.PlayerJinglePreload
+				? layers.Caspar.PlayerJinglePreload
+				: layers.Caspar.PlayerJingle,
+		content: {
+			deviceType: TSR.DeviceType.CASPARCG,
+			type: TSR.TimelineContentTypeCasparCg.MEDIA,
+			file: fileName
+		}
+	}
 }

--- a/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
@@ -133,7 +133,7 @@ export function createJingleContentOfftube(
 	return CreateJingleContentBase(config, file, alphaAtStart, loadFirstFrame, duration, alphaAtEnd, {
 		Caspar: {
 			PlayerJingle: OfftubeCasparLLayer.CasparPlayerJingle,
-			PlayerJingleLookahead: OfftubeCasparLLayer.CasparPlayerJingleLookahead
+			PlayerJinglePreload: OfftubeCasparLLayer.CasparPlayerJinglePreload
 		},
 		ATEM: {
 			USKJinglePreview: OfftubeAtemLLayer.AtemMENextJingle

--- a/src/tv2_offtube_studio/layers.ts
+++ b/src/tv2_offtube_studio/layers.ts
@@ -70,7 +70,8 @@ export const OfftubeAtemLLayer = {
 export type OfftubeAtemLLayer = AtemLLayer | SharedATEMLLayer
 
 enum CasparLLayer {
-	CasparPlayerJingleLookahead = 'casparcg_player_jingle_looakhead',
+	/** Maps to the same Caspar layer as CasparPlayerJingle but its lookahead preloads the first frame */
+	CasparPlayerJinglePreload = 'casparcg_player_jingle_preload',
 	CasparGraphicsFullLoop = 'casparcg_graphics_full_loop',
 	CasparCGDVELoop = 'casparcg_dve_loop',
 	CasparCGDVEKeyedLoop = 'casparcg_dve_keyed_loop',

--- a/src/tv2_offtube_studio/migrations/index.ts
+++ b/src/tv2_offtube_studio/migrations/index.ts
@@ -268,7 +268,7 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	RenameStudioConfig('1.4.6', 'Offtube', 'GraphicBasePath', 'NetworkBasePathGraphic'),
 	RenameStudioConfig('1.4.6', 'Offtube', 'GraphicFlowId', 'GraphicMediaFlowId'),
 
-	GetMappingDefaultMigrationStepForLayer('1.4.8', OfftubeCasparLLayer.CasparPlayerJingleLookahead, true),
+	GetMappingDefaultMigrationStepForLayer('1.4.8', 'casparcg_player_jingle_looakhead', true),
 
 	RenameStudioConfig('1.5.0', 'Offtube', 'NetworkBasePathJingle', 'JingleNetworkBasePath'),
 	RenameStudioConfig('1.5.0', 'Offtube', 'NetworkBasePathClip', 'ClipNetworkBasePath'),
@@ -329,6 +329,15 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	 * - Force soundbed caspar layer to defaults (channel 3, layer 101)
 	 */
 	GetMappingDefaultMigrationStepForLayer('1.6.10', OfftubeCasparLLayer.CasparCGLYD, true),
+
+	/**
+	 * 1.7.3
+	 * - Rename the CasparPlayerJingleLookahead layer
+	 * - Disable previewWhenNotOnAir on CasparPlayerJingle layer
+	 */
+	renameMapping('1.7.3', 'casparcg_player_jingle_looakhead', OfftubeCasparLLayer.CasparPlayerJinglePreload),
+	GetMappingDefaultMigrationStepForLayer('1.7.3', OfftubeCasparLLayer.CasparPlayerJinglePreload, true),
+	GetMappingDefaultMigrationStepForLayer('1.7.3', OfftubeCasparLLayer.CasparPlayerJingle, true),
 
 	// Fill in any mappings that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_offtube_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_offtube_studio/migrations/mappings-defaults.ts
@@ -263,12 +263,12 @@ const MAPPINGS_CASPAR: BlueprintMappings = {
 		lookahead: LookaheadMode.PRELOAD,
 		channel: 3,
 		layer: 110,
-		previewWhenNotOnAir: true
+		previewWhenNotOnAir: false
 	}),
-	[OfftubeCasparLLayer.CasparPlayerJingleLookahead]: literal<TSR.MappingCasparCG & BlueprintMapping>({
+	[OfftubeCasparLLayer.CasparPlayerJinglePreload]: literal<TSR.MappingCasparCG & BlueprintMapping>({
 		device: TSR.DeviceType.CASPARCG,
 		deviceId: 'caspar01',
-		layerName: 'Jingle Lookahead',
+		layerName: 'Jingle (Preloading First Frame)',
 		lookahead: LookaheadMode.PRELOAD,
 		lookaheadMaxSearchDistance: 1,
 		channel: 3,


### PR DESCRIPTION
Fixes the issue causing the first frame of all offtube jingles to be preloaded and shown on PGM regardless of the LoadFirstFrame setting.
Refactors some layer names to be less confusing.