### PR TITLE
fix: Updated black box in header to correct position and size.

### DIFF
--- a/shelf-layouts/Rundown_Header_Layout.json
+++ b/shelf-layouts/Rundown_Header_Layout.json
@@ -192,7 +192,7 @@
 			"iconColor": "#000000",
 			"x": 37,
 			"width": 27,
-			"height": 1.1,
+			"height": 2,
 			"y": 0,
 			"xUnit": "%",
 			"widthUnit": "%"
@@ -215,7 +215,7 @@
 				""
 			],
 			"timingType": "count_down",
-			"y": -1.25,
+			"y": -1.35,
 			"x": 37.5,
 			"hideLabel": true,
 			"requiredLayerIds": [


### PR DESCRIPTION
Fixed position of part countdown label and height of black box in header of rundown view.