### PR TITLE
fix: SOF-1079 set postrollDuration on jingles to offset the freeze indicator

### DIFF
--- a/src/tv2-common/content/jingle.ts
+++ b/src/tv2-common/content/jingle.ts
@@ -42,6 +42,7 @@ export function CreateJingleExpectedMedia(
 		ignoreBlackFrames: true,
 		ignoreFreezeFrame: true,
 		sourceDuration: TimeFromFrames(Number(duration) - Number(alphaAtEnd)),
+		postrollDuration: TimeFromFrames(Number(alphaAtEnd)),
 		timelineObjects: []
 	})
 }


### PR DESCRIPTION
The end-alpha still needs to be subtracted from the `sourceDuration` so that the `PieceCountdownPanel` counts down to the start of the transition. The freeze indicator, on the other hand, takes `sourceDuration + postrollDuration` into consideration so we can put the end-alpha there.