### PR TITLE
fix: SOF-1057 Creates cut-to-dve-box addlibs for EVS X 100 again

### DIFF
--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -709,11 +709,12 @@ function getGlobalAdlibActionsAFVD(_context: IStudioUserContext, config: Bluepri
 			makeAdlibBoxesActions(o, globalRank++)
 		})
 
-	config.sources.replays
-		.slice(0, 10) // the first x remote to create INP1/2/3 live-adlibs from
-		.forEach(o => {
-			makeAdlibBoxesActionsReplay(o, globalRank++, true)
-		})
+	config.sources.replays.forEach(o => {
+		if (!/EPSIO/i.test(o.id)) {
+			makeAdlibBoxesActionsReplay(o, globalRank++, false)
+		}
+		makeAdlibBoxesActionsReplay(o, globalRank++, true)
+	})
 
 	makeServerAdlibBoxesActions(globalRank++)
 


### PR DESCRIPTION
Reintroducing the call that makes the 'EVS X 100' cut-to-dve-box adlib.
It looks like it was lost in a merge.