### PR TITLE
chore: SOF-1006 add Q Flow rundown view layout

### DIFF
--- a/shelf-layouts/Q_Flow_Rundown_View_Layout.json
+++ b/shelf-layouts/Q_Flow_Rundown_View_Layout.json
@@ -1,0 +1,34 @@
+{
+	"_id": "X4GYdLrEcFTXWKkhm",
+	"name": "Q flow",
+	"showStyleBaseId": "show0",
+	"type": "rundown_view_layout",
+	"icon": {
+		"prefix": "fas",
+		"iconName": "columns",
+		"icon": [
+			512,
+			512,
+			[],
+			"f0db",
+			"M464 32H48C21.49 32 0 53.49 0 80v352c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V80c0-26.51-21.49-48-48-48zM224 416H64V160h160v256zm224 0H288V160h160v256z"
+		]
+	},
+	"iconColor": "#14c942",
+	"regionId": "rundown_view_layouts",
+	"shelfLayout": "Ri9ZjAJh3QfeJ7KzG",
+	"miniShelfLayout": "2LcnzqDKS6PaQKhze",
+	"exposeAsSelectableLayout": true,
+	"liveLineProps": {
+		"requiredLayerIds": [
+			"studio0_clip",
+			"studio0_voiceover"
+		]
+	},
+	"hideRundownDivider": true,
+	"showBreaksAsSegments": true,
+	"fixedSegmentDuration": true,
+	"countdownToSegmentRequireLayers": [
+		"studio0_live"
+	]
+}


### PR DESCRIPTION
The `exposeAsSelectableLayout` is only available to Rundown View Layouts, so we need a new Rundown View Layout layout that uses the Q flow Shelf Layout