### PR TITLE
fix: SOF-767 set `length` for clips with `seek`

### DIFF
--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -17,6 +17,7 @@ import {
 import { AbstractLLayer, ControlClasses, GetEnableClassForServer } from 'tv2-constants'
 import { TV2BlueprintConfig } from '../blueprintConfig'
 import { TimelineBlueprintExt } from '../onTimelineGenerate'
+import { ServerContentProps, ServerPartProps } from '../parts'
 import { AdlibServerOfftubeOptions } from '../pieces'
 import { JoinAssetToNetworkPath } from '../util'
 
@@ -41,67 +42,49 @@ type VTProps = Pick<
 
 export function GetVTContentProperties(
 	config: TV2BlueprintConfig,
-	file: string,
-	seek?: number,
-	sourceDuration?: number
+	contentProps: Omit<ServerContentProps, 'mediaPlayerSession'>
 ): VTProps {
 	return literal<VTProps>({
-		fileName: file,
+		fileName: contentProps.file,
 		path: JoinAssetToNetworkPath(
 			config.studio.ClipNetworkBasePath,
 			config.studio.ClipFolder,
-			file,
+			contentProps.file,
 			config.studio.ClipFileExtension
 		), // full path on the source network storage
 		mediaFlowIds: [config.studio.ClipMediaFlowId],
-		sourceDuration: sourceDuration && sourceDuration > 0 ? sourceDuration : undefined,
+		sourceDuration:
+			contentProps.sourceDuration && contentProps.sourceDuration > 0 ? contentProps.sourceDuration : undefined,
 		postrollDuration: config.studio.ServerPostrollDuration,
 		ignoreMediaObjectStatus: config.studio.ClipIgnoreStatus,
-		seek
+		seek: contentProps.seek
 	})
 }
 
 export function MakeContentServer(
 	context: IShowStyleUserContext,
-	file: string,
-	mediaPlayerSessionId: string,
 	partDefinition: PartDefinition,
 	config: TV2BlueprintConfig,
 	sourceLayers: MakeContentServerSourceLayers,
-	adLibPix: boolean,
-	voLevels: boolean,
-	seek?: number,
-	sourceDuration?: number
+	props: ServerPartProps,
+	contentProps: ServerContentProps
 ): WithTimeline<VTContent> {
 	return literal<WithTimeline<VTContent>>({
-		...GetVTContentProperties(config, file, seek, sourceDuration),
+		...GetVTContentProperties(config, contentProps),
 		ignoreMediaObjectStatus: true,
-		timelineObjects: GetServerTimeline(
-			context,
-			file,
-			mediaPlayerSessionId,
-			partDefinition,
-			config,
-			sourceLayers,
-			adLibPix,
-			voLevels,
-			seek
-		)
+		timelineObjects: GetServerTimeline(context, partDefinition, config, sourceLayers, props, contentProps)
 	})
 }
 
 function GetServerTimeline(
 	context: IShowStyleUserContext,
-	file: string,
-	mediaPlayerSessionId: string,
 	partDefinition: PartDefinition,
 	config: TV2BlueprintConfig,
 	sourceLayers: MakeContentServerSourceLayers,
-	adLibPix?: boolean,
-	voLevels?: boolean,
-	seek?: number
+	props: ServerPartProps,
+	contentProps: ServerContentProps
 ) {
-	const serverEnableClass = `.${GetEnableClassForServer(mediaPlayerSessionId)}`
+	const serverEnableClass = `.${GetEnableClassForServer(contentProps.mediaPlayerSession)}`
 
 	const mediaObj = literal<TSR.TimelineObjCCGMedia & TimelineBlueprintExt>({
 		id: '',
@@ -113,16 +96,20 @@ function GetServerTimeline(
 		content: {
 			deviceType: TSR.DeviceType.CASPARCG,
 			type: TSR.TimelineContentTypeCasparCg.MEDIA,
-			file,
-			loop: adLibPix,
-			seek,
-			// length: duration,
+			file: contentProps.file,
+			loop: props.adLibPix,
+			seek: contentProps.seek,
+			length: contentProps.clipDuration,
 			playing: true
 		},
 		metaData: {
-			mediaPlayerSession: mediaPlayerSessionId
+			mediaPlayerSession: contentProps.mediaPlayerSession
 		},
-		classes: [...(AddParentClass(config, partDefinition) && !adLibPix ? [ServerParentClass('studio0', file)] : [])]
+		classes: [
+			...(AddParentClass(config, partDefinition) && !props.adLibPix
+				? [ServerParentClass('studio0', contentProps.file)]
+				: [])
+		]
 	})
 
 	const mediaOffObj = JSON.parse(JSON.stringify(mediaObj)) as TSR.TimelineObjCCGMedia & TimelineBlueprintExt
@@ -143,14 +130,14 @@ function GetServerTimeline(
 			content: {
 				deviceType: TSR.DeviceType.SISYFOS,
 				type: TSR.TimelineContentTypeSisyfos.CHANNEL,
-				isPgm: voLevels ? 2 : 1
+				isPgm: props.voLevels ? 2 : 1
 			},
 			metaData: {
-				mediaPlayerSession: mediaPlayerSessionId
+				mediaPlayerSession: contentProps.mediaPlayerSession
 			},
 			classes: []
 		}),
-		...(voLevels
+		...(props.voLevels
 			? [GetSisyfosTimelineObjForCamera(context, config, 'server', sourceLayers.Sisyfos.StudioMicsGroup)]
 			: []),
 		...(sourceLayers.ATEM.ServerLookaheadAux
@@ -170,7 +157,7 @@ function GetServerTimeline(
 							}
 						},
 						metaData: {
-							mediaPlayerSession: mediaPlayerSessionId
+							mediaPlayerSession: contentProps.mediaPlayerSession
 						}
 					})
 			  ]

--- a/src/tv2-common/getSegment.ts
+++ b/src/tv2-common/getSegment.ts
@@ -59,7 +59,7 @@ export interface GetSegmentShowstyleOptions<
 		context: IShowStyleUserContext,
 		config: ShowStyleConfig,
 		partDefinition: PartDefinition,
-		props: ServerPartProps
+		partProps: ServerPartProps
 	) => BlueprintResultPart | Promise<BlueprintResultPart>
 	CreatePartTeknik?: (
 		context: IShowStyleUserContext,

--- a/src/tv2-common/pieces/adlibServer.ts
+++ b/src/tv2-common/pieces/adlibServer.ts
@@ -50,7 +50,10 @@ export function CreateAdlibServer<
 			label: t(`${partDefinition.storyName}`),
 			sourceLayerId: sourceLayers.SourceLayer.PgmServer,
 			outputLayerId: SharedOutputLayers.PGM,
-			content: GetVTContentProperties(config, file, 0, duration),
+			content: GetVTContentProperties(config, {
+				file,
+				sourceDuration: duration
+			}),
 			tags: [
 				tagAsAdlib || voLayer ? AdlibTags.OFFTUBE_ADLIB_SERVER : AdlibTags.OFFTUBE_100pc_SERVER,
 				AdlibTags.ADLIB_KOMMENTATOR,

--- a/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
@@ -43,13 +43,9 @@ export async function EvaluateAdLib(
 			return
 		}
 
-		const sourceDuration = Math.max(
-			((await context.hackGetMediaObjectDuration(file)) || 0) * 1000 - config.studio.ServerPostrollDuration,
-			0
-		)
-
 		actions.push(
-			CreateAdlibServer(
+			await CreateAdlibServer(
+				context,
 				config,
 				rank,
 				partDefinition,
@@ -73,7 +69,6 @@ export async function EvaluateAdLib(
 					},
 					ATEM: {}
 				},
-				sourceDuration,
 				true
 			)
 		)

--- a/src/tv2_afvd_showstyle/parts/server.ts
+++ b/src/tv2_afvd_showstyle/parts/server.ts
@@ -15,12 +15,12 @@ export async function CreatePartServer(
 	context: ISegmentUserContext,
 	config: BlueprintConfig,
 	partDefinition: PartDefinition,
-	props: ServerPartProps
+	partProps: ServerPartProps
 ): Promise<BlueprintResultPart> {
-	const basePartProps = await CreatePartServerBase(context, config, partDefinition, props, {
+	const basePartProps = await CreatePartServerBase(context, config, partDefinition, partProps, {
 		SourceLayer: {
-			PgmServer: props.voLayer ? SourceLayer.PgmVoiceOver : SourceLayer.PgmServer, // TODO this actually is shared
-			SelectedServer: props.voLayer ? SourceLayer.SelectedVoiceOver : SourceLayer.SelectedServer
+			PgmServer: partProps.voLayer ? SourceLayer.PgmVoiceOver : SourceLayer.PgmServer, // TODO this actually is shared
+			SelectedServer: partProps.voLayer ? SourceLayer.SelectedVoiceOver : SourceLayer.SelectedServer
 		},
 		AtemLLayer: {
 			MEPgm: AtemLLayer.AtemMEProgram

--- a/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
@@ -46,13 +46,9 @@ export async function OfftubeEvaluateAdLib(
 			return
 		}
 
-		const sourceDuration = Math.max(
-			((await context.hackGetMediaObjectDuration(file)) || 0) * 1000 - config.studio.ServerPostrollDuration,
-			0
-		)
-
 		actions.push(
-			CreateAdlibServer(
+			await CreateAdlibServer(
+				context,
 				config,
 				rank,
 				partDefinition,
@@ -78,7 +74,6 @@ export async function OfftubeEvaluateAdLib(
 						ServerLookaheadAux: OfftubeAtemLLayer.AtemAuxServerLookahead
 					}
 				},
-				sourceDuration,
 				true
 			)
 		)

--- a/src/tv2_offtube_showstyle/parts/OfftubeServer.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeServer.ts
@@ -15,12 +15,12 @@ export async function OfftubeCreatePartServer(
 	context: ISegmentUserContext,
 	config: OfftubeShowstyleBlueprintConfig,
 	partDefinition: PartDefinition,
-	props: ServerPartProps
+	partProps: ServerPartProps
 ): Promise<BlueprintResultPart> {
-	const basePartProps = await CreatePartServerBase(context, config, partDefinition, props, {
+	const basePartProps = await CreatePartServerBase(context, config, partDefinition, partProps, {
 		SourceLayer: {
-			PgmServer: props.voLayer ? OfftubeSourceLayer.PgmVoiceOver : OfftubeSourceLayer.PgmServer, // TODO this actually is shared
-			SelectedServer: props.voLayer ? OfftubeSourceLayer.SelectedVoiceOver : OfftubeSourceLayer.SelectedServer
+			PgmServer: partProps.voLayer ? OfftubeSourceLayer.PgmVoiceOver : OfftubeSourceLayer.PgmServer, // TODO this actually is shared
+			SelectedServer: partProps.voLayer ? OfftubeSourceLayer.SelectedVoiceOver : OfftubeSourceLayer.SelectedServer
 		},
 		AtemLLayer: {
 			MEPgm: OfftubeAtemLLayer.AtemMEClean,
@@ -52,23 +52,19 @@ export async function OfftubeCreatePartServer(
 
 	part = { ...part, ...CreateEffektForpart(context, config, partDefinition, pieces) }
 
-	const sourceDuration = Math.max(
-		((await context.hackGetMediaObjectDuration(file)) || 0) * 1000 - config.studio.ServerPostrollDuration,
-		0
-	)
-
 	actions.push(
-		CreateAdlibServer(
+		await CreateAdlibServer(
+			context,
 			config,
 			0,
 			partDefinition,
 			file,
-			props.voLayer,
-			props.voLevels,
+			partProps.voLayer,
+			partProps.voLevels,
 			{
 				SourceLayer: {
-					PgmServer: props.voLayer ? OfftubeSourceLayer.PgmVoiceOver : OfftubeSourceLayer.PgmServer, // TODO this actually is shared
-					SelectedServer: props.voLayer ? OfftubeSourceLayer.SelectedVoiceOver : OfftubeSourceLayer.SelectedServer
+					PgmServer: partProps.voLayer ? OfftubeSourceLayer.PgmVoiceOver : OfftubeSourceLayer.PgmServer, // TODO this actually is shared
+					SelectedServer: partProps.voLayer ? OfftubeSourceLayer.SelectedVoiceOver : OfftubeSourceLayer.SelectedServer
 				},
 				Caspar: {
 					ClipPending: OfftubeCasparLLayer.CasparPlayerClipPending
@@ -85,7 +81,6 @@ export async function OfftubeCreatePartServer(
 					ServerLookaheadAux: OfftubeAtemLLayer.AtemAuxServerLookahead
 				}
 			},
-			sourceDuration,
 			false
 		)
 	)


### PR DESCRIPTION
Makes seeking work for resumed clips. (in TSR `seek` requires `length` to be provided)
Also refactors some functions by grouping params.