### PR TITLE
fix: SOF-1022 missing externalId on pieces

### DIFF
--- a/config/tsconfig.strict.json
+++ b/config/tsconfig.strict.json
@@ -7,6 +7,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "strictPropertyInitialization": true
   }
 }

--- a/src/__mocks__/context.ts
+++ b/src/__mocks__/context.ts
@@ -27,6 +27,7 @@ import {
 	OmitId,
 	PackageInfo,
 	PieceLifespan,
+	PlaylistTimingType,
 	Time
 } from '@tv2media/blueprints-integration'
 import { literal } from 'tv2-common'
@@ -121,7 +122,7 @@ export class UserNotesContext extends CommonContext implements IUserNotesContext
 
 // tslint:disable-next-line: max-classes-per-file
 export class StudioContext extends CommonContext implements IStudioContext {
-	public studioId: string
+	public studioId: string = 'studio0'
 	public studioConfig: { [key: string]: ConfigItemValue } = {}
 	public showStyleConfig: { [key: string]: ConfigItemValue } = {}
 
@@ -217,7 +218,7 @@ export class GetRundownContext extends ShowStyleUserContext implements IGetRundo
 
 // tslint:disable-next-line: max-classes-per-file
 export class RundownContext extends ShowStyleContext implements IRundownContext {
-	public readonly rundownId: string
+	public readonly rundownId: string = 'rundown0'
 	public readonly rundown: Readonly<IBlueprintRundownDB>
 
 	constructor(
@@ -230,6 +231,16 @@ export class RundownContext extends ShowStyleContext implements IRundownContext 
 		partId?: string
 	) {
 		super(contextName, mappingsDefaults, parseStudioConfig, parseShowStyleConfig, rundownId, segmentId, partId)
+		this.rundownId = rundownId ?? this.rundownId
+		this.rundown = {
+			_id: this.rundownId,
+			externalId: this.rundownId,
+			name: this.rundownId,
+			timing: {
+				type: PlaylistTimingType.None
+			},
+			showStyleVariantId: 'variant0'
+		}
 	}
 }
 
@@ -300,7 +311,7 @@ export class SyncIngestUpdateToPartInstanceContext extends RundownUserContext
 		mappingsDefaults: BlueprintMappings,
 		parseStudioConfig: (context: ICommonContext, rawConfig: IBlueprintConfig) => any,
 		parseShowStyleConfig: (context: ICommonContext, config: IBlueprintConfig) => any,
-		rundownId?: string,
+		rundownId: string,
 		segmentId?: string,
 		partId?: string
 	) {
@@ -397,9 +408,6 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 
 	public takeAfterExecute: boolean = false
 
-	/** Get the mappings for the studio */
-	public getStudioMappings: () => Readonly<BlueprintMappings>
-
 	constructor(
 		contextName: string,
 		mappingsDefaults: BlueprintMappings,
@@ -419,6 +427,11 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		this.currentPieceInstances = currentPieceInstances
 		this.nextPart = nextPart
 		this.nextPieceInstances = nextPieceInstances
+	}
+
+	/** Get the mappings for the studio */
+	public getStudioMappings = () => {
+		throw new Error(`Function not implemented in mock: 'getStudioMappings'`)
 	}
 
 	/** Get a PartInstance which can be modified */

--- a/src/tv2-common/actions/context.ts
+++ b/src/tv2-common/actions/context.ts
@@ -20,7 +20,7 @@ export interface ITV2ActionExecutionContext extends IActionExecutionContext {
 
 class TV2ActionExecutionContext implements ITV2ActionExecutionContext {
 	public studioId: string
-	public isTV2Context: true
+	public isTV2Context: true = true
 
 	private coreContext: IActionExecutionContext
 

--- a/src/tv2-common/helpers/graphics/pilot/index.ts
+++ b/src/tv2-common/helpers/graphics/pilot/index.ts
@@ -105,6 +105,7 @@ export class PilotGraphicGenerator {
 		this.context = graphicProps.context
 		this.engine = graphicProps.engine
 		this.parsedCue = graphicProps.parsedCue
+		this.partId = graphicProps.partId
 		this.settings = graphicProps.settings
 		this.adlib = graphicProps.adlib
 		this.segmentExternalId = graphicProps.segmentExternalId

--- a/src/tv2-common/migrations/__tests__/migrationContext.mock.ts
+++ b/src/tv2-common/migrations/__tests__/migrationContext.mock.ts
@@ -10,9 +10,8 @@ import {
 } from '@tv2media/blueprints-integration'
 
 export class MockShowstyleMigrationContext implements MigrationContextShowStyle {
-	public variants: IBlueprintShowStyleVariant[]
+	public variants: IBlueprintShowStyleVariant[] = []
 	public configs: Map<string, ConfigItemValue> = new Map()
-	public getTriggeredActionId: (triggeredActionId: string) => string
 
 	public getAllVariants(): IBlueprintShowStyleVariant[] {
 		return this.variants
@@ -96,5 +95,8 @@ export class MockShowstyleMigrationContext implements MigrationContextShowStyle 
 	}
 	public removeTriggeredAction(triggeredActionsId: string): void {
 		throw new Error(`Function not implemented in mock: 'removeTriggeredAction' args: ${triggeredActionsId}`)
+	}
+	public getTriggeredActionId(triggeredActionId: string): string {
+		throw new Error(`Function not implemented in mock: 'getTriggeredActionId' args: ${triggeredActionId}`)
 	}
 }


### PR DESCRIPTION
Fixes missing missing `externalId` on pieces that led to failing to ingest the rundown/segment.
Enables `strictPropertyInitialization` compiler option to avoid such bugs in the future