### PR TITLE
fix: SOF-769 make `direkte` idents behave like other idents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv2-sofie-blueprints-inews",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "repository": "https://github.com/olzzon/tv2-sofie-blueprints-inews",
   "license": "MIT",
   "private": true,

--- a/src/inews-mixins/playlist.ts
+++ b/src/inews-mixins/playlist.ts
@@ -93,13 +93,13 @@ function getRundownPlaylistInfoINewsPlaylist(
 	resultPlaylist: BlueprintResultRundownPlaylist
 ): BlueprintResultRundownPlaylist {
 	const result: BlueprintResultOrderedRundowns = {}
-	return literal<BlueprintResultRundownPlaylist>({
+	return {
 		...resultPlaylist,
 		order: rundowns.reduce((prev, curr) => {
 			prev[curr.externalId] = (curr.metaData as RundownMetaData).rank
 			return prev
 		}, result)
-	})
+	}
 }
 
 type GetRundownMixin = (
@@ -152,15 +152,15 @@ export function GetRundownPlaylistInfoWithMixins(
 				expectedStart: lastRundownTiming.expectedStart
 			}
 		}
-		let result =
-			(getRundownPlaylistInfo ? getRundownPlaylistInfo(context, rundowns, '') : undefined) ??
-			literal<BlueprintResultRundownPlaylist>({
-				playlist: literal<IBlueprintResultRundownPlaylist>({
-					name: (rundowns[0] ?? { name: '' }).name,
-					timing
-				}),
-				order: null
-			})
+		let result: BlueprintResultRundownPlaylist = (getRundownPlaylistInfo
+			? getRundownPlaylistInfo(context, rundowns, '')
+			: undefined) ?? {
+			playlist: literal<IBlueprintResultRundownPlaylist>({
+				name: (rundowns[0] ?? { name: '' }).name,
+				timing
+			}),
+			order: null
+		}
 
 		for (const mixin of mixins) {
 			result = mixin(context, rundowns, result)

--- a/src/tv2-common/__tests__/onTimelineGenerate.spec.ts
+++ b/src/tv2-common/__tests__/onTimelineGenerate.spec.ts
@@ -5,7 +5,6 @@ import {
 	PieceMetaData,
 	SisyfosPersistMetaData
 } from '../onTimelineGenerate'
-import { literal } from '../util'
 
 const LAYER_THAT_WANTS_TO_BE_PERSISTED = 'layerThatWantsToBePersisted'
 const LAYERS_THAT_WANTS_TO_BE_PERSISTED_ARRAY: SisyfosPersistMetaData['sisyfosLayers'] = [
@@ -16,7 +15,7 @@ const LAYERS_THAT_WANTS_TO_BE_PERSISTED_ARRAY: SisyfosPersistMetaData['sisyfosLa
 describe('onTimelineGenerate', () => {
 	describe('createSisyfosPersistedLevelsTimelineObject', () => {
 		it('has one layer to persist, piece accept persist - timelineObject with layer is added', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('currentPiece', 10, undefined, true, true)
 			]
 
@@ -29,7 +28,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('has layer to persist, timelineObject with correct Sisyfos information is added', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('currentPiece', 10, undefined, true, true)
 			]
 
@@ -42,7 +41,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('should persist non-VO layers with isPgm 1', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('currentPiece', 10, undefined, true, true)
 			]
 
@@ -51,7 +50,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('should persist only current piece layer when piece wants to persist but dont accept', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('previousPiece', 0, 10, true, true),
 				createPieceInstance('currentPiece', 10, undefined, true, false)
 			]
@@ -62,7 +61,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('should not persist anything when current piece dont accept and dont want to persist', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('previousPiece', 0, 10, true, true),
 				createPieceInstance('currentPiece', 10, undefined, false, false)
 			]
@@ -73,7 +72,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('should persist when previous piece does not accept persist, but current does accept', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('previousPiece', 0, 10, true, false),
 				createPieceInstance('currentPiece', 10, undefined, false, true)
 			]
@@ -84,7 +83,9 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('should persist when current piece accepts persist and duration is not undefined', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [createPieceInstance('currentPiece', 0, 5, false, true)]
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
+				createPieceInstance('currentPiece', 0, 5, false, true)
+			]
 
 			const result = createSisyfosPersistedLevelsTimelineObject(resolvedPieces, LAYERS_THAT_WANTS_TO_BE_PERSISTED_ARRAY)
 
@@ -100,7 +101,9 @@ describe('onTimelineGenerate', () => {
 				secondLayerThatWantToBePersisted,
 				thirdLayerThatWantToBePersisted
 			]
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [createPieceInstance('currentPiece', 0, 5, true, true)]
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
+				createPieceInstance('currentPiece', 0, 5, true, true)
+			]
 
 			const result = createSisyfosPersistedLevelsTimelineObject(resolvedPieces, layersThatWantToBePersisted)
 
@@ -116,7 +119,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts to executeAction that dont accept persist, dont persist layers', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('previousPieceNotExecuteAction', 0, 10, true, true),
 				createExecuteActionPieceInstance('currentPieceIsExecuteAction', 10, undefined, false, false)
 			]
@@ -127,7 +130,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts to executeAction that accept persist from piece that accept, add persist timelineObject containing all layers that want to be persisted plus previous piece layers', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('previousPieceNotExecuteAction', 0, 10, true, true),
 				createExecuteActionPieceInstance('currentPieceIsExecuteAction', 10, undefined, false, true)
 			]
@@ -141,7 +144,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts to executionAction that accept from piece that dont accept, add persist timelineObject that only contain previous piece layers', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('previousPieceNotExecuteAction', 0, 10, true, false),
 				createExecuteActionPieceInstance('currentPieceIsExecuteAction', 10, undefined, false, true)
 			]
@@ -153,7 +156,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts to executeAction that accept persist from piece that dont want to persist and dont accept persist, dont persist any layers', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('previousPieceNotExecuteAction', 0, 10, false, false),
 				createExecuteActionPieceInstance('currentPieceIsExecuteAction', 10, undefined, false, true)
 			]
@@ -164,7 +167,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts to executeAction that accept persist from piece that dont want to persist and that accept persist, persist previous layers', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('previousPieceNotExecuteAction', 0, 10, false, true),
 				createExecuteActionPieceInstance('currentPieceIsExecuteAction', 10, undefined, false, true)
 			]
@@ -178,7 +181,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts from executeAction that dont accept to piece that accepts, dont persist', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createExecuteActionPieceInstance('previousPieceIsExecuteAction', 0, 10, false, false),
 				createPieceInstance('currentPieceNotExecuteAction', 10, undefined, false, true)
 			]
@@ -189,7 +192,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts from executeAction that dont accept to piece that dont accepts, dont persist layers', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createExecuteActionPieceInstance('previousPieceIsExecuteAction', 0, 10, false, false),
 				createPieceInstance('currentPieceNotExecuteAction', 10, undefined, false, false)
 			]
@@ -200,7 +203,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts from executeAction that accept to piece that dont accepts, dont persist layers', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createExecuteActionPieceInstance('previousPieceIsExecuteAction', 0, 10, false, true),
 				createPieceInstance('currentPieceNotExecuteAction', 10, undefined, false, false)
 			]
@@ -211,7 +214,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts from executeAction that accept to piece that accepts, add persist timelineObject with previous layer before executeAction + new layer', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('firstPiece', 0, 5, true, true),
 				createExecuteActionPieceInstance('previousPieceIsExecuteAction', 5, 5, false, true, {
 					acceptPersistAudio: true,
@@ -226,7 +229,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts from piece that wants to persist to executeAction that do not accept to piece that accepts, do not persist', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('firstPiece', 0, 5, true, true),
 				createExecuteActionPieceInstance('previousPieceIsExecuteAction', 5, 5, false, true, {
 					acceptPersistAudio: false,
@@ -241,7 +244,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts from piece that wants to persist to executeAction that accepts to another executeAction that accepts, persist layer from first piece', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('firstPiece', 0, 5, true, true),
 				createExecuteActionPieceInstance('executeAction', 5, undefined, false, true, {
 					acceptPersistAudio: true,
@@ -260,7 +263,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('cuts from piece that wants to persist to executeAction that do not accept to another executeAction that accepts, dont persist any layers', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('firstPiece', 0, 5, true, true),
 				createExecuteActionPieceInstance('executeAction', 5, undefined, false, true, {
 					acceptPersistAudio: true,
@@ -278,7 +281,7 @@ describe('onTimelineGenerate', () => {
 		})
 
 		it('should not contain any duplicate layers to persist', () => {
-			const resolvedPieces: IBlueprintResolvedPieceInstance[] = [
+			const resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>> = [
 				createPieceInstance('piece', 0, 5, true, true),
 				createPieceInstance('piece', 5, undefined, true, true)
 			]
@@ -296,21 +299,21 @@ function createPieceInstance(
 	duration: number | undefined,
 	wantToPersistAudio: boolean,
 	acceptPersistAudio: boolean
-): IBlueprintResolvedPieceInstance {
+): IBlueprintResolvedPieceInstance<PieceMetaData> {
 	return {
 		resolvedStart: start,
 		resolvedDuration: duration,
 		piece: {
 			name,
-			metaData: literal<PieceMetaData>({
+			metaData: {
 				sisyfosPersistMetaData: {
 					sisyfosLayers: [name],
 					wantsToPersistAudio: wantToPersistAudio,
 					acceptPersistAudio
 				}
-			})
-		} as IBlueprintPieceDB
-	} as IBlueprintResolvedPieceInstance
+			}
+		} as IBlueprintPieceDB<PieceMetaData>
+	} as IBlueprintResolvedPieceInstance<PieceMetaData>
 }
 
 function createExecuteActionPieceInstance(
@@ -320,7 +323,7 @@ function createExecuteActionPieceInstance(
 	wantToPersistAudio: boolean,
 	acceptPersistAudio: boolean,
 	previousMetaData?: SisyfosPersistMetaData
-): IBlueprintResolvedPieceInstance {
+): IBlueprintResolvedPieceInstance<PieceMetaData> {
 	return {
 		resolvedStart: start,
 		resolvedDuration: duration,
@@ -332,8 +335,8 @@ function createExecuteActionPieceInstance(
 					wantsToPersistAudio: wantToPersistAudio,
 					acceptPersistAudio,
 					previousPersistMetaDataForCurrentPiece: previousMetaData
-				} as SisyfosPersistMetaData
+				}
 			}
-		} as IBlueprintPieceDB
-	} as IBlueprintResolvedPieceInstance
+		} as IBlueprintPieceDB<PieceMetaData>
+	} as IBlueprintResolvedPieceInstance<PieceMetaData>
 }

--- a/src/tv2-common/actions/actionTypes.ts
+++ b/src/tv2-common/actions/actionTypes.ts
@@ -2,8 +2,6 @@ import { AdlibActionType } from 'tv2-constants'
 import { DVEConfigInput } from '../helpers'
 import {
 	CueDefinitionDVE,
-	CueDefinitionGraphic,
-	GraphicInternal,
 	PartDefinition,
 	SourceDefinition,
 	SourceDefinitionKam,
@@ -137,11 +135,6 @@ export interface ActionFadeDownPersistedAudioLevels extends ActionBase {
 	type: AdlibActionType.FADE_DOWN_PERSISTED_AUDIO_LEVELS
 }
 
-export interface ActionPlayGraphics extends ActionBase {
-	type: AdlibActionType.PLAY_GRAPHICS
-	graphic: CueDefinitionGraphic<GraphicInternal>
-}
-
 export type TV2AdlibAction =
 	| ActionSelectServerClip
 	| ActionSelectDVE
@@ -159,4 +152,3 @@ export type TV2AdlibAction =
 	| ActionRecallLastLive
 	| ActionRecallLastDVE
 	| ActionFadeDownPersistedAudioLevels
-	| ActionPlayGraphics

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -10,7 +10,6 @@ import {
 	IBlueprintPieceDB,
 	IBlueprintPieceGeneric,
 	IBlueprintPieceInstance,
-	IBlueprintResolvedPieceInstance,
 	IShowStyleUserContext,
 	PieceLifespan,
 	SplitsContent,
@@ -371,7 +370,7 @@ async function getExistingTransition<
 	return
 }
 
-function sanitizePieceId(piece: IBlueprintPieceDB): IBlueprintPiece {
+function sanitizePieceId(piece: IBlueprintPieceDB<PieceMetaData>): IBlueprintPiece<PieceMetaData> {
 	return _.omit(piece, ['_id', 'partId', 'infiniteId', 'playoutDuration'])
 }
 
@@ -379,7 +378,7 @@ export async function getPiecesToPreserve(
 	context: ITV2ActionExecutionContext,
 	adlibLayers: string[],
 	ignoreLayers: string[]
-): Promise<IBlueprintPiece[]> {
+): Promise<Array<IBlueprintPiece<PieceMetaData>>> {
 	const currentPartSegmentId = await context.getPartInstance('current').then(partInstance => partInstance?.segmentId)
 	const nextPartSegmentId = await context.getPartInstance('next').then(partInstance => partInstance?.segmentId)
 
@@ -395,9 +394,9 @@ export async function getPiecesToPreserve(
 		return pieceInstances
 			.filter(p => adlibLayers.includes(p.piece.sourceLayerId) && !ignoreLayers.includes(p.piece.sourceLayerId))
 			.filter(p => !p.infinite?.fromPreviousPart && !p.infinite?.fromPreviousPlayhead)
-			.map<IBlueprintPiece>(p => p.piece)
+			.map<IBlueprintPiece<PieceMetaData>>(p => p.piece)
 			.map(p => sanitizePieceStart(p))
-			.map(p => sanitizePieceId(p as IBlueprintPieceDB))
+			.map(p => sanitizePieceId(p as IBlueprintPieceDB<PieceMetaData>))
 	})
 }
 
@@ -479,8 +478,8 @@ async function executeActionSelectServerClip<
 
 	let part = basePart.part.part
 
-	const grafikPieces: IBlueprintPiece[] = []
-	const effektPieces: IBlueprintPiece[] = []
+	const grafikPieces: Array<IBlueprintPiece<PieceMetaData>> = []
+	const effektPieces: Array<IBlueprintPiece<PieceMetaData>> = []
 
 	part = {
 		...part,
@@ -517,8 +516,8 @@ async function executeActionSelectServerClip<
 	}
 
 	await context.queuePart(part, [
-		activeServerPiece,
-		serverDataStore,
+		activeServerPiece as IBlueprintPiece<PieceMetaData>, // @todo: get rid of these casts
+		serverDataStore as IBlueprintPiece<PieceMetaData>,
 		...grafikPieces,
 		...(settings.SelectedAdlibs
 			? await getPiecesToPreserve(context, settings.SelectedAdlibs.SELECTED_ADLIB_LAYERS, [
@@ -602,7 +601,7 @@ async function executeActionSelectDVE<
 	start = start ? start : 0
 	const end = parsedCue.end ? CalculateTime(parsedCue.end) : undefined
 
-	const metaData = literal<PieceMetaData & DVEPieceMetaData>({
+	const metaData: DVEPieceMetaData = {
 		mediaPlayerSessions: dveContainsServer(parsedCue.sources) ? [externalId] : [],
 		sources: parsedCue.sources,
 		config: rawTemplate,
@@ -610,9 +609,9 @@ async function executeActionSelectDVE<
 			sisyfosLayers: []
 		},
 		userData
-	})
+	}
 
-	let dvePiece = literal<IBlueprintPiece>({
+	let dvePiece: IBlueprintPiece<DVEPieceMetaData> = {
 		externalId,
 		name: `${parsedCue.template}`,
 		enable: {
@@ -633,7 +632,7 @@ async function executeActionSelectDVE<
 			GetTagForDVENext(userData.segmentExternalId, parsedCue.template, parsedCue.sources),
 			TallyTags.DVE_IS_LIVE
 		]
-	})
+	}
 
 	dvePiece = await cutServerToBox(context, settings, dvePiece)
 
@@ -659,17 +658,17 @@ async function cutServerToBox<
 >(
 	context: ITV2ActionExecutionContext,
 	settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>,
-	newDvePiece: IBlueprintPiece,
+	newDvePiece: IBlueprintPiece<DVEPieceMetaData>,
 	containedServerBefore?: boolean,
 	modifiesCurrent?: boolean
-): Promise<IBlueprintPiece> {
+): Promise<IBlueprintPiece<DVEPieceMetaData>> {
 	// Check if DVE should continue server + copy server properties
 
 	if (!newDvePiece.metaData) {
 		return newDvePiece
 	}
 
-	const meta = newDvePiece.metaData as DVEPieceMetaData
+	const meta = newDvePiece.metaData
 
 	const containsServer = dveContainsServer(meta.sources)
 
@@ -731,7 +730,7 @@ async function cutServerToBox<
 
 		newDvePiece.content.timelineObjects[ssrcObjIndex] = ssrcObj
 		newDvePiece.content.timelineObjects.push(EnableServer(existingCasparObj.metaData.mediaPlayerSession))
-		;(newDvePiece.metaData as any).mediaPlayerSessions = [existingCasparObj.metaData.mediaPlayerSession]
+		newDvePiece.metaData.mediaPlayerSessions = [existingCasparObj.metaData.mediaPlayerSession]
 
 		if (!containedServerBefore) {
 			startServerMetaData(context, meta, modifiesCurrent)
@@ -785,11 +784,13 @@ async function executeActionSelectDVELayout<
 
 	const nextPart = await context.getPartInstance('next')
 
-	const nextDVE = await context
+	const nextDVE = (await context
 		.getPieceInstances('next')
-		.then(nextPieceInstances => nextPieceInstances.find(p => p.piece.sourceLayerId === settings.SourceLayers.DVE))
+		.then(nextPieceInstances => nextPieceInstances.find(p => p.piece.sourceLayerId === settings.SourceLayers.DVE))) as
+		| IBlueprintPieceInstance<DVEPieceMetaData>
+		| undefined
 
-	const meta = nextDVE?.piece.metaData as DVEPieceMetaData
+	const meta = nextDVE?.piece.metaData
 
 	if (!nextPart || !nextDVE || !meta || nextPart.segmentId !== (await context.getPartInstance('current'))?.segmentId) {
 		const content = MakeContentDVE2(context, config, userData.config, {}, sources, settings.DVEGeneratorOptions)
@@ -798,27 +799,27 @@ async function executeActionSelectDVELayout<
 			return
 		}
 
-		const newMetaData = literal<DVEPieceMetaData & PieceMetaData>({
+		const newMetaData: DVEPieceMetaData = {
 			sources,
 			config: userData.config,
 			sisyfosPersistMetaData: {
 				sisyfosLayers: []
 			},
-			userData: literal<ActionSelectDVE>({
+			userData: {
 				type: AdlibActionType.SELECT_DVE,
-				config: literal<CueDefinitionDVE>({
+				config: {
 					type: CueType.DVE,
 					template: userData.config.DVEName,
 					sources,
 					labels: [],
 					iNewsCommand: `DVE=${userData.config.DVEName}`
-				}),
+				},
 				videoId: undefined,
 				segmentExternalId: ''
-			})
-		})
+			}
+		}
 
-		let newDVEPiece = literal<IBlueprintPiece>({
+		let newDVEPiece: IBlueprintPiece<DVEPieceMetaData> = {
 			externalId,
 			enable: {
 				start: 0
@@ -829,7 +830,7 @@ async function executeActionSelectDVELayout<
 			outputLayerId: SharedOutputLayers.PGM,
 			metaData: newMetaData,
 			content: content.content
-		})
+		}
 
 		newDVEPiece = await cutServerToBox(context, settings, newDVEPiece)
 
@@ -849,16 +850,16 @@ async function executeActionSelectDVELayout<
 		)
 	}
 
-	const newMetaData2 = literal<PieceMetaData & DVEPieceMetaData>({
+	const newMetaData2: DVEPieceMetaData = {
 		...meta,
 		config: userData.config,
 		sisyfosPersistMetaData: {
 			sisyfosLayers: []
 		}
-	})
+	}
 
 	const pieceContent = MakeContentDVE2(context, config, userData.config, {}, meta.sources, settings.DVEGeneratorOptions)
-	let dvePiece: IBlueprintPiece = {
+	let dvePiece: IBlueprintPiece<DVEPieceMetaData> = {
 		...nextDVE.piece,
 		content: pieceContent.content,
 		metaData: newMetaData2,
@@ -896,9 +897,9 @@ async function startNewDVELayout<
 	context: ITV2ActionExecutionContext,
 	config: ShowStyleConfig,
 	settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>,
-	dvePiece: IBlueprintPiece,
+	dvePiece: IBlueprintPiece<PieceMetaData>,
 	pieceContent: WithTimeline<SplitsContent>,
-	meta: PieceMetaData & DVEPieceMetaData,
+	metaData: DVEPieceMetaData,
 	templateName: string,
 	_sources: CueDefinitionDVE['sources'],
 	externalId: string,
@@ -908,8 +909,8 @@ async function startNewDVELayout<
 ) {
 	settings.postProcessPieceTimelineObjects(context, config, dvePiece, false)
 
-	const dveDataStore = settings.SelectedAdlibs.SourceLayer.DVE
-		? literal<IBlueprintPiece>({
+	const dveDataStore: IBlueprintPiece<PieceMetaData> | undefined = settings.SelectedAdlibs.SourceLayer.DVE
+		? {
 				externalId,
 				name: templateName,
 				enable: {
@@ -918,7 +919,7 @@ async function startNewDVELayout<
 				outputLayerId: settings.SelectedAdlibs.OutputLayer.SelectedAdLib,
 				sourceLayerId: settings.SelectedAdlibs.SourceLayer.DVE,
 				lifespan: PieceLifespan.OutOnSegmentEnd,
-				metaData: meta,
+				metaData,
 				tags: [nextTag],
 				content: {
 					...pieceContent,
@@ -933,16 +934,16 @@ async function startNewDVELayout<
 						)
 						.map(obj => ({ ...obj, priority: obj.priority ?? 1 / 2 }))
 				}
-		  })
+		  }
 		: undefined
 
 	if (replacePieceInstancesOrQueue === 'queue') {
-		const newPart = literal<IBlueprintPart>({
+		const newPart: IBlueprintPart = {
 			externalId,
 			title: templateName,
 			metaData: {},
 			expectedDuration: 0
-		})
+		}
 
 		const currentPieceInstances = await context.getPieceInstances('current')
 		// If a DVE is not on air, but a layout is selected, stop the selected layout and replace with the new one.
@@ -950,7 +951,7 @@ async function startNewDVELayout<
 
 		const dataPiece =
 			settings.SelectedAdlibs &&
-			currentPieceInstances.find(p => p.piece.sourceLayerId === settings.SelectedAdlibs!.SourceLayer.DVE)
+			currentPieceInstances.find(p => p.piece.sourceLayerId === settings.SelectedAdlibs.SourceLayer.DVE)
 
 		if (onAirPiece === undefined && dataPiece !== undefined) {
 			await context.stopPieceInstances([dataPiece._id])
@@ -1026,7 +1027,7 @@ async function executeActionSelectJingle<
 		jingle.EndAlpha
 	)
 
-	const piece = literal<IBlueprintPiece>({
+	const piece: IBlueprintPiece<PieceMetaData> = {
 		externalId: `${externalId}-JINGLE`,
 		name: userData.clip,
 		enable: {
@@ -1043,41 +1044,19 @@ async function executeActionSelectJingle<
 			TallyTags.JINGLE_IS_LIVE,
 			TallyTags.JINGLE
 		]
-	})
-
-	const jingleDataStore = settings.SelectedAdlibs.SourceLayer.Effekt
-		? literal<IBlueprintPiece>({
-				externalId,
-				name: userData.clip,
-				enable: {
-					start: 0
-				},
-				outputLayerId: settings.SelectedAdlibs.OutputLayer.SelectedAdLib,
-				sourceLayerId: settings.SelectedAdlibs.SourceLayer.Effekt,
-				lifespan: PieceLifespan.WithinPart,
-				metaData: {
-					userData
-				},
-				content: {
-					...pieceContent,
-					timelineObjects: []
-				},
-				tags: [GetTagForJingleNext(userData.segmentExternalId, userData.clip)]
-		  })
-		: undefined
+	}
 
 	settings.postProcessPieceTimelineObjects(context, config, piece, false)
 
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId,
 		title: `JINGLE ${userData.clip}`,
 		metaData: {},
 		...props
-	})
+	}
 
 	await context.queuePart(part, [
 		piece,
-		...(jingleDataStore ? [] : []),
 		...(settings.SelectedAdlibs
 			? await getPiecesToPreserve(
 					context,
@@ -1105,12 +1084,12 @@ async function executeActionCutToCamera<
 
 	const externalId = generateExternalId(context, actionId, [userData.sourceDefinition.name])
 
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId,
 		title: userData.sourceDefinition.name,
 		metaData: {},
 		expectedDuration: 0
-	})
+	}
 
 	const sourceInfoCam = findSourceInfo(config.sources, userData.sourceDefinition)
 	if (sourceInfoCam === undefined) {
@@ -1127,7 +1106,7 @@ async function executeActionCutToCamera<
 
 	const camSisyfos = GetSisyfosTimelineObjForCamera(config, sourceInfoCam, false)
 
-	const kamPiece = literal<IBlueprintPiece>({
+	const kamPiece: IBlueprintPiece<PieceMetaData> = {
 		externalId,
 		name: part.title,
 		enable: { start: 0 },
@@ -1135,11 +1114,11 @@ async function executeActionCutToCamera<
 		sourceLayerId: settings.SourceLayers.Cam,
 		lifespan: PieceLifespan.WithinPart,
 		metaData: {
-			sisyfosPersistMetaData: literal<SisyfosPersistMetaData>({
+			sisyfosPersistMetaData: {
 				sisyfosLayers: [],
 				acceptPersistAudio: sourceInfoCam.acceptPersistAudio,
 				isPieceInjectedInPart: true
-			})
+			}
 		},
 		tags: [GetTagForKam(userData.sourceDefinition)],
 		content: {
@@ -1162,7 +1141,7 @@ async function executeActionCutToCamera<
 				...camSisyfos
 			])
 		}
-	})
+	}
 
 	settings.postProcessPieceTimelineObjects(context, config, kamPiece, false)
 
@@ -1180,8 +1159,8 @@ async function executeActionCutToCamera<
 	} else if (currentKam) {
 		kamPiece.externalId = currentKam.piece.externalId
 		kamPiece.enable = currentKam.piece.enable
-		const currentMetaData = currentKam.piece.metaData as PieceMetaData
-		const metaData = kamPiece.metaData as PieceMetaData
+		const currentMetaData = currentKam.piece.metaData!
+		const metaData = kamPiece.metaData!
 		metaData.sisyfosPersistMetaData!.previousPersistMetaDataForCurrentPiece = currentMetaData.sisyfosPersistMetaData
 
 		await stopGraphicPiecesThatShouldEndWithPart(context, currentPieceInstances)
@@ -1224,7 +1203,7 @@ async function stopGraphicPiecesThatShouldEndWithPart(
 	)
 }
 
-function isGraphicThatShouldEndWithPart(pieceInstance: IBlueprintPieceInstance<unknown>): unknown {
+function isGraphicThatShouldEndWithPart(pieceInstance: IBlueprintPieceInstance<unknown>): boolean {
 	return (
 		pieceInstance.piece.lifespan === PieceLifespan.WithinPart &&
 		!pieceInstance.stoppedPlayback &&
@@ -1247,12 +1226,12 @@ async function executeActionCutToRemote<
 
 	const title = userData.sourceDefinition.name
 
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId,
 		title,
 		metaData: {},
 		expectedDuration: 0
-	})
+	}
 
 	const sourceInfo = findSourceInfo(config.sources, userData.sourceDefinition)
 	if (sourceInfo === undefined) {
@@ -1271,7 +1250,7 @@ async function executeActionCutToRemote<
 			  }
 			: { sisyfosLayers: [] }
 
-	const remotePiece = literal<IBlueprintPiece>({
+	const remotePiece: IBlueprintPiece<PieceMetaData> = {
 		externalId,
 		name: title,
 		enable: {
@@ -1305,7 +1284,7 @@ async function executeActionCutToRemote<
 				...eksternSisyfos
 			])
 		}
-	})
+	}
 
 	settings.postProcessPieceTimelineObjects(context, config, remotePiece, false)
 
@@ -1349,21 +1328,20 @@ async function executeActionCutSourceToBox<
 	)
 
 	let modify: undefined | 'current' | 'next'
-	let modifiedPiece: IBlueprintPieceInstance | undefined
+	let modifiedPiece: IBlueprintPieceInstance<DVEPieceMetaData> | undefined
 	let modifiedDataStore: IBlueprintPieceInstance | undefined
 
 	if (currentDVE && !currentDVE.stoppedPlayback) {
 		modify = 'current'
-		modifiedPiece = currentDVE
+		modifiedPiece = currentDVE as IBlueprintPieceInstance<DVEPieceMetaData>
 		modifiedDataStore = currentDataStore
 	} else if (nextDVE) {
 		modify = 'next'
-		modifiedPiece = nextDVE
+		modifiedPiece = nextDVE as IBlueprintPieceInstance<DVEPieceMetaData>
 		modifiedDataStore = nextDataStore
 	}
 
-	const meta: (DVEPieceMetaData & PieceMetaData) | undefined = modifiedPiece?.piece.metaData as PieceMetaData &
-		DVEPieceMetaData
+	const meta = modifiedPiece?.piece.metaData
 
 	if (
 		!modifiedPiece ||
@@ -1405,7 +1383,11 @@ async function executeActionCutSourceToBox<
 		mediaPlayerSession
 	)
 
-	let newDVEPiece: IBlueprintPiece = { ...modifiedPiece.piece, content: newPieceContent.content, metaData: meta }
+	let newDVEPiece: IBlueprintPiece<DVEPieceMetaData> = {
+		...modifiedPiece.piece,
+		content: newPieceContent.content,
+		metaData: meta
+	}
 	if (!containsServerBefore || !containsServerAfter) {
 		newDVEPiece = await cutServerToBox(context, settings, newDVEPiece, !!containsServerBefore, modify === 'current')
 	}
@@ -1429,10 +1411,10 @@ async function executeActionCutSourceToBox<
 }
 
 interface PiecesBySourceLayer {
-	[key: string]: IBlueprintPieceInstance[]
+	[key: string]: Array<IBlueprintPieceInstance<PieceMetaData>>
 }
 
-function groupPiecesBySourceLayer(pieceInstances: IBlueprintPieceInstance[]): PiecesBySourceLayer {
+function groupPiecesBySourceLayer(pieceInstances: Array<IBlueprintPieceInstance<PieceMetaData>>): PiecesBySourceLayer {
 	const piecesBySourceLayer: PiecesBySourceLayer = {}
 	pieceInstances.forEach(piece => {
 		if (!piecesBySourceLayer[piece.piece.sourceLayerId]) {
@@ -1509,7 +1491,7 @@ async function executeActionTakeWithTransition<
 ) {
 	const externalId = generateExternalId(context, actionId, [userData.variant.type])
 
-	const nextPieces: IBlueprintPieceInstance[] = await context.getPieceInstances('next')
+	const nextPieces = await context.getPieceInstances('next')
 
 	const nextPiecesBySourceLayer = groupPiecesBySourceLayer(nextPieces)
 	const primaryPiece = findPrimaryPieceUsingPriority(settings, nextPiecesBySourceLayer)
@@ -1559,7 +1541,7 @@ async function executeActionTakeWithTransition<
 
 				await context.updatePieceInstance(primaryPiece._id, primaryPiece.piece)
 
-				const cutTransitionPiece: IBlueprintPiece = {
+				const cutTransitionPiece: IBlueprintPiece<PieceMetaData> = {
 					enable: {
 						start: 0,
 						duration: 1000
@@ -1592,7 +1574,7 @@ async function executeActionTakeWithTransition<
 			await context.updatePieceInstance(primaryPiece._id, primaryPiece.piece)
 
 			const config = settings.getConfig(context)
-			const pieces: IBlueprintPiece[] = []
+			const pieces: Array<IBlueprintPiece<PieceMetaData>> = []
 			partProps = CreateEffektForPartInner(
 				context,
 				config,
@@ -1623,7 +1605,7 @@ async function executeActionTakeWithTransition<
 				timelineObjectIndex
 			)
 
-			const blueprintPiece: IBlueprintPiece = CreateMixTransitionBlueprintPieceForPart(
+			const blueprintPiece = CreateMixTransitionBlueprintPieceForPart(
 				externalId,
 				userData.variant.frames,
 				settings.SourceLayers.Effekt
@@ -1645,7 +1627,7 @@ async function executeActionTakeWithTransition<
 				primaryPiece,
 				timelineObjectIndex
 			)
-			const blueprintPiece: IBlueprintPiece = CreateDipTransitionBlueprintPieceForPart(
+			const blueprintPiece = CreateDipTransitionBlueprintPieceForPart(
 				externalId,
 				userData.variant.frames,
 				settings.SourceLayers.Effekt
@@ -1668,7 +1650,7 @@ async function updateTimelineObjectMeTransition(
 	timelineObject: TSR.TimelineObjAtemME,
 	transitionStyle: TSR.AtemTransitionStyle,
 	transitionSettings: TSR.AtemTransitionSettings,
-	pieceInstance: IBlueprintPieceInstance,
+	pieceInstance: IBlueprintPieceInstance<PieceMetaData>,
 	indexOfTimelineObject: number
 ): Promise<void> {
 	timelineObject.content.me.transition = transitionStyle
@@ -1681,7 +1663,7 @@ async function updateTimelineObjectMeTransition(
 async function findPieceToRecoverDataFrom(
 	context: ITV2ActionExecutionContext,
 	dataStoreLayers: string[]
-): Promise<{ piece: IBlueprintPieceInstance; part: 'current' | 'next' } | undefined> {
+): Promise<{ piece: IBlueprintPieceInstance<PieceMetaData>; part: 'current' | 'next' } | undefined> {
 	const pieces = await Promise.all([context.getPieceInstances('current'), context.getPieceInstances('next')])
 	const currentPieces = pieces[0]
 	const nextPieces = pieces[1]
@@ -1690,7 +1672,7 @@ async function findPieceToRecoverDataFrom(
 
 	const nextServer = nextPieces.find(p => dataStoreLayers.includes(p.piece.sourceLayerId))
 
-	let pieceToRecoverDataFrom: IBlueprintPieceInstance | undefined
+	let pieceToRecoverDataFrom: IBlueprintPieceInstance<PieceMetaData> | undefined
 
 	let part: 'current' | 'next' = 'current'
 
@@ -1698,7 +1680,6 @@ async function findPieceToRecoverDataFrom(
 		part = 'next'
 		pieceToRecoverDataFrom = nextServer
 	} else if (currentServer) {
-		part = 'current'
 		pieceToRecoverDataFrom = currentServer
 	}
 
@@ -1738,7 +1719,7 @@ async function findMediaPlayerSessions(
 		}
 	}
 
-	const sessions = (mediaPlayerSessionPiece.piece.piece.metaData as any)?.mediaPlayerSessions
+	const sessions = mediaPlayerSessionPiece.piece.piece.metaData?.mediaPlayerSessions
 
 	return {
 		// Assume there will be only one session
@@ -1875,12 +1856,12 @@ async function executeActionRecallLastLive<
 
 	const externalId = generateExternalId(context, actionId, [lastLive.piece.name])
 
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId,
 		title: lastLive.piece.name
-	})
+	}
 
-	const pieces: IBlueprintPiece[] = []
+	const pieces: Array<IBlueprintPiece<PieceMetaData>> = []
 	pieces.push({
 		...lastLive.piece,
 		externalId,
@@ -1916,12 +1897,9 @@ async function executeActionRecallLastDVE<
 		return
 	}
 
-	const lastPlayedScheduledDVE: IBlueprintPieceInstance | undefined = await context.findLastPieceOnLayer(
-		settings.SourceLayers.DVE,
-		{
-			originalOnly: true
-		}
-	)
+	const lastPlayedScheduledDVE = (await context.findLastPieceOnLayer(settings.SourceLayers.DVE, {
+		originalOnly: true
+	})) as IBlueprintPieceInstance<DVEPieceMetaData> | undefined
 	const isLastPlayedAScheduledDVE: boolean = !lastPlayedScheduledDVE?.dynamicallyInserted
 
 	if (lastPlayedScheduledDVE && isLastPlayedAScheduledDVE) {
@@ -1936,16 +1914,16 @@ async function executeActionFadeDownPersistedAudioLevels<
 	ShowStyleConfig extends TV2BlueprintConfigBase<StudioConfig>
 >(context: ITV2ActionExecutionContext, _settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>) {
 	const fadeSisyfosMetaData = await createFadeSisyfosLevelsMetaData(context)
-	const resetSisyfosPersistedLevelsPiece: IBlueprintPiece = {
+	const resetSisyfosPersistedLevelsPiece: IBlueprintPiece<PieceMetaData> = {
 		externalId: 'fadeSisyfosPersistedLevelsDown',
 		name: FADE_SISYFOS_LEVELS_PIECE_NAME,
 		outputLayerId: '',
 		sourceLayerId: '',
 		enable: { start: 'now' },
 		lifespan: PieceLifespan.WithinPart,
-		metaData: literal<PieceMetaData>({
+		metaData: {
 			sisyfosPersistMetaData: fadeSisyfosMetaData
-		}),
+		},
 		content: {
 			timelineObjects: []
 		}
@@ -1954,7 +1932,7 @@ async function executeActionFadeDownPersistedAudioLevels<
 }
 
 async function createFadeSisyfosLevelsMetaData(context: ITV2ActionExecutionContext) {
-	const resolvedPieceInstances: IBlueprintResolvedPieceInstance[] = await context.getResolvedPieceInstances('current')
+	const resolvedPieceInstances = await context.getResolvedPieceInstances('current')
 	const emptySisyfosMetaData: SisyfosPersistMetaData = {
 		sisyfosLayers: []
 	}
@@ -1962,11 +1940,11 @@ async function createFadeSisyfosLevelsMetaData(context: ITV2ActionExecutionConte
 		return emptySisyfosMetaData
 	}
 
-	const latestPiece: IBlueprintResolvedPieceInstance = resolvedPieceInstances
+	const latestPiece = resolvedPieceInstances
 		.filter(piece => piece.piece.name !== FADE_SISYFOS_LEVELS_PIECE_NAME)
 		.sort((a, b) => b.resolvedStart - a.resolvedStart)[0]
 
-	const latestPieceMetaData = latestPiece.piece.metaData as PieceMetaData
+	const latestPieceMetaData = latestPiece.piece.metaData
 
 	if (!latestPieceMetaData || !latestPieceMetaData.sisyfosPersistMetaData) {
 		return emptySisyfosMetaData
@@ -1986,22 +1964,17 @@ async function scheduleLastPlayedDVE<
 	context: ITV2ActionExecutionContext,
 	settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>,
 	actionId: string,
-	lastPlayedDVE: IBlueprintPieceInstance
+	lastPlayedDVE: IBlueprintPieceInstance<DVEPieceMetaData>
 ): Promise<void> {
-	const lastPlayedDVEMeta: DVEPieceMetaData = lastPlayedDVE.piece.metaData as DVEPieceMetaData
+	const lastPlayedDVEMeta: DVEPieceMetaData = lastPlayedDVE.piece.metaData!
 	const externalId: string = generateExternalId(context, actionId, [lastPlayedDVE.piece.name])
 
-	await executeActionSelectDVE(
-		context,
-		settings,
-		actionId,
-		literal<ActionSelectDVE>({
-			type: AdlibActionType.SELECT_DVE,
-			config: lastPlayedDVEMeta.userData.config,
-			segmentExternalId: externalId,
-			videoId: lastPlayedDVEMeta.userData.videoId
-		})
-	)
+	await executeActionSelectDVE(context, settings, actionId, {
+		type: AdlibActionType.SELECT_DVE,
+		config: lastPlayedDVEMeta.userData.config,
+		segmentExternalId: externalId,
+		videoId: lastPlayedDVEMeta.userData.videoId
+	})
 }
 
 async function scheduleNextScriptedDVE<
@@ -2023,17 +1996,12 @@ async function scheduleNextScriptedDVE<
 	const externalId: string = generateExternalId(context, actionId, [nextScriptedDVE.name])
 	const dveMeta: DVEPieceMetaData = nextScriptedDVE.metaData as DVEPieceMetaData
 
-	await executeActionSelectDVE(
-		context,
-		settings,
-		actionId,
-		literal<ActionSelectDVE>({
-			type: AdlibActionType.SELECT_DVE,
-			config: dveMeta.userData.config,
-			segmentExternalId: externalId,
-			videoId: dveMeta.userData.videoId
-		})
-	)
+	await executeActionSelectDVE(context, settings, actionId, {
+		type: AdlibActionType.SELECT_DVE,
+		config: dveMeta.userData.config,
+		segmentExternalId: externalId,
+		videoId: dveMeta.userData.videoId
+	})
 }
 
 async function executeActionSelectFull<
@@ -2049,7 +2017,8 @@ async function executeActionSelectFull<
 
 	const template = GetFullGrafikTemplateName(config, userData.name)
 
-	const externalId = `adlib-action_${context.getHashId(`cut_to_full_${template}`)}`
+	const hash = context.getHashId(`cut_to_full_${template}`)
+	const externalId = `adlib-action_${hash}`
 
 	const graphicType = config.studio.GraphicsType
 	const previousPartKeepaliveDuration =
@@ -2057,7 +2026,7 @@ async function executeActionSelectFull<
 			? config.studio.HTMLGraphics.KeepAliveDuration
 			: config.studio.VizPilotGraphics.KeepAliveDuration
 
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId,
 		title: `Full ${template}`,
 		metaData: {},
@@ -2067,9 +2036,9 @@ async function executeActionSelectFull<
 			partContentDelayDuration: 0,
 			blockTakeDuration: 0
 		}
-	})
+	}
 
-	const cue = literal<CueDefinitionGraphic<GraphicPilot>>({
+	const cue: CueDefinitionGraphic<GraphicPilot> = {
 		type: CueType.Graphic,
 		target: 'FULL',
 		graphic: {
@@ -2079,7 +2048,7 @@ async function executeActionSelectFull<
 			continueCount: -1
 		},
 		iNewsCommand: ''
-	})
+	}
 
 	const generator = new PilotGraphicGenerator({
 		config,
@@ -2121,54 +2090,51 @@ async function executeActionClearGraphics<
 	const config = settings.getConfig(context)
 
 	await context.stopPiecesOnLayers(STOPPABLE_GRAPHICS_LAYERS)
-	await context.insertPiece(
-		'current',
-		literal<IBlueprintPiece>({
-			enable: {
-				start: 'now',
-				duration: 3000
-			},
-			externalId: 'clearAllGFX',
-			name: userData.label,
-			sourceLayerId: SharedSourceLayers.PgmAdlibGraphicCmd,
-			outputLayerId: SharedOutputLayers.SEC,
-			lifespan: PieceLifespan.WithinPart,
-			content:
-				config.studio.GraphicsType === 'HTML'
-					? {
-							timelineObjects: [
-								literal<TSR.TimelineObjAbstractAny>({
-									id: '',
-									enable: {
-										start: 0
-									},
-									priority: 1,
-									layer: SharedGraphicLLayer.GraphicLLayerAdLibs,
-									content: {
-										deviceType: TSR.DeviceType.ABSTRACT
-									}
-								})
-							]
-					  }
-					: {
-							timelineObjects: [
-								literal<TSR.TimelineObjVIZMSEClearAllElements>({
-									id: '',
-									enable: {
-										start: 0
-									},
-									priority: 100,
-									layer: SharedGraphicLLayer.GraphicLLayerAdLibs,
-									content: {
-										deviceType: TSR.DeviceType.VIZMSE,
-										type: TSR.TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
-										channelsToSendCommands: userData.sendCommands ? ['OVL1', 'FULL1', 'WALL1'] : undefined,
-										showId: config.selectedGraphicsSetup.OvlShowId
-									}
-								})
-							]
-					  },
-			tags: userData.sendCommands ? [TallyTags.GFX_CLEAR] : [TallyTags.GFX_ALTUD]
-		})
-	)
+	await context.insertPiece('current', {
+		enable: {
+			start: 'now',
+			duration: 3000
+		},
+		externalId: 'clearAllGFX',
+		name: userData.label,
+		sourceLayerId: SharedSourceLayers.PgmAdlibGraphicCmd,
+		outputLayerId: SharedOutputLayers.SEC,
+		lifespan: PieceLifespan.WithinPart,
+		content:
+			config.studio.GraphicsType === 'HTML'
+				? {
+						timelineObjects: [
+							literal<TSR.TimelineObjAbstractAny>({
+								id: '',
+								enable: {
+									start: 0
+								},
+								priority: 1,
+								layer: SharedGraphicLLayer.GraphicLLayerAdLibs,
+								content: {
+									deviceType: TSR.DeviceType.ABSTRACT
+								}
+							})
+						]
+				  }
+				: {
+						timelineObjects: [
+							literal<TSR.TimelineObjVIZMSEClearAllElements>({
+								id: '',
+								enable: {
+									start: 0
+								},
+								priority: 100,
+								layer: SharedGraphicLLayer.GraphicLLayerAdLibs,
+								content: {
+									deviceType: TSR.DeviceType.VIZMSE,
+									type: TSR.TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
+									channelsToSendCommands: userData.sendCommands ? ['OVL1', 'FULL1', 'WALL1'] : undefined,
+									showId: config.selectedGraphicsSetup.OvlShowId
+								}
+							})
+						]
+				  },
+		tags: userData.sendCommands ? [TallyTags.GFX_CLEAR] : [TallyTags.GFX_ALTUD]
+	})
 }

--- a/src/tv2-common/content/dve.ts
+++ b/src/tv2-common/content/dve.ts
@@ -21,6 +21,7 @@ import {
 	JoinAssetToFolder,
 	literal,
 	PartDefinition,
+	PieceMetaData,
 	TimelineBlueprintExt,
 	TV2BlueprintConfigBase,
 	TV2StudioConfigBase
@@ -106,7 +107,7 @@ export interface DVEMetaData {
 	mediaPlayerSession?: string
 }
 
-export interface DVEPieceMetaData {
+export interface DVEPieceMetaData extends PieceMetaData {
 	config: DVEConfigInput
 	sources: DVESources
 	userData: ActionSelectDVE
@@ -147,10 +148,6 @@ export function MakeContentDVEBase<
 			}
 		}
 	}
-
-	// console.log('boxmap1', boxMap)
-	// boxMap = boxMap.filter(map => map !== '')
-	// console.log('boxmap2', boxMap)
 
 	const graphicsTemplateContent: { [key: string]: string } = {}
 	parsedCue.labels.forEach((label, i) => {

--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -79,10 +79,10 @@ function GetServerTimeline(
 	sourceLayers: MakeContentServerSourceLayers,
 	partProps: ServerPartProps,
 	contentProps: ServerContentProps
-) {
+): TimelineObjectCoreExt[] {
 	const serverEnableClass = `.${GetEnableClassForServer(contentProps.mediaPlayerSession)}`
 
-	const mediaObj = literal<TSR.TimelineObjCCGMedia & TimelineBlueprintExt>({
+	const mediaObj: TSR.TimelineObjCCGMedia & TimelineBlueprintExt = {
 		id: '',
 		enable: {
 			while: serverEnableClass
@@ -106,7 +106,7 @@ function GetServerTimeline(
 				? [ServerParentClass('studio0', contentProps.file)]
 				: [])
 		]
-	})
+	}
 
 	const mediaOffObj = JSON.parse(JSON.stringify(mediaObj)) as TSR.TimelineObjCCGMedia & TimelineBlueprintExt
 	mediaOffObj.enable = { while: `!${serverEnableClass}` }
@@ -115,7 +115,7 @@ function GetServerTimeline(
 	const audioEnable = {
 		while: serverEnableClass
 	}
-	return literal<TimelineObjectCoreExt[]>([
+	return [
 		mediaObj,
 		mediaOffObj,
 		...GetSisyfosTimelineObjForServer(
@@ -147,7 +147,7 @@ function GetServerTimeline(
 					})
 			  ]
 			: [])
-	])
+	]
 }
 
 export function CutToServer(

--- a/src/tv2-common/cueTiming.ts
+++ b/src/tv2-common/cueTiming.ts
@@ -38,22 +38,14 @@ export function CreateTimingEnable(
 		lifespan: PieceLifespan.WithinPart
 	}
 
-	if (cue.start) {
-		;(result.enable as any).start = CalculateTime(cue.start)
-	} else {
-		;(result.enable as any).start = 0
-	}
+	result.enable.start = (cue.start && CalculateTime(cue.start)) ?? 0
 
 	if (cue.end) {
 		if (cue.end.infiniteMode) {
 			result.lifespan = LifeSpan(cue.end.infiniteMode, PieceLifespan.WithinPart)
 		} else {
 			const end = CalculateTime(cue.end)
-			;(result.enable as any).duration = end
-				? result.enable.start
-					? end - Number(result.enable.start)
-					: end
-				: undefined
+			result.enable.duration = end ? end - result.enable.start : undefined
 		}
 	} else if (defaultOut !== undefined) {
 		result.enable.duration = defaultOut

--- a/src/tv2-common/cues/ekstern.ts
+++ b/src/tv2-common/cues/ekstern.ts
@@ -17,7 +17,7 @@ import {
 	literal,
 	PartDefinition,
 	PartToParentClass,
-	SisyfosPersistMetaData,
+	PieceMetaData,
 	TransitionSettings,
 	TV2BlueprintConfigBase,
 	TV2StudioConfigBase
@@ -43,8 +43,8 @@ export function EvaluateEksternBase<
 	context: IShowStyleUserContext,
 	config: ShowStyleConfig,
 	part: IBlueprintPart,
-	pieces: IBlueprintPiece[],
-	adlibPieces: IBlueprintAdLibPiece[],
+	pieces: Array<IBlueprintPiece<PieceMetaData>>,
+	adlibPieces: Array<IBlueprintAdLibPiece<PieceMetaData>>,
 	partId: string,
 	parsedCue: CueDefinitionEkstern,
 	partDefinition: PartDefinition,
@@ -61,105 +61,101 @@ export function EvaluateEksternBase<
 	const atemInput = sourceInfoEkstern.port
 
 	if (adlib) {
-		adlibPieces.push(
-			literal<IBlueprintAdLibPiece>({
-				_rank: rank || 0,
-				externalId: partId,
-				name: parsedCue.sourceDefinition.name,
-				outputLayerId: SharedOutputLayers.PGM,
-				sourceLayerId: layersEkstern.SourceLayer.PgmLive,
-				toBeQueued: true,
-				lifespan: PieceLifespan.WithinPart,
-				metaData: {
-					sisyfosPersistMetaData: literal<SisyfosPersistMetaData>({
-						sisyfosLayers: sourceInfoEkstern.sisyfosLayers ?? [],
-						wantsToPersistAudio: sourceInfoEkstern.wantsToPersistAudio,
-						acceptPersistAudio: sourceInfoEkstern.acceptPersistAudio
-					})
-				},
-				content: literal<WithTimeline<RemoteContent>>({
-					studioLabel: '',
-					switcherInput: atemInput,
-					timelineObjects: literal<TimelineObjectCoreExt[]>([
-						literal<TSR.TimelineObjAtemME>({
-							id: '',
-							enable: {
-								start: 0
-							},
-							priority: 1,
-							layer: layersEkstern.ATEM.MEProgram,
-							content: {
-								deviceType: TSR.DeviceType.ATEM,
-								type: TSR.TimelineContentTypeAtem.ME,
-								me: {
-									input: atemInput,
-									transition: partDefinition.transition ? partDefinition.transition.style : TSR.AtemTransitionStyle.CUT,
-									transitionSettings: TransitionSettings(config, partDefinition)
-								}
-							},
-							classes: [ControlClasses.LiveSourceOnAir]
-						}),
+		adlibPieces.push({
+			_rank: rank || 0,
+			externalId: partId,
+			name: parsedCue.sourceDefinition.name,
+			outputLayerId: SharedOutputLayers.PGM,
+			sourceLayerId: layersEkstern.SourceLayer.PgmLive,
+			toBeQueued: true,
+			lifespan: PieceLifespan.WithinPart,
+			metaData: {
+				sisyfosPersistMetaData: {
+					sisyfosLayers: sourceInfoEkstern.sisyfosLayers ?? [],
+					wantsToPersistAudio: sourceInfoEkstern.wantsToPersistAudio,
+					acceptPersistAudio: sourceInfoEkstern.acceptPersistAudio
+				}
+			},
+			content: literal<WithTimeline<RemoteContent>>({
+				studioLabel: '',
+				switcherInput: atemInput,
+				timelineObjects: literal<TimelineObjectCoreExt[]>([
+					literal<TSR.TimelineObjAtemME>({
+						id: '',
+						enable: {
+							start: 0
+						},
+						priority: 1,
+						layer: layersEkstern.ATEM.MEProgram,
+						content: {
+							deviceType: TSR.DeviceType.ATEM,
+							type: TSR.TimelineContentTypeAtem.ME,
+							me: {
+								input: atemInput,
+								transition: partDefinition.transition ? partDefinition.transition.style : TSR.AtemTransitionStyle.CUT,
+								transitionSettings: TransitionSettings(config, partDefinition)
+							}
+						},
+						classes: [ControlClasses.LiveSourceOnAir]
+					}),
 
-						...GetSisyfosTimelineObjForRemote(config, sourceInfoEkstern)
-					])
-				})
+					...GetSisyfosTimelineObjForRemote(config, sourceInfoEkstern)
+				])
 			})
-		)
+		})
 	} else {
-		pieces.push(
-			literal<IBlueprintPiece>({
-				externalId: partId,
-				name: parsedCue.sourceDefinition.name,
-				enable: {
-					start: 0
-				},
-				outputLayerId: SharedOutputLayers.PGM,
-				sourceLayerId: layersEkstern.SourceLayer.PgmLive,
-				lifespan: PieceLifespan.WithinPart,
-				toBeQueued: true,
-				metaData: {
-					sisyfosPersistMetaData: literal<SisyfosPersistMetaData>({
-						sisyfosLayers: sourceInfoEkstern.sisyfosLayers ?? [],
-						wantsToPersistAudio: sourceInfoEkstern.wantsToPersistAudio,
-						acceptPersistAudio: sourceInfoEkstern.acceptPersistAudio
-					})
-				},
-				tags: [GetTagForLive(parsedCue.sourceDefinition)],
-				content: literal<WithTimeline<RemoteContent>>({
-					studioLabel: '',
-					switcherInput: atemInput,
-					timelineObjects: literal<TimelineObjectCoreExt[]>([
-						createEmptyObject({
-							// Only want the ident for original versions (or clones)
-							enable: { start: 0 },
-							layer: 'ekstern_enable_ident',
-							classes: [PartToParentClass('studio0', partDefinition) ?? '']
-						}),
-						literal<TSR.TimelineObjAtemME>({
-							id: '',
-							enable: {
-								start: 0
-							},
-							priority: 1,
-							layer: layersEkstern.ATEM.MEProgram,
-							content: {
-								deviceType: TSR.DeviceType.ATEM,
-								type: TSR.TimelineContentTypeAtem.ME,
-								me: {
-									input: atemInput,
-									transition: partDefinition.transition ? partDefinition.transition.style : TSR.AtemTransitionStyle.CUT,
-									transitionSettings: TransitionSettings(config, partDefinition)
-								}
-							},
-							...(AddParentClass(config, partDefinition)
-								? { classes: [EksternParentClass('studio0', parsedCue.sourceDefinition.name)] }
-								: {})
-						}),
+		pieces.push({
+			externalId: partId,
+			name: parsedCue.sourceDefinition.name,
+			enable: {
+				start: 0
+			},
+			outputLayerId: SharedOutputLayers.PGM,
+			sourceLayerId: layersEkstern.SourceLayer.PgmLive,
+			lifespan: PieceLifespan.WithinPart,
+			toBeQueued: true,
+			metaData: {
+				sisyfosPersistMetaData: {
+					sisyfosLayers: sourceInfoEkstern.sisyfosLayers ?? [],
+					wantsToPersistAudio: sourceInfoEkstern.wantsToPersistAudio,
+					acceptPersistAudio: sourceInfoEkstern.acceptPersistAudio
+				}
+			},
+			tags: [GetTagForLive(parsedCue.sourceDefinition)],
+			content: literal<WithTimeline<RemoteContent>>({
+				studioLabel: '',
+				switcherInput: atemInput,
+				timelineObjects: literal<TimelineObjectCoreExt[]>([
+					createEmptyObject({
+						// Only want the ident for original versions (or clones)
+						enable: { start: 0 },
+						layer: 'ekstern_enable_ident',
+						classes: [PartToParentClass('studio0', partDefinition) ?? '']
+					}),
+					literal<TSR.TimelineObjAtemME>({
+						id: '',
+						enable: {
+							start: 0
+						},
+						priority: 1,
+						layer: layersEkstern.ATEM.MEProgram,
+						content: {
+							deviceType: TSR.DeviceType.ATEM,
+							type: TSR.TimelineContentTypeAtem.ME,
+							me: {
+								input: atemInput,
+								transition: partDefinition.transition ? partDefinition.transition.style : TSR.AtemTransitionStyle.CUT,
+								transitionSettings: TransitionSettings(config, partDefinition)
+							}
+						},
+						...(AddParentClass(config, partDefinition)
+							? { classes: [EksternParentClass('studio0', parsedCue.sourceDefinition.name)] }
+							: {})
+					}),
 
-						...GetSisyfosTimelineObjForRemote(config, sourceInfoEkstern)
-					])
-				})
+					...GetSisyfosTimelineObjForRemote(config, sourceInfoEkstern)
+				])
 			})
-		)
+		})
 	}
 }

--- a/src/tv2-common/cues/ekstern.ts
+++ b/src/tv2-common/cues/ekstern.ts
@@ -133,7 +133,7 @@ export function EvaluateEksternBase<
 							// Only want the ident for original versions (or clones)
 							enable: { start: 0 },
 							layer: 'ekstern_enable_ident',
-							classes: [ControlClasses.ShowIdentGraphic, PartToParentClass('studio0', partDefinition) ?? '']
+							classes: [PartToParentClass('studio0', partDefinition) ?? '']
 						}),
 						literal<TSR.TimelineObjAtemME>({
 							id: '',

--- a/src/tv2-common/cues/lyd.ts
+++ b/src/tv2-common/cues/lyd.ts
@@ -59,44 +59,40 @@ export function EvaluateLYD(
 	const lifespan = stop || fade || parsedCue.end ? PieceLifespan.WithinPart : PieceLifespan.OutOnRundownChange
 
 	if (adlib) {
-		adlibPieces.push(
-			literal<IBlueprintAdLibPiece>({
-				_rank: rank || 0,
-				externalId: part.externalId,
-				name: parsedCue.variant,
-				outputLayerId: SharedOutputLayers.MUSIK,
-				sourceLayerId: SharedSourceLayers.PgmAudioBed,
-				lifespan,
-				expectedDuration: stop
-					? 2000
-					: fade
-					? Math.max(1000, fadeIn ? TimeFromFrames(fadeIn) : 0)
-					: CreateTimingEnable(parsedCue).enable.duration ?? undefined,
-				content: LydContent(config, file, lydType, fadeIn, fadeOut),
-				tags: [AdlibTags.ADLIB_FLOW_PRODUCER]
-			})
-		)
+		adlibPieces.push({
+			_rank: rank || 0,
+			externalId: part.externalId,
+			name: parsedCue.variant,
+			outputLayerId: SharedOutputLayers.MUSIK,
+			sourceLayerId: SharedSourceLayers.PgmAudioBed,
+			lifespan,
+			expectedDuration: stop
+				? 2000
+				: fade
+				? Math.max(1000, fadeIn ? TimeFromFrames(fadeIn) : 0)
+				: CreateTimingEnable(parsedCue).enable.duration ?? undefined,
+			content: LydContent(config, file, lydType, fadeIn, fadeOut),
+			tags: [AdlibTags.ADLIB_FLOW_PRODUCER]
+		})
 	} else {
-		pieces.push(
-			literal<IBlueprintPiece>({
-				externalId: part.externalId,
-				name: parsedCue.variant,
-				...(stop
-					? { enable: { start: CreateTimingEnable(parsedCue).enable.start, duration: 2000 } }
-					: fade
-					? {
-							enable: {
-								start: CreateTimingEnable(parsedCue).enable.start,
-								duration: Math.max(1000, fadeIn ? TimeFromFrames(fadeIn) : 0)
-							}
-					  }
-					: CreateTimingEnable(parsedCue)),
-				outputLayerId: SharedOutputLayers.MUSIK,
-				sourceLayerId: SharedSourceLayers.PgmAudioBed,
-				lifespan,
-				content: LydContent(config, file, lydType, fadeIn, fadeOut)
-			})
-		)
+		pieces.push({
+			externalId: part.externalId,
+			name: parsedCue.variant,
+			...(stop
+				? { enable: { start: CreateTimingEnable(parsedCue).enable.start, duration: 2000 } }
+				: fade
+				? {
+						enable: {
+							start: CreateTimingEnable(parsedCue).enable.start,
+							duration: Math.max(1000, fadeIn ? TimeFromFrames(fadeIn) : 0)
+						}
+				  }
+				: CreateTimingEnable(parsedCue)),
+			outputLayerId: SharedOutputLayers.MUSIK,
+			sourceLayerId: SharedSourceLayers.PgmAudioBed,
+			lifespan,
+			content: LydContent(config, file, lydType, fadeIn, fadeOut)
+		})
 	}
 }
 

--- a/src/tv2-common/cues/mixMinus.ts
+++ b/src/tv2-common/cues/mixMinus.ts
@@ -28,23 +28,21 @@ export function EvaluateCueMixMinus(
 	}
 	const atemInput = sourceInfo.port
 
-	pieces.push(
-		literal<IBlueprintPiece>({
-			externalId: part.externalId,
-			name: `MixMinus: ${name}`,
-			enable: {
-				start: 0
-			},
-			lifespan: PieceLifespan.OutOnShowStyleEnd,
-			sourceLayerId: SharedSourceLayers.AuxMixMinus,
-			outputLayerId: SharedOutputLayers.AUX,
-			content: MixMinusContent(atemInput)
-		})
-	)
+	pieces.push({
+		externalId: part.externalId,
+		name: `MixMinus: ${name}`,
+		enable: {
+			start: 0
+		},
+		lifespan: PieceLifespan.OutOnShowStyleEnd,
+		sourceLayerId: SharedSourceLayers.AuxMixMinus,
+		outputLayerId: SharedOutputLayers.AUX,
+		content: MixMinusContent(atemInput)
+	})
 }
 
 function MixMinusContent(atemInput: number): WithTimeline<BaseContent> {
-	return literal<WithTimeline<BaseContent>>({
+	return {
 		timelineObjects: literal<TimelineObjectCoreExt[]>([
 			literal<TSR.TimelineObjAtemAUX>({
 				content: {
@@ -62,5 +60,5 @@ function MixMinusContent(atemInput: number): WithTimeline<BaseContent> {
 				priority: 1
 			})
 		])
-	})
+	}
 }

--- a/src/tv2-common/evaluateCues.ts
+++ b/src/tv2-common/evaluateCues.ts
@@ -181,7 +181,7 @@ export interface EvaluateCuesOptions {
 	/** Whether the parent part is a graphic part. */
 	isGrafikPart?: boolean
 	/** Passing this arguments sets the types of cues to evaluate. */
-	selectedCueTypes?: CueType[] | undefined
+	selectedCueTypes?: CueType[]
 	/** Don't evaluate adlibs. */
 	excludeAdlibs?: boolean
 	/** Only evaluate adlibs. */

--- a/src/tv2-common/getSegment.ts
+++ b/src/tv2-common/getSegment.ts
@@ -109,7 +109,7 @@ export async function getSegmentBase<
 ): Promise<BlueprintResultSegment> {
 	const segmentPayload = ingestSegment.payload as INewsPayload | undefined
 	const iNewsStory = segmentPayload?.iNewsStory
-	const segment = literal<IBlueprintSegment>({
+	const segment: IBlueprintSegment = {
 		name: ingestSegment.name || '',
 		metaData: {},
 		showShelf: false,
@@ -117,7 +117,7 @@ export async function getSegmentBase<
 			iNewsStory && iNewsStory.fields.pageNumber && iNewsStory.fields.pageNumber.trim()
 				? iNewsStory.fields.pageNumber.trim()
 				: undefined
-	})
+	}
 	const config = showStyleOptions.getConfig(context)
 
 	if (!segmentPayload || !iNewsStory || iNewsStory.meta.float === 'float' || !iNewsStory.body) {
@@ -292,11 +292,11 @@ export async function getSegmentBase<
 		if (!part.part.expectedDuration && totalTimeMs > 0) {
 			part.part.expectedDuration = (totalTimeMs - allocatedTime || 0) / partsWithoutExpectedDuration
 
-			if (part.part.expectedDuration! < 0) {
+			if (part.part.expectedDuration < 0) {
 				part.part.expectedDuration = 0
 			}
 
-			if (part.part.expectedDuration! > config.studio.MaximumPartDuration) {
+			if (part.part.expectedDuration > config.studio.MaximumPartDuration) {
 				part.part.expectedDuration = config.studio.MaximumPartDuration
 			}
 		}

--- a/src/tv2-common/helpers/__tests__/serverResume.spec.ts
+++ b/src/tv2-common/helpers/__tests__/serverResume.spec.ts
@@ -6,7 +6,7 @@ import {
 	VTContent,
 	WithTimeline
 } from '@tv2media/blueprints-integration'
-import { DVEPieceMetaData, literal, RemoteType, SourceDefinitionRemote } from 'tv2-common'
+import { DVEPieceMetaData, literal, PieceMetaData, RemoteType, SourceDefinitionRemote } from 'tv2-common'
 import { SharedSourceLayers, SourceType } from 'tv2-constants'
 import { getServerPositionForPartInstance } from '../serverResume'
 
@@ -36,7 +36,7 @@ function getMockPartInstance(partInstance: Partial<IBlueprintPartInstance>): IBl
 describe('Server Resume', () => {
 	it('Returns server position from server part with resolved duration', () => {
 		const position = getServerPositionForPartInstance(getMockPartInstance({ _id: 'mock_1' }), [
-			literal<IBlueprintResolvedPieceInstance>({
+			literal<IBlueprintResolvedPieceInstance<PieceMetaData>>({
 				_id: '',
 				partInstanceId: 'mock_1',
 				resolvedStart: 1000,
@@ -64,7 +64,7 @@ describe('Server Resume', () => {
 		const position = getServerPositionForPartInstance(
 			getMockPartInstance({ _id: 'mock_1', timings: { startedPlayback: 1000 } }),
 			[
-				literal<IBlueprintResolvedPieceInstance>({
+				literal<IBlueprintResolvedPieceInstance<PieceMetaData>>({
 					_id: '',
 					partInstanceId: 'mock_1',
 					startedPlayback: 1000,
@@ -105,7 +105,7 @@ describe('Server Resume', () => {
 				timings: { startedPlayback: 11000 }
 			}),
 			[
-				literal<IBlueprintResolvedPieceInstance>({
+				literal<IBlueprintResolvedPieceInstance<PieceMetaData>>({
 					_id: '',
 					partInstanceId: 'mock_1',
 					resolvedStart: 1000,
@@ -151,7 +151,7 @@ describe('Server Resume', () => {
 				timings: { startedPlayback: 11000 }
 			}),
 			[
-				literal<IBlueprintResolvedPieceInstance>({
+				literal<IBlueprintResolvedPieceInstance<PieceMetaData>>({
 					_id: '',
 					partInstanceId: 'mock_1',
 					resolvedStart: 1000,

--- a/src/tv2-common/helpers/abPlayback.ts
+++ b/src/tv2-common/helpers/abPlayback.ts
@@ -72,20 +72,19 @@ interface SessionTime {
 }
 function calculateSessionTimeRanges(
 	_context: ITimelineEventContext,
-	resolvedPieces: IBlueprintResolvedPieceInstance[]
+	resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>
 ) {
 	const piecesWantingMediaPlayers = _.filter(resolvedPieces, p => {
 		if (!p.piece.metaData) {
 			return false
 		}
-		const metadata = p.piece.metaData as PieceMetaData
-		return (metadata.mediaPlayerSessions || []).length > 0
+		return (p.piece.metaData.mediaPlayerSessions || []).length > 0
 	})
 
 	const sessionRequests: { [sessionId: string]: SessionTime | undefined } = {}
 	_.each(piecesWantingMediaPlayers, p => {
-		const metadata = p.piece.metaData as PieceMetaData
-		const start = p.resolvedStart as number
+		const metadata = p.piece.metaData!
+		const start = p.resolvedStart
 		const duration = p.resolvedDuration
 		const end = duration !== undefined ? start + duration : undefined
 
@@ -205,7 +204,7 @@ export function resolveMediaPlayerAssignments<
 	context: ITimelineEventContext,
 	config: ShowStyleConfig,
 	previousAssignmentRev: SessionToPlayerMap,
-	resolvedPieces: IBlueprintResolvedPieceInstance[]
+	resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>
 ) {
 	const debugLog = config.studio.ABPlaybackDebugLogging
 	const sessionRequests = calculateSessionTimeRanges(context, resolvedPieces)
@@ -370,7 +369,7 @@ export function assignMediaPlayers<
 	config: ShowStyleConfig,
 	timelineObjs: OnGenerateTimelineObj[],
 	previousAssignment: TimelinePersistentStateExt['activeMediaPlayers'],
-	resolvedPieces: IBlueprintResolvedPieceInstance[],
+	resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>,
 	sourceLayers: ABSourceLayers
 ): TimelinePersistentStateExt['activeMediaPlayers'] {
 	const previousAssignmentRev = reversePreviousAssignment(previousAssignment, timelineObjs)

--- a/src/tv2-common/helpers/graphics/InternalGraphic.ts
+++ b/src/tv2-common/helpers/graphics/InternalGraphic.ts
@@ -1,33 +1,16 @@
-import {
-	IBlueprintActionManifest,
-	IBlueprintAdLibPiece,
-	IBlueprintPiece,
-	ICommonContext,
-	PieceLifespan,
-	TSR
-} from '@tv2media/blueprints-integration'
+import { IBlueprintAdLibPiece, IBlueprintPiece, PieceLifespan } from '@tv2media/blueprints-integration'
 import { Adlib } from 'tv2-common'
 import _ = require('underscore')
-import {
-	AbstractLLayer,
-	AdlibActionType,
-	AdlibTags,
-	GraphicEngine,
-	SharedOutputLayers,
-	SharedSourceLayers
-} from '../../../tv2-constants'
-import { ActionPlayGraphics } from '../../actions'
+import { AdlibTags, GraphicEngine, PartType, SharedOutputLayers, SharedSourceLayers } from '../../../tv2-constants'
 import { TV2BlueprintConfig } from '../../blueprintConfig'
-import { GetDefaultOut } from '../../cueTiming'
-import { CueDefinitionGraphic, GraphicInternal, IsStickyIdent, PartDefinition } from '../../inewsConversion'
+import { CueDefinitionGraphic, GraphicInternal, PartDefinition } from '../../inewsConversion'
 import { PieceMetaData } from '../../onTimelineGenerate'
-import { generateExternalId, literal } from '../../util'
-import { t } from '../translation'
+import { literal } from '../../util'
 import { GetInternalGraphicContentCaspar } from './caspar'
 import { GetSourceLayerForGraphic } from './layers'
 import { GetFullGraphicTemplateNameFromCue, GraphicDisplayName } from './name'
 import { IsTargetingOVL, IsTargetingTLF, IsTargetingWall } from './target'
-import { CreateTimingGraphic, GetInfiniteModeForGraphic } from './timing'
+import { CreateTimingGraphic, GetPieceLifespanForGraphic } from './timing'
 import { GetInternalGraphicContentVIZ } from './viz'
 
 export class InternalGraphic {
@@ -36,7 +19,6 @@ export class InternalGraphic {
 	private readonly parsedCue: CueDefinitionGraphic<GraphicInternal>
 	private readonly partDefinition?: PartDefinition
 	private readonly adlib?: Adlib
-	private readonly isStickyIdent: boolean
 	private readonly engine: GraphicEngine
 	private readonly name: string
 	private readonly sourceLayerId: SharedSourceLayers
@@ -52,130 +34,71 @@ export class InternalGraphic {
 		partId?: string,
 		partDefinition?: PartDefinition
 	) {
-		const isStickyIdent = IsStickyIdent(parsedCue)
-
-		const engine = parsedCue.target
-
 		const mappedTemplate = GetFullGraphicTemplateNameFromCue(config, parsedCue)
 
-		const sourceLayerId = GetSourceLayerForGraphic(config, mappedTemplate, isStickyIdent)
+		const sourceLayerId = GetSourceLayerForGraphic(config, mappedTemplate)
 
 		this.config = config
 		this.parsedCue = parsedCue
 		this.partDefinition = partDefinition
 		this.adlib = adlib
 		this.mappedTemplate = mappedTemplate
-		this.isStickyIdent = isStickyIdent
 		this.engine = parsedCue.target
 		this.name = GraphicDisplayName(config, parsedCue)
 		this.sourceLayerId = sourceLayerId
-		this.outputLayerId = IsTargetingWall(engine) ? SharedOutputLayers.SEC : SharedOutputLayers.OVERLAY
+		this.outputLayerId = IsTargetingWall(this.engine) ? SharedOutputLayers.SEC : SharedOutputLayers.OVERLAY
 		this.partId = partId
 		this.content = this.getInternalGraphicContent()
 	}
 
-	public createAdlibTargetingOVL(
-		context: ICommonContext,
-		actions: IBlueprintActionManifest[],
-		adlibPieces: IBlueprintAdLibPiece[]
-	): void {
-		if (IsTargetingOVL(this.engine) && this.isStickyIdent) {
-			const userData = literal<ActionPlayGraphics>({
-				type: AdlibActionType.PLAY_GRAPHICS,
-				graphic: this.parsedCue
-			})
-			actions.push(
-				literal<IBlueprintActionManifest>({
-					externalId: generateExternalId(context, userData),
-					actionId: AdlibActionType.PLAY_GRAPHICS,
-					userData,
-					userDataManifest: {},
-					display: {
-						_rank: this.rank || 0,
-						label: t(this.name),
-						uniquenessId: `gfx_${this.name}_${this.sourceLayerId}_${this.outputLayerId}_commentator`,
-						sourceLayerId: this.sourceLayerId,
-						outputLayerId: SharedOutputLayers.OVERLAY,
-						tags: [AdlibTags.ADLIB_KOMMENTATOR],
-						content: _.clone(this.content)
-					}
-				})
-			)
-		} else if (IsTargetingOVL(this.engine)) {
-			const adLibPiece = literal<IBlueprintAdLibPiece>({
+	public createCommentatorAdlib(adlibPieces: IBlueprintAdLibPiece[]): void {
+		if (!IsTargetingOVL(this.engine)) {
+			return
+		}
+		const adLibPiece = literal<IBlueprintAdLibPiece>({
+			_rank: this.rank || 0,
+			externalId: this.partId ?? '',
+			name: this.name,
+			uniquenessId: `gfx_${this.name}_${this.sourceLayerId}_${this.outputLayerId}_commentator`,
+			sourceLayerId: this.sourceLayerId,
+			outputLayerId: SharedOutputLayers.OVERLAY,
+			lifespan: PieceLifespan.WithinPart,
+			metaData: literal<PieceMetaData>({
+				sisyfosPersistMetaData: {
+					sisyfosLayers: []
+				}
+			}),
+			expectedDuration: 5000,
+			tags: [AdlibTags.ADLIB_KOMMENTATOR],
+			content: _.clone(this.content)
+		})
+		adlibPieces.push(adLibPiece)
+	}
+
+	public createAdlib(adlibPieces: IBlueprintAdLibPiece[]): void {
+		adlibPieces.push(
+			literal<IBlueprintAdLibPiece>({
 				_rank: this.rank || 0,
 				externalId: this.partId ?? '',
 				name: this.name,
-				uniquenessId: `gfx_${this.name}_${this.sourceLayerId}_${this.outputLayerId}_commentator`,
+				uniquenessId: `gfx_${this.name}_${this.sourceLayerId}_${this.outputLayerId}_flow`,
 				sourceLayerId: this.sourceLayerId,
-				outputLayerId: SharedOutputLayers.OVERLAY,
-				lifespan: PieceLifespan.WithinPart,
+				outputLayerId: this.outputLayerId,
+				tags: [AdlibTags.ADLIB_FLOW_PRODUCER],
+				...(IsTargetingTLF(this.engine) || (this.parsedCue.end && this.parsedCue.end.infiniteMode)
+					? {}
+					: {
+							expectedDuration: CreateTimingGraphic(this.config, this.parsedCue).duration
+					  }),
+				lifespan: GetPieceLifespanForGraphic(this.engine, this.config, this.parsedCue),
 				metaData: literal<PieceMetaData>({
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					}
 				}),
-				expectedDuration: 5000,
-				tags: [AdlibTags.ADLIB_KOMMENTATOR],
 				content: _.clone(this.content)
 			})
-			adlibPieces.push(adLibPiece)
-		}
-	}
-
-	public createAdlib(
-		context: ICommonContext,
-		actions: IBlueprintActionManifest[],
-		adlibPieces: IBlueprintAdLibPiece[]
-	): void {
-		if (this.isStickyIdent) {
-			const userData = literal<ActionPlayGraphics>({
-				type: AdlibActionType.PLAY_GRAPHICS,
-				graphic: this.parsedCue
-			})
-			actions.push(
-				literal<IBlueprintActionManifest>({
-					externalId: generateExternalId(context, userData),
-					actionId: AdlibActionType.PLAY_GRAPHICS,
-					userData,
-					userDataManifest: {},
-					display: {
-						_rank: this.rank || 0,
-						label: t(this.name),
-						uniquenessId: `gfx_${this.name}_${this.sourceLayerId}_${this.outputLayerId}_flow`,
-						sourceLayerId: this.sourceLayerId,
-						outputLayerId: SharedOutputLayers.OVERLAY,
-						tags: [AdlibTags.ADLIB_FLOW_PRODUCER],
-						content: _.clone(this.content)
-					}
-				})
-			)
-		} else {
-			adlibPieces.push(
-				literal<IBlueprintAdLibPiece>({
-					_rank: this.rank || 0,
-					externalId: this.partId ?? '',
-					name: this.name,
-					uniquenessId: `gfx_${this.name}_${this.sourceLayerId}_${this.outputLayerId}_flow`,
-					sourceLayerId: this.sourceLayerId,
-					outputLayerId: this.outputLayerId,
-					tags: [AdlibTags.ADLIB_FLOW_PRODUCER],
-					...(IsTargetingTLF(this.engine) || (this.parsedCue.end && this.parsedCue.end.infiniteMode)
-						? {}
-						: {
-								expectedDuration:
-									CreateTimingGraphic(this.config, this.parsedCue).duration || GetDefaultOut(this.config)
-						  }),
-					lifespan: GetInfiniteModeForGraphic(this.engine, this.config, this.parsedCue, this.isStickyIdent),
-					metaData: literal<PieceMetaData>({
-						sisyfosPersistMetaData: {
-							sisyfosLayers: []
-						}
-					}),
-					content: _.clone(this.content)
-				})
-			)
-		}
+		)
 	}
 
 	public createPiece(pieces: IBlueprintPiece[]): void {
@@ -186,58 +109,21 @@ export class InternalGraphic {
 				? { enable: { start: 0 } }
 				: {
 						enable: {
-							...CreateTimingGraphic(this.config, this.parsedCue, !this.isStickyIdent)
+							...CreateTimingGraphic(this.config, this.parsedCue)
 						}
 				  }),
 			outputLayerId: this.outputLayerId,
 			sourceLayerId: this.sourceLayerId,
-			lifespan: GetInfiniteModeForGraphic(this.engine, this.config, this.parsedCue, this.isStickyIdent),
+			lifespan: GetPieceLifespanForGraphic(this.engine, this.config, this.parsedCue),
 			metaData: literal<PieceMetaData>({
 				sisyfosPersistMetaData: {
 					sisyfosLayers: []
-				}
+				},
+				belongsToRemotePart: this.partDefinition?.type === PartType.REMOTE
 			}),
 			content: _.clone(this.content)
 		})
 		pieces.push(piece)
-
-		if (
-			this.sourceLayerId === SharedSourceLayers.PgmGraphicsIdentPersistent &&
-			(piece.lifespan === PieceLifespan.OutOnSegmentEnd || piece.lifespan === PieceLifespan.OutOnShowStyleEnd) &&
-			this.isStickyIdent
-		) {
-			// Special case for the ident. We want it to continue to exist in case the Live gets shown again, but we dont want the continuation showing in the ui.
-			// So we create the normal object on a hidden layer, and then clone it on another layer without content for the ui
-			pieces.push(this.createIndicatorPieceForIdentPersistent(piece))
-		}
-	}
-
-	public createIndicatorPieceForIdentPersistent(piece: IBlueprintPiece): IBlueprintPiece {
-		return literal<IBlueprintPiece>({
-			...piece,
-			enable: { ...CreateTimingGraphic(this.config, this.parsedCue, true) }, // Allow default out for visual representation
-			sourceLayerId: SharedSourceLayers.PgmGraphicsIdent,
-			lifespan: PieceLifespan.WithinPart,
-			metaData: literal<PieceMetaData>({
-				sisyfosPersistMetaData: {
-					sisyfosLayers: []
-				}
-			}),
-			content: {
-				timelineObjects: [
-					literal<TSR.TimelineObjAbstractAny>({
-						id: '',
-						enable: {
-							while: '1'
-						},
-						layer: AbstractLLayer.IdentMarker,
-						content: {
-							deviceType: TSR.DeviceType.ABSTRACT
-						}
-					})
-				]
-			}
-		})
 	}
 
 	private getInternalGraphicContent(): IBlueprintPiece['content'] {
@@ -246,7 +132,6 @@ export class InternalGraphic {
 					this.config,
 					this.engine,
 					this.parsedCue,
-					this.isStickyIdent,
 					this.partDefinition,
 					this.mappedTemplate,
 					!!this.adlib
@@ -255,7 +140,6 @@ export class InternalGraphic {
 					this.config,
 					this.engine,
 					this.parsedCue,
-					this.isStickyIdent,
 					this.partDefinition,
 					this.mappedTemplate,
 					!!this.adlib

--- a/src/tv2-common/helpers/graphics/caspar/index.ts
+++ b/src/tv2-common/helpers/graphics/caspar/index.ts
@@ -32,21 +32,12 @@ export function GetInternalGraphicContentCaspar(
 	config: TV2BlueprintConfig,
 	engine: GraphicEngine,
 	parsedCue: CueDefinitionGraphic<GraphicInternal>,
-	isIdentGraphic: boolean,
 	partDefinition: PartDefinition | undefined,
 	mappedTemplate: string,
 	adlib: boolean
 ): IBlueprintPiece['content'] {
 	return {
-		timelineObjects: CasparOverlayTimeline(
-			config,
-			engine,
-			parsedCue,
-			isIdentGraphic,
-			partDefinition,
-			mappedTemplate,
-			adlib
-		)
+		timelineObjects: CasparOverlayTimeline(config, engine, parsedCue, partDefinition, mappedTemplate, adlib)
 	}
 }
 
@@ -116,7 +107,6 @@ function CasparOverlayTimeline(
 	config: TV2BlueprintConfig,
 	engine: GraphicEngine,
 	parsedCue: CueDefinitionGraphic<GraphicInternal>,
-	isIdentGrafik: boolean,
 	partDefinition: PartDefinition | undefined,
 	mappedTemplate: string,
 	adlib: boolean
@@ -124,7 +114,7 @@ function CasparOverlayTimeline(
 	return [
 		literal<TSR.TimelineObjCCGTemplate>({
 			id: '',
-			enable: GetEnableForGraphic(config, engine, parsedCue, isIdentGrafik, partDefinition, adlib),
+			enable: GetEnableForGraphic(config, engine, parsedCue, partDefinition, adlib),
 			priority: 1,
 			layer: GetTimelineLayerForGraphic(config, mappedTemplate),
 			content: CreateHTMLRendererContent(config, mappedTemplate, { ...parsedCue.graphic.textFields })

--- a/src/tv2-common/helpers/graphics/caspar/index.ts
+++ b/src/tv2-common/helpers/graphics/caspar/index.ts
@@ -47,7 +47,7 @@ export function GetPilotGraphicContentCaspar(
 	parsedCue: CueDefinitionGraphic<GraphicPilot>,
 	settings: CasparPilotGeneratorSettings,
 	engine: GraphicEngine
-) {
+): WithTimeline<GraphicsContent> {
 	const graphicFolder = config.studio.GraphicFolder ? `${config.studio.GraphicFolder}\\` : ''
 	const fileName = JoinAssetToFolder(config.studio.GraphicFolder, parsedCue.graphic.name)
 	const templateData = {
@@ -65,7 +65,7 @@ export function GetPilotGraphicContentCaspar(
 			}
 		}
 	}
-	return literal<WithTimeline<GraphicsContent>>({
+	return {
 		fileName,
 		path: JoinAssetToNetworkPath(
 			config.studio.GraphicNetworkBasePath,
@@ -100,7 +100,7 @@ export function GetPilotGraphicContentCaspar(
 			}),
 			...(IsTargetingFull(engine) ? settings.createPilotTimelineForStudio(config, context) : [])
 		]
-	})
+	}
 }
 
 function CasparOverlayTimeline(

--- a/src/tv2-common/helpers/graphics/design/index.ts
+++ b/src/tv2-common/helpers/graphics/design/index.ts
@@ -29,41 +29,37 @@ export function EvaluateDesignBase(
 	}
 
 	if (adlib) {
-		adlibPieces.push(
-			literal<IBlueprintAdLibPiece>({
-				_rank: rank || 0,
-				externalId: partId,
-				name: parsedCue.design,
-				outputLayerId: SharedOutputLayers.SEC,
-				sourceLayerId: SharedSourceLayers.PgmDesign,
-				lifespan: PieceLifespan.OutOnShowStyleEnd,
-				content: literal<WithTimeline<GraphicsContent>>({
-					fileName: parsedCue.design,
-					path: parsedCue.design,
-					ignoreMediaObjectStatus: true,
-					timelineObjects: designTimeline(config, parsedCue)
-				})
+		adlibPieces.push({
+			_rank: rank || 0,
+			externalId: partId,
+			name: parsedCue.design,
+			outputLayerId: SharedOutputLayers.SEC,
+			sourceLayerId: SharedSourceLayers.PgmDesign,
+			lifespan: PieceLifespan.OutOnShowStyleEnd,
+			content: literal<WithTimeline<GraphicsContent>>({
+				fileName: parsedCue.design,
+				path: parsedCue.design,
+				ignoreMediaObjectStatus: true,
+				timelineObjects: designTimeline(config, parsedCue)
 			})
-		)
+		})
 	} else {
-		pieces.push(
-			literal<IBlueprintPiece>({
-				externalId: partId,
-				name: parsedCue.design,
-				enable: {
-					start
-				},
-				outputLayerId: SharedOutputLayers.SEC,
-				sourceLayerId: SharedSourceLayers.PgmDesign,
-				lifespan: PieceLifespan.OutOnShowStyleEnd,
-				content: literal<WithTimeline<GraphicsContent>>({
-					fileName: parsedCue.design,
-					path: parsedCue.design,
-					ignoreMediaObjectStatus: true,
-					timelineObjects: designTimeline(config, parsedCue)
-				})
+		pieces.push({
+			externalId: partId,
+			name: parsedCue.design,
+			enable: {
+				start
+			},
+			outputLayerId: SharedOutputLayers.SEC,
+			sourceLayerId: SharedSourceLayers.PgmDesign,
+			lifespan: PieceLifespan.OutOnShowStyleEnd,
+			content: literal<WithTimeline<GraphicsContent>>({
+				fileName: parsedCue.design,
+				path: parsedCue.design,
+				ignoreMediaObjectStatus: true,
+				timelineObjects: designTimeline(config, parsedCue)
 			})
-		)
+		})
 	}
 }
 

--- a/src/tv2-common/helpers/graphics/internal/index.ts
+++ b/src/tv2-common/helpers/graphics/internal/index.ts
@@ -1,5 +1,12 @@
 import { IBlueprintAdLibPiece, IBlueprintPiece, IShowStyleUserContext } from '@tv2media/blueprints-integration'
-import { Adlib, CueDefinitionGraphic, GraphicInternal, PartDefinition, TV2BlueprintConfig } from 'tv2-common'
+import {
+	Adlib,
+	CueDefinitionGraphic,
+	GraphicInternal,
+	IsTargetingOVL,
+	PartDefinition,
+	TV2BlueprintConfig
+} from 'tv2-common'
 import { InternalGraphic } from '../InternalGraphic'
 
 export function CreateInternalGraphic(
@@ -20,9 +27,11 @@ export function CreateInternalGraphic(
 	}
 
 	if (adlib) {
-		internalGraphic.createCommentatorAdlib(adlibPieces)
-		internalGraphic.createAdlib(adlibPieces)
+		if (IsTargetingOVL(parsedCue.target)) {
+			adlibPieces.push(internalGraphic.createCommentatorAdlib())
+		}
+		adlibPieces.push(internalGraphic.createAdlib())
 	} else {
-		internalGraphic.createPiece(pieces)
+		pieces.push(internalGraphic.createPiece())
 	}
 }

--- a/src/tv2-common/helpers/graphics/internal/index.ts
+++ b/src/tv2-common/helpers/graphics/internal/index.ts
@@ -1,9 +1,4 @@
-import {
-	IBlueprintActionManifest,
-	IBlueprintAdLibPiece,
-	IBlueprintPiece,
-	IShowStyleUserContext
-} from '@tv2media/blueprints-integration'
+import { IBlueprintAdLibPiece, IBlueprintPiece, IShowStyleUserContext } from '@tv2media/blueprints-integration'
 import { Adlib, CueDefinitionGraphic, GraphicInternal, PartDefinition, TV2BlueprintConfig } from 'tv2-common'
 import { InternalGraphic } from '../InternalGraphic'
 
@@ -12,7 +7,6 @@ export function CreateInternalGraphic(
 	context: IShowStyleUserContext,
 	pieces: IBlueprintPiece[],
 	adlibPieces: IBlueprintAdLibPiece[],
-	actions: IBlueprintActionManifest[],
 	partId: string,
 	parsedCue: CueDefinitionGraphic<GraphicInternal>,
 	partDefinition: PartDefinition,
@@ -26,8 +20,8 @@ export function CreateInternalGraphic(
 	}
 
 	if (adlib) {
-		internalGraphic.createAdlibTargetingOVL(context, actions, adlibPieces)
-		internalGraphic.createAdlib(context, actions, adlibPieces)
+		internalGraphic.createCommentatorAdlib(adlibPieces)
+		internalGraphic.createAdlib(adlibPieces)
 	} else {
 		internalGraphic.createPiece(pieces)
 	}

--- a/src/tv2-common/helpers/graphics/layers.ts
+++ b/src/tv2-common/helpers/graphics/layers.ts
@@ -1,7 +1,7 @@
 import { TV2BlueprintConfig } from 'tv2-common'
 import { SharedGraphicLLayer, SharedSourceLayers } from 'tv2-constants'
 
-export function GetSourceLayerForGraphic(config: TV2BlueprintConfig, name: string, isStickyIdent?: boolean) {
+export function GetSourceLayerForGraphic(config: TV2BlueprintConfig, name: string) {
 	const conf = config.showStyle.GFXTemplates
 		? config.showStyle.GFXTemplates.find(gfk => gfk.VizTemplate.toString() === name)
 		: undefined
@@ -19,10 +19,6 @@ export function GetSourceLayerForGraphic(config: TV2BlueprintConfig, name: strin
 			}
 			return SharedSourceLayers.PgmGraphicsHeadline
 		case SharedSourceLayers.PgmGraphicsIdent:
-			if (isStickyIdent) {
-				return SharedSourceLayers.PgmGraphicsIdentPersistent
-			}
-
 			return SharedSourceLayers.PgmGraphicsIdent
 		case SharedSourceLayers.PgmGraphicsLower:
 			return SharedSourceLayers.PgmGraphicsLower

--- a/src/tv2-common/helpers/graphics/name.ts
+++ b/src/tv2-common/helpers/graphics/name.ts
@@ -34,13 +34,11 @@ export function GetFullGraphicTemplateNameFromCue(
 }
 
 export function GetFullGrafikTemplateName(config: TV2BlueprintConfig, iNewsTempalateName: string): string {
-	if (config.showStyle.GFXTemplates) {
-		const template = config.showStyle.GFXTemplates.find(templ =>
-			templ.INewsName ? templ.INewsName.toString().toUpperCase() === iNewsTempalateName.toUpperCase() : false
-		)
-		if (template && template.VizTemplate.toString().length) {
-			return template.VizTemplate.toString()
-		}
+	const template = config.showStyle.GFXTemplates.find(templ =>
+		templ.INewsName ? templ.INewsName.toString().toUpperCase() === iNewsTempalateName.toUpperCase() : false
+	)
+	if (template && template.VizTemplate.toString().length) {
+		return template.VizTemplate.toString()
 	}
 
 	// This means unconfigured templates will still be supported, with default out.

--- a/src/tv2-common/helpers/graphics/pilot/index.ts
+++ b/src/tv2-common/helpers/graphics/pilot/index.ts
@@ -15,7 +15,7 @@ import {
 	CueDefinitionGraphic,
 	generateExternalId,
 	GetFullGraphicTemplateNameFromCue,
-	GetInfiniteModeForGraphic,
+	GetPieceLifespanForGraphic,
 	GetPilotGraphicContentViz,
 	GetTagForFull,
 	GetTagForFullNext,
@@ -160,7 +160,7 @@ export class PilotGraphicGenerator {
 			outputLayerId: this.getOutputLayer(),
 			sourceLayerId: this.getSourceLayer(),
 			prerollDuration: this.getPrerollDuration(),
-			lifespan: GetInfiniteModeForGraphic(this.engine, this.config, this.parsedCue),
+			lifespan: GetPieceLifespanForGraphic(this.engine, this.config, this.parsedCue),
 			metaData: literal<PieceMetaData>({
 				sisyfosPersistMetaData: {
 					sisyfosLayers: []

--- a/src/tv2-common/helpers/graphics/pilot/index.ts
+++ b/src/tv2-common/helpers/graphics/pilot/index.ts
@@ -13,6 +13,7 @@ import {
 	Adlib,
 	CreateTimingGraphic,
 	CueDefinitionGraphic,
+	FullPieceMetaData,
 	generateExternalId,
 	GetFullGraphicTemplateNameFromCue,
 	GetPieceLifespanForGraphic,
@@ -111,18 +112,18 @@ export class PilotGraphicGenerator {
 		this.segmentExternalId = graphicProps.segmentExternalId
 	}
 
-	public createPilotAdLibAction() {
+	public createPilotAdLibAction(): IBlueprintActionManifest {
 		const name = GraphicDisplayName(this.config, this.parsedCue)
 		const sourceLayerId = this.getSourceLayer()
 		const outputLayerId = this.getOutputLayer()
 
-		const userData = literal<ActionSelectFullGrafik>({
+		const userData: ActionSelectFullGrafik = {
 			type: AdlibActionType.SELECT_FULL_GRAFIK,
 			name: this.parsedCue.graphic.name,
 			vcpid: this.parsedCue.graphic.vcpid,
 			segmentExternalId: this.segmentExternalId
-		})
-		return literal<IBlueprintActionManifest>({
+		}
+		return {
 			externalId: generateExternalId(this.context, userData),
 			actionId: AdlibActionType.SELECT_FULL_GRAFIK,
 			userData,
@@ -143,11 +144,11 @@ export class PilotGraphicGenerator {
 				currentPieceTags: [GetTagForFull(this.segmentExternalId, this.parsedCue.graphic.vcpid)],
 				nextPieceTags: [GetTagForFullNext(this.segmentExternalId, this.parsedCue.graphic.vcpid)]
 			}
-		})
+		}
 	}
 
-	public createPiece(): IBlueprintPiece {
-		return literal<IBlueprintPiece>({
+	public createPiece(): IBlueprintPiece<PieceMetaData> {
+		return {
 			externalId: this.partId,
 			name: GraphicDisplayName(this.config, this.parsedCue),
 			...(IsTargetingFull(this.engine) || IsTargetingWall(this.engine)
@@ -161,16 +162,16 @@ export class PilotGraphicGenerator {
 			sourceLayerId: this.getSourceLayer(),
 			prerollDuration: this.getPrerollDuration(),
 			lifespan: GetPieceLifespanForGraphic(this.engine, this.config, this.parsedCue),
-			metaData: literal<PieceMetaData>({
+			metaData: {
 				sisyfosPersistMetaData: {
 					sisyfosLayers: []
 				}
-			}),
+			},
 			content: this.createContent(),
 			tags: IsTargetingFull(this.engine)
 				? [GetTagForFull(this.segmentExternalId, this.parsedCue.graphic.vcpid), TallyTags.FULL_IS_LIVE]
 				: []
-		})
+		}
 	}
 
 	public createAdlibPiece(rank?: number): IBlueprintAdLibPiece {
@@ -182,7 +183,7 @@ export class PilotGraphicGenerator {
 		}
 	}
 
-	public createFullDataStore(): IBlueprintPiece {
+	public createFullDataStore(): IBlueprintPiece<FullPieceMetaData> {
 		const content = this.createContent()
 		content.timelineObjects = content.timelineObjects.filter(
 			o =>
@@ -191,7 +192,7 @@ export class PilotGraphicGenerator {
 				o.content.deviceType !== TSR.DeviceType.VIZMSE &&
 				o.content.deviceType !== TSR.DeviceType.CASPARCG
 		)
-		return literal<IBlueprintPiece>({
+		return {
 			externalId: this.partId,
 			name: GraphicDisplayName(this.config, this.parsedCue),
 			enable: {
@@ -201,19 +202,19 @@ export class PilotGraphicGenerator {
 			sourceLayerId: SharedSourceLayers.SelectedAdlibGraphicsFull,
 			lifespan: PieceLifespan.OutOnSegmentEnd,
 			metaData: {
-				userData: literal<ActionSelectFullGrafik>({
+				userData: {
 					type: AdlibActionType.SELECT_FULL_GRAFIK,
 					name: this.parsedCue.graphic.name,
 					vcpid: this.parsedCue.graphic.vcpid,
 					segmentExternalId: this.segmentExternalId
-				}),
+				},
 				sisyfosPersistMetaData: literal<SisyfosPersistMetaData>({
 					sisyfosLayers: []
 				})
 			},
 			content,
 			tags: [GetTagForFullNext(this.segmentExternalId, this.parsedCue.graphic.vcpid)]
-		})
+		}
 	}
 
 	private createContent(): WithTimeline<GraphicsContent> {

--- a/src/tv2-common/helpers/graphics/timing.ts
+++ b/src/tv2-common/helpers/graphics/timing.ts
@@ -10,26 +10,27 @@ import {
 	LifeSpan,
 	PartDefinition,
 	PartToParentClass,
+	TableConfigItemGFXTemplates,
 	TV2BlueprintConfig
 } from 'tv2-common'
-import { ControlClasses, GraphicEngine } from 'tv2-constants'
+import { GraphicEngine } from 'tv2-constants'
 import { GetFullGraphicTemplateNameFromCue, IsTargetingTLF, IsTargetingWall } from '.'
 
-export function GetInfiniteModeForGraphic(
+export function GetPieceLifespanForGraphic(
 	engine: GraphicEngine,
 	config: TV2BlueprintConfig,
-	parsedCue: CueDefinitionGraphic<GraphicInternalOrPilot>,
-	isStickyIdent?: boolean
+	parsedCue: CueDefinitionGraphic<GraphicInternalOrPilot>
 ): PieceLifespan {
-	return IsTargetingWall(engine)
-		? PieceLifespan.OutOnShowStyleEnd
-		: IsTargetingTLF(engine)
-		? PieceLifespan.WithinPart
-		: isStickyIdent
-		? PieceLifespan.OutOnSegmentEnd
-		: parsedCue.end && parsedCue.end.infiniteMode
-		? LifeSpan(parsedCue.end.infiniteMode, PieceLifespan.WithinPart)
-		: FindInfiniteModeFromConfig(config, parsedCue)
+	if (IsTargetingWall(engine)) {
+		return PieceLifespan.OutOnShowStyleEnd
+	}
+	if (IsTargetingTLF(engine)) {
+		return PieceLifespan.WithinPart
+	}
+	if (parsedCue.end && parsedCue.end.infiniteMode) {
+		return LifeSpan(parsedCue.end.infiniteMode, PieceLifespan.WithinPart)
+	}
+	return FindInfiniteModeFromConfig(config, parsedCue)
 }
 
 export function FindInfiniteModeFromConfig(
@@ -68,46 +69,27 @@ export function FindInfiniteModeFromConfig(
 
 export function GetGraphicDuration(
 	config: TV2BlueprintConfig,
-	cue: CueDefinitionGraphic<GraphicInternalOrPilot>,
-	defaultTime: boolean
+	cue: CueDefinitionGraphic<GraphicInternalOrPilot>
 ): number | undefined {
 	if (config.showStyle.GFXTemplates) {
-		if (GraphicIsInternal(cue)) {
-			const template = config.showStyle.GFXTemplates.find(templ =>
-				templ.INewsName ? templ.INewsName.toString().toUpperCase() === cue.graphic.template.toUpperCase() : false
-			)
-			if (template) {
-				if (template.OutType && !template.OutType.toString().match(/default/i)) {
-					return undefined
-				}
-			}
-		} else if (GraphicIsPilot(cue)) {
-			const template = config.showStyle.GFXTemplates.find(templ =>
-				templ.INewsName
-					? templ.INewsName.toString().toUpperCase() === cue.graphic.vcpid.toString().toUpperCase()
-					: false
-			)
-			if (template) {
-				if (template.OutType && !template.OutType.toString().match(/default/i)) {
-					return undefined
-				}
-			}
+		const template = findGFXTemplate(config, cue)
+		if (template && template.OutType && !template.OutType.toString().match(/default/i)) {
+			return undefined
 		}
 	}
 
-	return defaultTime ? GetDefaultOut(config) : undefined
+	return GetDefaultOut(config)
 }
 
 export function CreateTimingGraphic(
 	config: TV2BlueprintConfig,
-	cue: CueDefinitionGraphic<GraphicInternalOrPilot>,
-	defaultTime: boolean = true
+	cue: CueDefinitionGraphic<GraphicInternalOrPilot>
 ): { start: number; duration?: number } {
 	const ret: { start: number; duration?: number } = { start: 0, duration: 0 }
 	const start = cue.start ? CalculateTime(cue.start) : 0
 	start !== undefined ? (ret.start = start) : (ret.start = 0)
 
-	const duration = GetGraphicDuration(config, cue, defaultTime)
+	const duration = GetGraphicDuration(config, cue)
 	const end = cue.end
 		? cue.end.infiniteMode
 			? undefined
@@ -126,11 +108,27 @@ export function GetEnableForWall(): TSR.TSRTimelineObj['enable'] {
 	}
 }
 
+export function findGFXTemplate(
+	config: TV2BlueprintConfig,
+	cue: CueDefinitionGraphic<GraphicInternalOrPilot>
+): TableConfigItemGFXTemplates | undefined {
+	let graphicId: string | undefined
+	if (GraphicIsInternal(cue)) {
+		graphicId = cue.graphic.template
+	} else if (GraphicIsPilot(cue)) {
+		graphicId = cue.graphic.vcpid.toString()
+	}
+	if (graphicId === undefined) {
+		return undefined
+	}
+	return config.showStyle.GFXTemplates.find(templ =>
+		templ.INewsName ? templ.INewsName.toString().toUpperCase() === graphicId?.toUpperCase() : false
+	)
+}
 export function GetEnableForGraphic(
 	config: TV2BlueprintConfig,
 	engine: GraphicEngine,
 	cue: CueDefinitionGraphic<GraphicInternalOrPilot>,
-	isStickyIdent: boolean,
 	partDefinition?: PartDefinition,
 	adlib?: boolean
 ): TSR.TSRTimelineObj['enable'] {
@@ -139,18 +137,11 @@ export function GetEnableForGraphic(
 	}
 
 	if (
-		((cue.end && cue.end.infiniteMode && cue.end.infiniteMode === 'B') ||
-			GetInfiniteModeForGraphic(engine, config, cue, isStickyIdent) === PieceLifespan.OutOnSegmentEnd) &&
 		partDefinition &&
+		(endsOnPartEnd(config, cue) || GetPieceLifespanForGraphic(engine, config, cue) === PieceLifespan.OutOnSegmentEnd) &&
 		!adlib
 	) {
 		return { while: `.${PartToParentClass('studio0', partDefinition)} & !.adlib_deparent & !.full` }
-	}
-
-	if (isStickyIdent) {
-		return {
-			while: `.${ControlClasses.ShowIdentGraphic} & !.full`
-		}
 	}
 
 	const timing = CreateTimingEnable(cue, GetDefaultOut(config))
@@ -168,4 +159,9 @@ export function GetEnableForGraphic(
 			start: 0
 		}
 	}
+}
+function endsOnPartEnd(config: TV2BlueprintConfig, cue: CueDefinitionGraphic<GraphicInternalOrPilot>) {
+	return (
+		(cue.end && cue.end.infiniteMode && cue.end.infiniteMode === 'B') || findGFXTemplate(config, cue)?.OutType === 'B'
+	)
 }

--- a/src/tv2-common/helpers/graphics/timing.ts
+++ b/src/tv2-common/helpers/graphics/timing.ts
@@ -37,34 +37,30 @@ export function FindInfiniteModeFromConfig(
 	config: TV2BlueprintConfig,
 	parsedCue: CueDefinitionGraphic<GraphicInternalOrPilot>
 ): PieceLifespan {
-	if (config.showStyle.GFXTemplates) {
-		const template = GetFullGraphicTemplateNameFromCue(config, parsedCue)
-		const iNewsName = GraphicIsInternal(parsedCue) ? parsedCue.graphic.template : undefined
-		const conf = config.showStyle.GFXTemplates.find(cnf =>
-			cnf.VizTemplate
-				? cnf.VizTemplate.toString().toUpperCase() === template.toUpperCase() &&
-				  (iNewsName ? cnf.INewsName.toUpperCase() === iNewsName.toUpperCase() : true)
-				: false
-		)
+	const template = GetFullGraphicTemplateNameFromCue(config, parsedCue)
+	const iNewsName = GraphicIsInternal(parsedCue) ? parsedCue.graphic.template : undefined
+	const conf = config.showStyle.GFXTemplates.find(cnf =>
+		cnf.VizTemplate
+			? cnf.VizTemplate.toString().toUpperCase() === template.toUpperCase() &&
+			  (iNewsName ? cnf.INewsName.toUpperCase() === iNewsName.toUpperCase() : true)
+			: false
+	)
 
-		if (!conf) {
-			return PieceLifespan.WithinPart
-		}
-
-		if (!conf.OutType || !conf.OutType.toString().length) {
-			return PieceLifespan.WithinPart
-		}
-
-		const type = conf.OutType.toString().toUpperCase()
-
-		if (type !== 'B' && type !== 'S' && type !== 'O') {
-			return PieceLifespan.WithinPart
-		}
-
-		return LifeSpan(type, PieceLifespan.WithinPart)
+	if (!conf) {
+		return PieceLifespan.WithinPart
 	}
 
-	return PieceLifespan.WithinPart
+	if (!conf.OutType || !conf.OutType.toString().length) {
+		return PieceLifespan.WithinPart
+	}
+
+	const type = conf.OutType.toString().toUpperCase()
+
+	if (type !== 'B' && type !== 'S' && type !== 'O') {
+		return PieceLifespan.WithinPart
+	}
+
+	return LifeSpan(type, PieceLifespan.WithinPart)
 }
 
 export function GetGraphicDuration(

--- a/src/tv2-common/helpers/graphics/viz/index.ts
+++ b/src/tv2-common/helpers/graphics/viz/index.ts
@@ -36,7 +36,6 @@ export function GetInternalGraphicContentVIZ(
 	config: TV2BlueprintConfig,
 	engine: GraphicEngine,
 	parsedCue: CueDefinitionGraphic<GraphicInternal>,
-	isIdentGraphic: boolean,
 	partDefinition: PartDefinition | undefined,
 	mappedTemplate: string,
 	adlib: boolean
@@ -48,7 +47,7 @@ export function GetInternalGraphicContentVIZ(
 		timelineObjects: literal<TSR.TSRTimelineObj[]>([
 			literal<TSR.TimelineObjVIZMSEElementInternal>({
 				id: '',
-				enable: GetEnableForGraphic(config, engine, parsedCue, isIdentGraphic, partDefinition, adlib),
+				enable: GetEnableForGraphic(config, engine, parsedCue, partDefinition, adlib),
 				priority: 1,
 				layer: GetTimelineLayerForGraphic(config, GetFullGraphicTemplateNameFromCue(config, parsedCue)),
 				content: {
@@ -82,7 +81,7 @@ export function GetPilotGraphicContentViz(
 				id: '',
 				enable:
 					IsTargetingOVL(engine) || IsTargetingWall(engine)
-						? GetEnableForGraphic(config, engine, parsedCue, false, undefined, !!adlib)
+						? GetEnableForGraphic(config, engine, parsedCue, undefined, !!adlib)
 						: {
 								start: 0
 						  },

--- a/src/tv2-common/helpers/graphics/viz/index.ts
+++ b/src/tv2-common/helpers/graphics/viz/index.ts
@@ -1,10 +1,4 @@
-import {
-	GraphicsContent,
-	IBlueprintPiece,
-	IShowStyleUserContext,
-	TSR,
-	WithTimeline
-} from '@tv2media/blueprints-integration'
+import { GraphicsContent, IShowStyleUserContext, TSR, WithTimeline } from '@tv2media/blueprints-integration'
 import {
 	Adlib,
 	CueDefinitionGraphic,
@@ -39,8 +33,8 @@ export function GetInternalGraphicContentVIZ(
 	partDefinition: PartDefinition | undefined,
 	mappedTemplate: string,
 	adlib: boolean
-): IBlueprintPiece['content'] {
-	return literal<WithTimeline<GraphicsContent>>({
+): WithTimeline<GraphicsContent> {
+	return {
 		fileName: parsedCue.graphic.template,
 		path: parsedCue.graphic.template,
 		ignoreMediaObjectStatus: true,
@@ -62,7 +56,7 @@ export function GetInternalGraphicContentVIZ(
 			// Assume DSK is off by default (config table)
 			...EnableDSK(config, 'OVL')
 		])
-	})
+	}
 }
 
 export function GetPilotGraphicContentViz(
@@ -73,7 +67,7 @@ export function GetPilotGraphicContentViz(
 	engine: GraphicEngine,
 	adlib?: Adlib
 ): WithTimeline<GraphicsContent> {
-	return literal<WithTimeline<GraphicsContent>>({
+	return {
 		fileName: 'PILOT_' + parsedCue.graphic.vcpid.toString(),
 		path: parsedCue.graphic.vcpid.toString(),
 		timelineObjects: [
@@ -112,5 +106,5 @@ export function GetPilotGraphicContentViz(
 			}),
 			...(IsTargetingFull(engine) ? settings.createPilotTimelineForStudio(config, context, !!adlib) : [])
 		]
-	})
+	}
 }

--- a/src/tv2-common/helpers/rundownAdLibActions.ts
+++ b/src/tv2-common/helpers/rundownAdLibActions.ts
@@ -25,11 +25,11 @@ export function GetTransitionAdLibActions<
 	if (config.showStyle.ShowstyleTransition && config.showStyle.ShowstyleTransition.length) {
 		const defaultTransition = config.showStyle.ShowstyleTransition
 
-		const userData = literal<ActionTakeWithTransition>({
+		const userData: ActionTakeWithTransition = {
 			type: AdlibActionType.TAKE_WITH_TRANSITION,
 			variant: ParseTransitionString(defaultTransition),
 			takeNow: true
-		})
+		}
 
 		const jingleConfig = config.showStyle.BreakerConfig.find(
 			j => j.BreakerName === config.showStyle.ShowstyleTransition
@@ -63,11 +63,11 @@ export function GetTransitionAdLibActions<
 	if (config.showStyle.Transitions) {
 		config.showStyle.Transitions.forEach((transition, i) => {
 			if (transition.Transition && transition.Transition.length) {
-				const userData = literal<ActionTakeWithTransition>({
+				const userData: ActionTakeWithTransition = {
 					type: AdlibActionType.TAKE_WITH_TRANSITION,
 					variant: ParseTransitionString(transition.Transition),
 					takeNow: true
-				})
+				}
 
 				const jingleConfig = config.showStyle.BreakerConfig.find(j => j.BreakerName === transition.Transition)
 				let alphaAtStart: number | undefined
@@ -141,7 +141,7 @@ function makeTransitionAction(
 	const tag = GetTagForTransition(userData.variant)
 	const isEffekt = !!label.match(/^\d+$/)
 
-	return literal<IBlueprintActionManifest>({
+	return {
 		externalId: `${JSON.stringify(userData)}_${AdlibActionType.TAKE_WITH_TRANSITION}_${rank}`,
 		actionId: AdlibActionType.TAKE_WITH_TRANSITION,
 		userData,
@@ -159,5 +159,5 @@ function makeTransitionAction(
 					? {}
 					: CreateJingleExpectedMedia(config, jingle, alphaAtStart ?? 0, duration ?? 0, alphaAtEnd ?? 0)
 		}
-	})
+	}
 }

--- a/src/tv2-common/hotkeys/hotkey-defaults.ts
+++ b/src/tv2-common/hotkeys/hotkey-defaults.ts
@@ -36,7 +36,6 @@ export const defaultHotkeys: TV2Hotkeys = {
 			{
 				sourceLayers: [
 					SharedSourceLayers.PgmGraphicsIdent,
-					SharedSourceLayers.PgmGraphicsIdentPersistent,
 					SharedSourceLayers.PgmGraphicsTop,
 					SharedSourceLayers.PgmGraphicsLower,
 					SharedSourceLayers.PgmGraphicsHeadline,
@@ -48,7 +47,7 @@ export const defaultHotkeys: TV2Hotkeys = {
 				name: 'overlay ALT UD'
 			},
 			{
-				sourceLayers: [SharedSourceLayers.PgmGraphicsIdent, SharedSourceLayers.PgmGraphicsIdentPersistent],
+				sourceLayers: [SharedSourceLayers.PgmGraphicsIdent],
 				key: 'Ctrl+Shift+KeyA',
 				name: 'ovl: ident OUT'
 			},

--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -192,7 +192,13 @@ export function ParseBody(
 
 	// Handle intro segments, they have special behaviour.
 	if (segmentName === 'INTRO') {
-		;((definition as unknown) as PartDefinitionIntro).type = PartType.INTRO
+		definition = {
+			...definition,
+			type: PartType.INTRO,
+			rawType: 'INTRO',
+			externalId: `${segmentId}-${definitions.length}`,
+			segmentExternalId: segmentId
+		}
 		cues.forEach(cue => {
 			if (cue !== null) {
 				const parsedCue = ParseCue(cue, config)
@@ -202,9 +208,6 @@ export function ParseBody(
 				}
 			}
 		})
-		definition.rawType = 'INTRO'
-		definition.externalId = `${segmentId}-${definitions.length}`
-		definition.segmentExternalId = segmentId
 		definitions.push(definition)
 		definition = initDefinition(fields, modified, segmentName)
 		return definitions

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -1,4 +1,4 @@
-import { GetInfiniteModeForGraphic, literal, TableConfigSchema, TV2BlueprintConfig, UnparsedCue } from 'tv2-common'
+import { GetPieceLifespanForGraphic, literal, TableConfigSchema, TV2BlueprintConfig, UnparsedCue } from 'tv2-common'
 import { CueType, GraphicEngine, PartType, SourceType } from 'tv2-constants'
 import {
 	getSourceDefinition,
@@ -996,15 +996,8 @@ export function AddParentClass(config: TV2BlueprintConfig, partDefinition: PartD
 	}
 
 	return partDefinition.cues.some(
-		c =>
-			c.type === CueType.Graphic &&
-			GraphicIsInternal(c) &&
-			GetInfiniteModeForGraphic(c.target, config, c, IsStickyIdent(c))
+		c => c.type === CueType.Graphic && GraphicIsInternal(c) && GetPieceLifespanForGraphic(c.target, config, c)
 	)
-}
-
-export function IsStickyIdent(cue: CueDefinitionGraphic<GraphicInternal>) {
-	return !!cue.graphic.template.match(/direkte/i)
 }
 
 export function UnpairedPilotToGraphic(

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -578,13 +578,13 @@ function parseAdLib(cue: string[]) {
 	}
 
 	// tslint:disable-next-line: prefer-for-of
-	for (let i = 0; i < cue.length; i++) {
-		const input = cue[i].match(/^(INP\d)+=(.+)$/i)
+	for (const element of cue) {
+		const input = element.match(/^(INP\d)+=(.+)$/i)
 		if (input && input[1] && input[2] && adlib.inputs !== undefined) {
 			adlib.inputs[input[1].toUpperCase() as keyof DVESources] = getSourceDefinition(input[2])
 		}
 
-		const bynavn = cue[i].match(/^BYNAVN=(.+)$/i)
+		const bynavn = element.match(/^BYNAVN=(.+)$/i)
 		if (bynavn) {
 			adlib.bynavn = bynavn[1].split(/\/|\\/i)
 		}

--- a/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
@@ -360,26 +360,6 @@ describe('Cue parser', () => {
 		)
 	})
 
-	test('Grafik (kg) - Inline first text field, blank time', () => {
-		const cueGrafik = ['kg bund TEXT MORETEXT', 'some@email.fakeTLD', ';x.xx']
-		const result = ParseCue(cueGrafik, config)
-		expect(result).toEqual(
-			literal<CueDefinitionGraphic<GraphicInternal>>({
-				type: CueType.Graphic,
-				target: 'OVL',
-
-				graphic: {
-					type: 'internal',
-					template: 'bund',
-					cue: 'kg',
-					textFields: ['TEXT MORETEXT', 'some@email.fakeTLD']
-				},
-				adlib: true,
-				iNewsCommand: 'kg'
-			})
-		)
-	})
-
 	test('Grafik (kg) - Multiline text fields', () => {
 		const cueGrafik = ['kg bund', 'TEXT MORETEXT', 'some@email.fakeTLD', ';0.02']
 		const result = ParseCue(cueGrafik, config)

--- a/src/tv2-common/layers/sourceLayers.ts
+++ b/src/tv2-common/layers/sourceLayers.ts
@@ -1,7 +1,6 @@
 import { ISourceLayer, SourceLayerType } from '@tv2media/blueprints-integration'
 import { ATEMModel } from '../../types/atem'
 import { GetDSKCount } from '../helpers'
-import { literal } from '../util'
 
 /**
  * Get the sourcelayer name for a given DSK.
@@ -12,7 +11,7 @@ export function SourceLayerAtemDSK(i: number): string {
 }
 
 function GetSourceLayerDefaultsForDSK(i: number): ISourceLayer {
-	return literal<ISourceLayer>({
+	return {
 		_id: SourceLayerAtemDSK(i),
 		_rank: 22,
 		name: `DSK${i + 1} off`,
@@ -27,7 +26,7 @@ function GetSourceLayerDefaultsForDSK(i: number): ISourceLayer {
 		isHidden: true,
 		allowDisable: false,
 		onPresenterScreen: false
-	})
+	}
 }
 
 export function GetDSKSourceLayerNames(atemModel: ATEMModel): string[] {

--- a/src/tv2-common/migrations/addKeepAudio.ts
+++ b/src/tv2-common/migrations/addKeepAudio.ts
@@ -1,9 +1,8 @@
 import { MigrationContextStudio, MigrationStepStudio, TableConfigItemValue } from '@tv2media/blueprints-integration'
 import * as _ from 'underscore'
-import { literal } from '../util'
 
 export function AddKeepAudio(versionStr: string, configName: string): MigrationStepStudio {
-	const res = literal<MigrationStepStudio>({
+	const res: MigrationStepStudio = {
 		id: `${versionStr}.studioConfig.addKeepAudio.${configName}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -29,7 +28,7 @@ export function AddKeepAudio(versionStr: string, configName: string): MigrationS
 				context.setConfig(configName, configVal)
 			}
 		}
-	})
+	}
 
 	return res
 }

--- a/src/tv2-common/migrations/forceSourceLayerToDefaultsBase.ts
+++ b/src/tv2-common/migrations/forceSourceLayerToDefaultsBase.ts
@@ -1,5 +1,4 @@
 import { ISourceLayer, MigrationContextShowStyle, MigrationStepShowStyle } from '@tv2media/blueprints-integration'
-import { literal } from 'tv2-common'
 import _ = require('underscore')
 
 export function forceSourceLayerToDefaultsBase(
@@ -9,7 +8,7 @@ export function forceSourceLayerToDefaultsBase(
 	layer: string,
 	overrideSteps?: string[]
 ): MigrationStepShowStyle {
-	return literal<MigrationStepShowStyle>({
+	return {
 		id: `${versionStr}.${showStyleId}.sourcelayer.defaults.${layer}.forced`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -43,5 +42,5 @@ export function forceSourceLayerToDefaultsBase(
 				context.insertSourceLayer(layer, defaultVal)
 			}
 		}
-	})
+	}
 }

--- a/src/tv2-common/migrations/hotkeys.ts
+++ b/src/tv2-common/migrations/hotkeys.ts
@@ -43,7 +43,7 @@ export function GetDefaultAdLibTriggers(
 				sourceLayers
 			)
 
-			const needsMigration = shortcutsDefaults.some(defaultShortcut => {
+			return shortcutsDefaults.some(defaultShortcut => {
 				const existingShortcut = context.getTriggeredAction(defaultShortcut._id)
 
 				if (!existingShortcut) {
@@ -52,7 +52,6 @@ export function GetDefaultAdLibTriggers(
 
 				return forceToDefaults && shortcutsAreDifferent(defaultShortcut, existingShortcut)
 			})
-			return needsMigration
 		},
 		migrate: (context: MigrationContextShowStyle) => {
 			const shortcutsDefaults = MakeAllAdLibsTriggers(
@@ -79,7 +78,7 @@ export function RemoveOldShortcuts(
 	showStyleId: string,
 	sourceLayerDefaults: ISourceLayer[]
 ): MigrationStepShowStyle {
-	return literal<MigrationStepShowStyle>({
+	return {
 		id: `${versionStr}.migrateShortcutsToAdLibTriggers.${showStyleId}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -88,15 +87,13 @@ export function RemoveOldShortcuts(
 				ISourceLayerWithHotKeys | undefined
 			>
 
-			const oldHotKeysExist = sourceLayers.some(
+			return sourceLayers.some(
 				sourceLayer =>
 					!!sourceLayer?.clearKeyboardHotkey ||
 					!!sourceLayer?.activateKeyboardHotkeys ||
 					!!sourceLayer?.activateStickyKeyboardHotkey ||
 					sourceLayer?.assignHotkeysToGlobalAdlibs !== undefined
 			)
-
-			return oldHotKeysExist
 		},
 		migrate: (context: MigrationContextShowStyle) => {
 			for (const sourceLayer of sourceLayerDefaults) {
@@ -113,5 +110,5 @@ export function RemoveOldShortcuts(
 				context.updateSourceLayer(sourceLayer._id, coreSourceLayer)
 			}
 		}
-	})
+	}
 }

--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -22,7 +22,7 @@ export * from './forceSourceLayerToDefaultsBase'
 export * from './hotkeys'
 
 export function RenameStudioConfig(versionStr: string, studio: string, from: string, to: string): MigrationStepStudio {
-	return literal<MigrationStepStudio>({
+	return {
 		id: `${versionStr}.studioConfig.rename.${from}.${studio}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -41,7 +41,7 @@ export function RenameStudioConfig(versionStr: string, studio: string, from: str
 
 			context.removeConfig(from)
 		}
-	})
+	}
 }
 
 export function renameSourceLayer(
@@ -50,7 +50,7 @@ export function renameSourceLayer(
 	from: string,
 	to: string
 ): MigrationStepShowStyle {
-	return literal<MigrationStepShowStyle>({
+	return {
 		id: `${versionStr}.renameSourceLayer.${studioId}.${from}.${to}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -69,10 +69,10 @@ export function renameSourceLayer(
 			context.insertSourceLayer(to, existing)
 			context.removeSourceLayer(from)
 		}
-	})
+	}
 }
 
-export function removeSourceLayer(versionStr: string, studioId: string, layer: string) {
+export function removeSourceLayer(versionStr: string, studioId: string, layer: string): MigrationStepShowStyle {
 	return literal<MigrationStepShowStyle>({
 		id: `${versionStr}.removeSourceLayer.${studioId}.${layer}`,
 		version: versionStr,
@@ -94,8 +94,12 @@ export function removeSourceLayer(versionStr: string, studioId: string, layer: s
 	})
 }
 
-export function AddGraphicToGFXTable(versionStr: string, studio: string, config: TableConfigItemGFXTemplates) {
-	return literal<MigrationStepShowStyle>({
+export function AddGraphicToGFXTable(
+	versionStr: string,
+	studio: string,
+	config: TableConfigItemGFXTemplates
+): MigrationStepShowStyle {
+	return {
 		id: `${versionStr}.gfxConfig.add${config.INewsName}.${studio}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -118,7 +122,7 @@ export function AddGraphicToGFXTable(versionStr: string, studio: string, config:
 
 			context.setBaseConfig('GFXTemplates', (existing as unknown) as ConfigItemValue)
 		}
-	})
+	}
 }
 
 export function addSourceToSourcesConfig(
@@ -126,8 +130,8 @@ export function addSourceToSourcesConfig(
 	studio: string,
 	configId: string,
 	source: TableConfigItemSourceMappingWithSisyfos
-) {
-	return literal<MigrationStepStudio>({
+): MigrationStepStudio {
+	return {
 		id: `${versionStr}.studioConfig.addReplaySource.${source.SourceName}.${studio}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -144,7 +148,7 @@ export function addSourceToSourcesConfig(
 			config.push(source)
 			context.setConfig(configId, (config as unknown) as ConfigItemValue)
 		}
-	})
+	}
 }
 
 export function changeGFXTemplate(
@@ -152,9 +156,9 @@ export function changeGFXTemplate(
 	studio: string,
 	oldConfig: Partial<TableConfigItemGFXTemplates>,
 	config: Partial<TableConfigItemGFXTemplates>
-) {
+): MigrationStepShowStyle {
 	const keysToUpdate = Object.keys(config).join('_')
-	return literal<MigrationStepShowStyle>({
+	return {
 		id: `${versionStr}.gfxConfig.change_${keysToUpdate}.${studio}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -176,7 +180,7 @@ export function changeGFXTemplate(
 
 			context.setBaseConfig('GFXTemplates', (existing as unknown) as ConfigItemValue)
 		}
-	})
+	}
 }
 
 function isGfxTemplateSubset(
@@ -194,40 +198,38 @@ export function SetLayerNamesToDefaults(
 	const migrations: MigrationStepStudio[] = []
 
 	for (const [layerId, mapping] of Object.entries(mappings)) {
-		migrations.push(
-			literal<MigrationStepStudio>({
-				id: `${versionStr}.studioConfig.setLayerName.${layerId}.${studio}`,
-				version: versionStr,
-				canBeRunAutomatically: true,
-				validate: (context: MigrationContextStudio) => {
-					const configVal = context.getMapping(layerId)
+		migrations.push({
+			id: `${versionStr}.studioConfig.setLayerName.${layerId}.${studio}`,
+			version: versionStr,
+			canBeRunAutomatically: true,
+			validate: (context: MigrationContextStudio) => {
+				const configVal = context.getMapping(layerId)
 
-					if (!configVal) {
-						return false
-					}
-
-					return configVal.layerName !== mapping.layerName
-				},
-				migrate: (context: MigrationContextStudio) => {
-					const configVal = context.getMapping(layerId)
-
-					if (!configVal) {
-						return
-					}
-
-					configVal.layerName = mapping.layerName
-					context.removeMapping(layerId)
-					context.insertMapping(layerId, configVal)
+				if (!configVal) {
+					return false
 				}
-			})
-		)
+
+				return configVal.layerName !== mapping.layerName
+			},
+			migrate: (context: MigrationContextStudio) => {
+				const configVal = context.getMapping(layerId)
+
+				if (!configVal) {
+					return
+				}
+
+				configVal.layerName = mapping.layerName
+				context.removeMapping(layerId)
+				context.insertMapping(layerId, configVal)
+			}
+		})
 	}
 
 	return migrations
 }
 
-export function SetConfigTo(versionStr: string, studio: string, id: string, value: any) {
-	return literal<MigrationStepStudio>({
+export function SetConfigTo(versionStr: string, studio: string, id: string, value: any): MigrationStepStudio {
+	return {
 		id: `${versionStr}.config.valueSet.${studio}.${id}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -244,11 +246,11 @@ export function SetConfigTo(versionStr: string, studio: string, id: string, valu
 		migrate: (context: MigrationContextStudio) => {
 			context.setConfig(id, value)
 		}
-	})
+	}
 }
 
-export function RemoveConfig(versionStr: string, studio: string, id: string) {
-	return literal<MigrationStepStudio>({
+export function RemoveConfig(versionStr: string, studio: string, id: string): MigrationStepStudio {
+	return {
 		id: `${versionStr}.config.valueSet.${studio}.${id}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -258,7 +260,7 @@ export function RemoveConfig(versionStr: string, studio: string, id: string) {
 		migrate: (context: MigrationContextStudio) => {
 			context.removeConfig(id)
 		}
-	})
+	}
 }
 
 const SOUNDBED_REGEX = /^audio\/(.*)/i
@@ -288,7 +290,7 @@ export function StripFolderFromShowStyleConfig(
 	configFields: string[],
 	regex: RegExp
 ): MigrationStepShowStyle {
-	return literal<MigrationStepShowStyle>({
+	return {
 		id: `${versionStr}.normalizeFolders.${studio}.${configId}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -330,7 +332,7 @@ export function StripFolderFromShowStyleConfig(
 
 			context.setBaseConfig(configId, configTableValue)
 		}
-	})
+	}
 }
 
 export function PrefixEvsWithEvs(
@@ -339,7 +341,7 @@ export function PrefixEvsWithEvs(
 	configId: string,
 	evsSourceNumber: string
 ): MigrationStepStudio {
-	return literal<MigrationStepStudio>({
+	return {
 		id: `${versionStr}.prefixEvs${evsSourceNumber}WithEvs.${studio}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -364,5 +366,5 @@ export function PrefixEvsWithEvs(
 			config[index] = evsSource
 			context.setConfig(configId, (config as unknown) as ConfigItemValue)
 		}
-	})
+	}
 }

--- a/src/tv2-common/migrations/moveSourcesToTable.ts
+++ b/src/tv2-common/migrations/moveSourcesToTable.ts
@@ -10,7 +10,7 @@ export function MoveSourcesToTable(
 	getSisyfosLayersForMigration: (configName: string, val: string) => string[],
 	studioMics?: boolean
 ): MigrationStepStudio {
-	const res = literal<MigrationStepStudio>({
+	return {
 		id: `${versionStr}.studioConfig.moveToTable.${configName}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -52,13 +52,11 @@ export function MoveSourcesToTable(
 				context.setConfig(configName, table)
 			}
 		}
-	})
-
-	return res
+	}
 }
 
 export function MoveClipSourcePath(versionStr: string, studio: string): MigrationStepStudio {
-	const res = literal<MigrationStepStudio>({
+	return {
 		id: `${versionStr}.studioConfig.moveClipSourcePath.${studio}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -76,7 +74,5 @@ export function MoveClipSourcePath(versionStr: string, studio: string): Migratio
 				context.removeConfig('ClipSourcePath')
 			}
 		}
-	})
-
-	return res
+	}
 }

--- a/src/tv2-common/migrations/sourceManifest.ts
+++ b/src/tv2-common/migrations/sourceManifest.ts
@@ -8,7 +8,7 @@ export function MakeConfigForSources(
 	acceptPersistAudio: boolean,
 	defaultVal: ConfigManifestEntryTable['defaultVal']
 ): ConfigManifestEntryTable {
-	return literal<ConfigManifestEntryTable>({
+	return {
 		id: `Sources${name}`,
 		name: `${displayName} Mapping`,
 		description: `${displayName} number to ATEM input and Sisyfos layer`,
@@ -85,5 +85,5 @@ export function MakeConfigForSources(
 				  ]
 				: [])
 		]
-	})
+	}
 }

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -56,6 +56,7 @@ export interface PieceMetaData {
 	mediaPlayerSessions?: string[]
 	mediaPlayerOptional?: boolean
 	modifiedByAction?: boolean
+	belongsToRemotePart?: boolean // used to find last idents in Lives
 }
 
 export interface SisyfosPersistMetaData {

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -12,7 +12,7 @@ import {
 	TimelinePersistentState,
 	TSR
 } from '@tv2media/blueprints-integration'
-import { CasparPlayerClip, literal } from 'tv2-common'
+import { ActionSelectFullGrafik, ActionSelectJingle, ActionSelectServerClip, CasparPlayerClip } from 'tv2-common'
 import { AbstractLLayer, TallyTags } from 'tv2-constants'
 import * as _ from 'underscore'
 import { SisyfosLLAyer } from '../tv2_afvd_studio/layers'
@@ -56,7 +56,22 @@ export interface PieceMetaData {
 	mediaPlayerSessions?: string[]
 	mediaPlayerOptional?: boolean
 	modifiedByAction?: boolean
-	belongsToRemotePart?: boolean // used to find last idents in Lives
+}
+
+export interface GraphicPieceMetaData extends PieceMetaData {
+	belongsToRemotePart?: boolean
+}
+
+export interface JinglePieceMetaData extends PieceMetaData {
+	userData: ActionSelectJingle
+}
+
+export interface FullPieceMetaData extends PieceMetaData {
+	userData: ActionSelectFullGrafik
+}
+
+export interface ServerPieceMetaData extends PieceMetaData {
+	userData: ActionSelectServerClip
 }
 
 export interface SisyfosPersistMetaData {
@@ -81,7 +96,7 @@ export function onTimelineGenerate<
 	timeline: OnGenerateTimelineObj[],
 	previousPersistentState: TimelinePersistentState | undefined,
 	previousPartEndState: PartEndState | undefined,
-	resolvedPieces: IBlueprintResolvedPieceInstance[],
+	resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>,
 	getConfig: (context: IShowStyleContext) => ShowStyleConfig,
 	sourceLayers: ABSourceLayers,
 	_casparLayerClipPending: string,
@@ -145,9 +160,7 @@ function processServerLookaheads(
 		return (
 			[sourceLayers.Caspar.ClipPending, CasparPlayerClip(1), CasparPlayerClip(2)].includes(layer) &&
 			!obj.isLookahead &&
-			resolvedPieces.some(
-				p => p._id === obj.pieceInstanceId && (p as any).partInstanceId === context.currentPartInstance?._id
-			)
+			resolvedPieces.some(p => p._id === obj.pieceInstanceId && p.partInstanceId === context.currentPartInstance?._id)
 		)
 	})
 
@@ -190,12 +203,14 @@ function processServerLookaheads(
 	})
 }
 
-function isAnyPieceInjectedIntoPart(resolvedPieces: IBlueprintResolvedPieceInstance[], context: ITimelineEventContext) {
+function isAnyPieceInjectedIntoPart(
+	resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>,
+	context: ITimelineEventContext
+) {
 	return resolvedPieces
 		.filter(piece => piece.partInstanceId === context.currentPartInstance?._id)
 		.some(piece => {
-			const metaData = piece.piece.metaData as PieceMetaData | undefined
-			return metaData?.sisyfosPersistMetaData?.isPieceInjectedInPart
+			return piece.piece.metaData?.sisyfosPersistMetaData?.isPieceInjectedInPart
 		})
 }
 
@@ -203,7 +218,7 @@ export function getEndStateForPart(
 	_context: IRundownContext,
 	_previousPersistentState: TimelinePersistentState | undefined,
 	partInstance: IBlueprintPartInstance,
-	resolvedPieces: IBlueprintResolvedPieceInstance[],
+	resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>,
 	time: number
 ): PartEndState {
 	const endState: PartEndStateExt = {
@@ -220,8 +235,8 @@ export function getEndStateForPart(
 		p =>
 			_.isNumber(p.piece.enable.start) &&
 			p.piece.enable &&
-			(p.piece.enable.start as number) <= time &&
-			(!p.piece.enable.duration || p.piece.enable.start + (p.piece.enable.duration as number) >= time)
+			p.piece.enable.start <= time &&
+			(!p.piece.enable.duration || p.piece.enable.start + p.piece.enable.duration >= time)
 	)
 
 	const previousPersistentState: TimelinePersistentStateExt = _previousPersistentState as TimelinePersistentStateExt
@@ -234,7 +249,7 @@ export function getEndStateForPart(
 
 	for (const piece of activePieces) {
 		if (piece.piece.metaData) {
-			const meta = (piece.piece.metaData as PieceMetaData).mediaPlayerSessions
+			const meta = piece.piece.metaData.mediaPlayerSessions
 			if (meta && meta.length) {
 				endState.mediaPlayerSessions[piece.piece.sourceLayerId] = meta
 			}
@@ -278,11 +293,11 @@ function dveBoxLookaheadUseOriginalEnable(timeline: OnGenerateTimelineObj[]) {
 }
 
 export function createSisyfosPersistedLevelsTimelineObject(
-	resolvedPieces: IBlueprintResolvedPieceInstance[],
+	resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>,
 	previousSisyfosLayersThatWantsToBePersisted: SisyfosPersistMetaData['sisyfosLayers']
 ): TSR.TimelineObjSisyfosChannels {
 	const layersToPersist = findLayersToPersist(resolvedPieces, previousSisyfosLayersThatWantsToBePersisted)
-	return literal<TSR.TimelineObjSisyfosChannels>({
+	return {
 		id: 'sisyfosPersistenceObject',
 		enable: {
 			start: 0
@@ -299,25 +314,22 @@ export function createSisyfosPersistedLevelsTimelineObject(
 				}
 			})
 		}
-	})
+	}
 }
 
 function findLayersToPersist(
-	pieces: IBlueprintResolvedPieceInstance[],
+	pieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>,
 	sisyfosLayersThatWantsToBePersisted: string[]
 ): string[] {
 	const sortedPieces = pieces
-		.filter(piece => {
-			const metaData = piece.piece.metaData as PieceMetaData | undefined
-			return metaData?.sisyfosPersistMetaData
-		})
+		.filter(piece => piece.piece.metaData?.sisyfosPersistMetaData)
 		.sort((a, b) => b.resolvedStart - a.resolvedStart)
 
 	if (sortedPieces.length === 0) {
 		return []
 	}
 
-	const firstPieceMetaData = sortedPieces[0].piece.metaData as PieceMetaData
+	const firstPieceMetaData = sortedPieces[0].piece.metaData!
 	if (!firstPieceMetaData.sisyfosPersistMetaData!.acceptPersistAudio) {
 		return firstPieceMetaData.sisyfosPersistMetaData!.wantsToPersistAudio
 			? firstPieceMetaData.sisyfosPersistMetaData!.sisyfosLayers
@@ -326,8 +338,8 @@ function findLayersToPersist(
 
 	const layersToPersist: string[] = []
 	for (let i = 0; i < sortedPieces.length; i++) {
-		const pieceMetaData = sortedPieces[i].piece.metaData as PieceMetaData
-		const sisyfosPersistMetaData: SisyfosPersistMetaData = pieceMetaData!.sisyfosPersistMetaData!
+		const pieceMetaData = sortedPieces[i].piece.metaData!
+		const sisyfosPersistMetaData: SisyfosPersistMetaData = pieceMetaData.sisyfosPersistMetaData!
 		if (sisyfosPersistMetaData.wantsToPersistAudio) {
 			layersToPersist.push(...sisyfosPersistMetaData.sisyfosLayers)
 		}

--- a/src/tv2-common/parts/effekt.ts
+++ b/src/tv2-common/parts/effekt.ts
@@ -16,6 +16,7 @@ import {
 	GetTagForTransition,
 	literal,
 	PartDefinition,
+	PieceMetaData,
 	TimeFromFrames,
 	TimelineBlueprintExt,
 	TV2BlueprintConfigBase,
@@ -117,60 +118,58 @@ export function CreateEffektForPartInner<
 
 	const fileName = JoinAssetToFolder(config.studio.JingleFolder, file)
 
-	pieces.push(
-		literal<IBlueprintPiece>({
-			externalId,
-			name: label,
-			enable: { start: 0, duration: TimeFromFrames(Number(effektConfig.Duration)) },
-			outputLayerId: SharedOutputLayers.JINGLE,
-			sourceLayerId: layers.sourceLayer,
-			lifespan: PieceLifespan.WithinPart,
-			pieceType: IBlueprintPieceType.InTransition,
-			content: literal<WithTimeline<VTContent>>({
-				fileName,
-				path: JoinAssetToNetworkPath(
-					config.studio.JingleNetworkBasePath,
-					config.studio.JingleFolder,
-					file,
-					config.studio.JingleFileExtension
-				), // full path on the source network storage
-				mediaFlowIds: [config.studio.JingleMediaFlowId],
-				previewFrame: Number(effektConfig.StartAlpha),
-				ignoreMediaObjectStatus: config.studio.JingleIgnoreStatus,
-				ignoreBlackFrames: true,
-				ignoreFreezeFrame: true,
-				timelineObjects: literal<TimelineObjectCoreExt[]>([
-					literal<TSR.TimelineObjCCGMedia & TimelineBlueprintExt>({
-						id: '',
-						enable: {
-							start: 0
-						},
-						priority: 1,
-						layer: layers.casparLayer,
-						content: {
-							deviceType: TSR.DeviceType.CASPARCG,
-							type: TSR.TimelineContentTypeCasparCg.MEDIA,
-							file: fileName
-						}
-					}),
-					...EnableDSK(config, 'JINGLE', { start: Number(config.studio.CasparPrerollDuration) }),
-					literal<TSR.TimelineObjSisyfosChannel & TimelineBlueprintExt>({
-						id: '',
-						enable: {
-							start: 0
-						},
-						priority: 1,
-						layer: layers.sisyfosLayer,
-						content: {
-							deviceType: TSR.DeviceType.SISYFOS,
-							type: TSR.TimelineContentTypeSisyfos.CHANNEL,
-							isPgm: 1
-						}
-					})
-				])
-			})
+	pieces.push({
+		externalId,
+		name: label,
+		enable: { start: 0, duration: TimeFromFrames(Number(effektConfig.Duration)) },
+		outputLayerId: SharedOutputLayers.JINGLE,
+		sourceLayerId: layers.sourceLayer,
+		lifespan: PieceLifespan.WithinPart,
+		pieceType: IBlueprintPieceType.InTransition,
+		content: literal<WithTimeline<VTContent>>({
+			fileName,
+			path: JoinAssetToNetworkPath(
+				config.studio.JingleNetworkBasePath,
+				config.studio.JingleFolder,
+				file,
+				config.studio.JingleFileExtension
+			), // full path on the source network storage
+			mediaFlowIds: [config.studio.JingleMediaFlowId],
+			previewFrame: Number(effektConfig.StartAlpha),
+			ignoreMediaObjectStatus: config.studio.JingleIgnoreStatus,
+			ignoreBlackFrames: true,
+			ignoreFreezeFrame: true,
+			timelineObjects: literal<TimelineObjectCoreExt[]>([
+				literal<TSR.TimelineObjCCGMedia & TimelineBlueprintExt>({
+					id: '',
+					enable: {
+						start: 0
+					},
+					priority: 1,
+					layer: layers.casparLayer,
+					content: {
+						deviceType: TSR.DeviceType.CASPARCG,
+						type: TSR.TimelineContentTypeCasparCg.MEDIA,
+						file: fileName
+					}
+				}),
+				...EnableDSK(config, 'JINGLE', { start: Number(config.studio.CasparPrerollDuration) }),
+				literal<TSR.TimelineObjSisyfosChannel & TimelineBlueprintExt>({
+					id: '',
+					enable: {
+						start: 0
+					},
+					priority: 1,
+					layer: layers.sisyfosLayer,
+					content: {
+						deviceType: TSR.DeviceType.SISYFOS,
+						type: TSR.TimelineContentTypeSisyfos.CHANNEL,
+						isPgm: 1
+					}
+				})
+			])
 		})
-	)
+	})
 
 	return {
 		inTransition: {
@@ -190,7 +189,7 @@ export function CreateMixTransitionBlueprintPieceForPart(
 	externalId: string,
 	durationInFrames: number,
 	sourceLayer: string
-): IBlueprintPiece {
+): IBlueprintPiece<PieceMetaData> {
 	const tags = [
 		GetTagForTransition(
 			literal<ActionTakeWithTransitionVariantMix>({
@@ -209,8 +208,8 @@ function createEffectBlueprintPiece(
 	name: string,
 	sourceLayer: string,
 	tags: string[]
-): IBlueprintPiece {
-	return literal<IBlueprintPiece>({
+): IBlueprintPiece<PieceMetaData> {
+	return {
 		enable: {
 			start: 0,
 			duration: Math.max(TimeFromFrames(durationInFrames), 1000)
@@ -225,7 +224,7 @@ function createEffectBlueprintPiece(
 			timelineObjects: [],
 			ignoreMediaObjectStatus: true
 		}
-	})
+	}
 }
 
 export function CreateInTransitionForAtemTransitionStyle(
@@ -245,7 +244,7 @@ export function CreateDipTransitionBlueprintPieceForPart(
 	externalId: string,
 	durationInFrames: number,
 	sourceLayer: string
-): IBlueprintPiece {
+): IBlueprintPiece<PieceMetaData> {
 	const tags = [
 		GetTagForTransition(
 			literal<ActionTakeWithTransitionVariantDip>({

--- a/src/tv2-common/parts/invalid.ts
+++ b/src/tv2-common/parts/invalid.ts
@@ -1,13 +1,13 @@
 import { BlueprintResultPart, IBlueprintPart } from '@tv2media/blueprints-integration'
-import { literal, PartDefinition } from 'tv2-common'
+import { PartDefinition } from 'tv2-common'
 
 export function CreatePartInvalid(ingestPart: PartDefinition, externalIdSuffix?: string): BlueprintResultPart {
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId: ingestPart.externalId + (externalIdSuffix ? `_${externalIdSuffix}` : ''),
 		title: ingestPart.rawType || 'Unknown',
 		metaData: {},
 		invalid: true
-	})
+	}
 
 	return {
 		part,

--- a/src/tv2-common/parts/kam.ts
+++ b/src/tv2-common/parts/kam.ts
@@ -1,5 +1,5 @@
 import { BlueprintResultPart, IBlueprintPart, IShowStyleUserContext } from '@tv2media/blueprints-integration'
-import { literal, PartDefinition, PartTime, TV2BlueprintConfigBase, TV2StudioConfigBase } from 'tv2-common'
+import { PartDefinition, PartTime, TV2BlueprintConfigBase, TV2StudioConfigBase } from 'tv2-common'
 
 export function CreatePartKamBase<
 	StudioConfig extends TV2StudioConfigBase,
@@ -12,12 +12,12 @@ export function CreatePartKamBase<
 ): { part: BlueprintResultPart; duration: number; invalid?: true } {
 	const partTime = PartTime(config, partDefinition, totalWords, false)
 
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title: partDefinition.rawType,
 		metaData: {},
 		expectedDuration: partTime > 0 ? partTime : 0
-	})
+	}
 
 	return {
 		part: {

--- a/src/tv2-common/pieces/adlibServer.ts
+++ b/src/tv2-common/pieces/adlibServer.ts
@@ -37,7 +37,7 @@ export async function CreateAdlibServer<
 	const mediaObjectDuration = mediaObjectDurationSec && mediaObjectDurationSec * 1000
 	const sourceDuration = getSourceDuration(mediaObjectDuration, config.studio.ServerPostrollDuration)
 
-	return literal<IBlueprintActionManifest>({
+	return {
 		externalId: partDefinition.externalId + '-adLib-server',
 		actionId: AdlibActionType.SELECT_SERVER_CLIP,
 		userData: literal<ActionSelectServerClip>({
@@ -70,5 +70,5 @@ export async function CreateAdlibServer<
 			uniquenessId: `${voLayer ? 'vo' : 'server'}_${partDefinition.storyName}_${file}`
 		}
 		// triggerModes: getServerAdLibTriggerModes() /** @todo: uncomment for Server Resume */
-	})
+	}
 }

--- a/src/tv2-common/pieces/script.ts
+++ b/src/tv2-common/pieces/script.ts
@@ -4,7 +4,6 @@ import { SharedOutputLayers } from 'tv2-constants'
 
 const PREVIEW_CHARACTERS = 30
 
-// export function AddScript(part: PartDefinition, pieces: IBlueprintPiece[], duration: number, slutord: boolean) {
 export function AddScript(part: PartDefinition, pieces: IBlueprintPiece[], duration: number, sourceLayerId: string) {
 	if (!pieces.length) {
 		return
@@ -16,29 +15,27 @@ export function AddScript(part: PartDefinition, pieces: IBlueprintPiece[], durat
 	}
 	if (script.length) {
 		const stripLength = Math.min(PREVIEW_CHARACTERS, script.length)
-		pieces.push(
-			literal<IBlueprintPiece>({
-				externalId: part.externalId,
-				name: script.slice(0, stripLength),
-				enable: {
-					start: 0
-				},
-				outputLayerId: SharedOutputLayers.MANUS,
-				sourceLayerId,
-				lifespan: PieceLifespan.WithinPart,
-				content: literal<WithTimeline<ScriptContent>>({
-					firstWords: script.slice(0, stripLength),
-					lastWords: script
-						.replace(/\n/gi, ' ')
-						.trim()
-						.slice(script.length - stripLength)
-						?.trim(),
-					fullScript: script,
-					sourceDuration: duration,
-					lastModified: part.modified * 1000,
-					timelineObjects: []
-				})
+		pieces.push({
+			externalId: part.externalId,
+			name: script.slice(0, stripLength),
+			enable: {
+				start: 0
+			},
+			outputLayerId: SharedOutputLayers.MANUS,
+			sourceLayerId,
+			lifespan: PieceLifespan.WithinPart,
+			content: literal<WithTimeline<ScriptContent>>({
+				firstWords: script.slice(0, stripLength),
+				lastWords: script
+					.replace(/\n/gi, ' ')
+					.trim()
+					.slice(script.length - stripLength)
+					?.trim(),
+				fullScript: script,
+				sourceDuration: duration,
+				lastModified: part.modified * 1000,
+				timelineObjects: []
 			})
-		)
+		})
 	}
 }

--- a/src/tv2-common/updatePolicies/shouldRemoveOrphanedPartInstance.ts
+++ b/src/tv2-common/updatePolicies/shouldRemoveOrphanedPartInstance.ts
@@ -5,5 +5,5 @@ export function shouldRemoveOrphanedPartInstance(
 	_context: IRundownUserContext,
 	partInstance: BlueprintRemoveOrphanedPartInstance
 ): boolean {
-	return !(partInstance.partInstance.part.metaData as PartMetaData).dirty
+	return !(partInstance.partInstance.part.metaData as PartMetaData | undefined)?.dirty
 }

--- a/src/tv2-common/updatePolicies/syncIngestUpdateToPartInstance.ts
+++ b/src/tv2-common/updatePolicies/syncIngestUpdateToPartInstance.ts
@@ -22,7 +22,6 @@ export function syncIngestUpdateToPartInstanceBase(
 					...freelyEditableLayers,
 					SharedSourceLayers.PgmGraphicsHeadline,
 					SharedSourceLayers.PgmGraphicsIdent,
-					SharedSourceLayers.PgmGraphicsIdentPersistent,
 					SharedSourceLayers.PgmGraphicsLower,
 					SharedSourceLayers.PgmGraphicsOverlay,
 					SharedSourceLayers.PgmGraphicsTLF,

--- a/src/tv2-common/util.ts
+++ b/src/tv2-common/util.ts
@@ -13,7 +13,7 @@ export type WithValuesOfTypes<T, Q> = { [P in keyof T as T[P] extends Q | undefi
 export type OptionalExceptFor<T, TRequired extends keyof T> = Partial<T> & Pick<T, TRequired>
 export type EmptyBaseObj = OptionalExceptFor<Omit<TSR.TimelineObjEmpty, 'content'>, 'layer' | 'enable' | 'classes'>
 export function createEmptyObject(obj: EmptyBaseObj): TSR.TimelineObjEmpty {
-	return literal<TSR.TimelineObjEmpty>({
+	return {
 		id: '',
 		priority: 0,
 		...obj,
@@ -21,7 +21,7 @@ export function createEmptyObject(obj: EmptyBaseObj): TSR.TimelineObjEmpty {
 			deviceType: TSR.DeviceType.ABSTRACT,
 			type: 'empty'
 		}
-	})
+	}
 }
 
 /**

--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -116,7 +116,6 @@ export function AdlibTagCutToBox(box: number): AdlibTags {
 }
 
 export enum ControlClasses {
-	ShowIdentGraphic = 'show_ident_graphic',
 	/** Indicates that a DVE is currently on air */
 	DVEOnAir = 'dve_on_air',
 	ServerOnAir = 'server_on_air',
@@ -148,8 +147,7 @@ export enum AdlibActionType {
 	TAKE_WITH_TRANSITION = 'take_with_transition',
 	RECALL_LAST_LIVE = 'recall_last_live',
 	RECALL_LAST_DVE = 'recall_last_dve',
-	FADE_DOWN_PERSISTED_AUDIO_LEVELS = 'fade_down_persisted_audio_levels',
-	PLAY_GRAPHICS = 'play_graphics'
+	FADE_DOWN_PERSISTED_AUDIO_LEVELS = 'fade_down_persisted_audio_levels'
 }
 
 export enum TallyTags {
@@ -237,7 +235,6 @@ export enum SharedSourceLayers {
 
 	// Graphics
 	PgmGraphicsIdent = 'studio0_graphicsIdent',
-	PgmGraphicsIdentPersistent = 'studio0_graphicsIdent_persistent',
 	PgmGraphicsTop = 'studio0_graphicsTop',
 	PgmGraphicsLower = 'studio0_graphicsLower',
 	PgmGraphicsHeadline = 'studio0_graphicsHeadline',

--- a/src/tv2_afvd_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/actions.spec.ts
@@ -406,7 +406,7 @@ async function getTransitionPiece(
 }
 
 function getATEMMEObj(piece: IBlueprintPieceInstance): TSR.TimelineObjAtemME {
-	const atemObj = (piece.piece.content!.timelineObjects as TSR.TSRTimelineObj[]).find(
+	const atemObj = (piece.piece.content.timelineObjects as TSR.TSRTimelineObj[]).find(
 		obj =>
 			obj.layer === AtemLLayer.AtemMEProgram &&
 			obj.content.deviceType === TSR.DeviceType.ATEM &&
@@ -792,9 +792,9 @@ describe('Camera shortcuts on server', () => {
 		const context = makeMockContext('cut', 'cam', 'cam')
 
 		context.currentPieceInstances = [
-			literal<IBlueprintPieceInstance>({
+			{
 				_id: 'serverPieceInstance',
-				piece: literal<IBlueprintPieceDB>({
+				piece: {
 					_id: 'Server Current',
 					enable: {
 						start: 0
@@ -807,9 +807,9 @@ describe('Camera shortcuts on server', () => {
 					content: {
 						timelineObjects: []
 					}
-				}),
+				},
 				partInstanceId: ''
-			})
+			}
 		]
 
 		context.nextPart = undefined
@@ -835,9 +835,9 @@ describe('Camera shortcuts on server', () => {
 		const context = makeMockContext('cut', 'cam', 'cam')
 
 		context.currentPieceInstances = [
-			literal<IBlueprintPieceInstance>({
+			{
 				_id: 'serverPieceInstance',
-				piece: literal<IBlueprintPieceDB>({
+				piece: {
 					_id: 'Server Current',
 					enable: {
 						start: 0
@@ -850,9 +850,9 @@ describe('Camera shortcuts on server', () => {
 					content: {
 						timelineObjects: []
 					}
-				}),
+				},
 				partInstanceId: ''
-			})
+			}
 		]
 
 		context.nextPart = undefined
@@ -880,9 +880,9 @@ describe('Camera shortcuts on VO', () => {
 		const context = makeMockContext('cut', 'cam', 'cam')
 
 		context.currentPieceInstances = [
-			literal<IBlueprintPieceInstance>({
+			{
 				_id: 'voPieceInstance',
-				piece: literal<IBlueprintPieceDB>({
+				piece: {
 					_id: 'VO Current',
 					enable: {
 						start: 0
@@ -895,9 +895,9 @@ describe('Camera shortcuts on VO', () => {
 					content: {
 						timelineObjects: []
 					}
-				}),
+				},
 				partInstanceId: ''
-			})
+			}
 		]
 
 		context.nextPart = undefined
@@ -923,9 +923,9 @@ describe('Camera shortcuts on VO', () => {
 		const context = makeMockContext('cut', 'cam', 'cam')
 
 		context.currentPieceInstances = [
-			literal<IBlueprintPieceInstance>({
+			{
 				_id: 'voPieceInstance',
-				piece: literal<IBlueprintPieceDB>({
+				piece: {
 					_id: 'VO Current',
 					enable: {
 						start: 0
@@ -938,9 +938,9 @@ describe('Camera shortcuts on VO', () => {
 					content: {
 						timelineObjects: []
 					}
-				}),
+				},
 				partInstanceId: ''
-			})
+			}
 		]
 
 		context.nextPart = undefined

--- a/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
@@ -1,6 +1,5 @@
 import {
 	BlueprintResultSegment,
-	IBlueprintActionManifest,
 	IBlueprintActionManifestDisplayContent,
 	IngestSegment
 } from '@tv2media/blueprints-integration'
@@ -172,7 +171,7 @@ describe('AFVD Blueprint', () => {
 		])
 		expect(fullPart.adLibPieces).toHaveLength(0)
 		expect(fullPart.actions).toHaveLength(1)
-		const fullAdlibAction = fullPart.actions![0] as IBlueprintActionManifest
+		const fullAdlibAction = fullPart.actions[0]
 		expect(fullAdlibAction).toBeTruthy()
 		expect((fullAdlibAction.display as IBlueprintActionManifestDisplayContent).sourceLayerId).toBe(
 			SharedSourceLayers.PgmPilot
@@ -253,7 +252,7 @@ describe('AFVD Blueprint', () => {
 		expect(fullPart.pieces).toHaveLength(2)
 		expect(fullPart.adLibPieces).toHaveLength(0)
 		expect(fullPart.actions).toHaveLength(1)
-		const fullAdlibAction = fullPart.actions![0] as IBlueprintActionManifest
+		const fullAdlibAction = fullPart.actions[0]
 		expect(fullAdlibAction).toBeTruthy()
 		expect((fullAdlibAction.display as IBlueprintActionManifestDisplayContent).sourceLayerId).toBe(
 			SharedSourceLayers.PgmPilot
@@ -305,7 +304,7 @@ describe('AFVD Blueprint', () => {
 		expect(fullPart.pieces).toHaveLength(3)
 		expect(fullPart.adLibPieces).toHaveLength(0)
 		expect(fullPart.actions).toHaveLength(1)
-		const fullAdlibAction = fullPart.actions![0] as IBlueprintActionManifest
+		const fullAdlibAction = fullPart.actions[0]
 		expect(fullAdlibAction).toBeTruthy()
 		expect((fullAdlibAction.display as IBlueprintActionManifestDisplayContent).sourceLayerId).toBe(
 			SharedSourceLayers.PgmPilot
@@ -356,7 +355,7 @@ describe('AFVD Blueprint', () => {
 		expect(fullPart.adLibPieces).toHaveLength(0)
 		expect(fullPart.actions).toHaveLength(1)
 		expect(fullPart.actions).toHaveLength(1)
-		const fullAdlibAction = fullPart.actions![0] as IBlueprintActionManifest
+		const fullAdlibAction = fullPart.actions[0]
 		expect(fullAdlibAction).toBeTruthy()
 		expect((fullAdlibAction.display as IBlueprintActionManifestDisplayContent).sourceLayerId).toBe(
 			SharedSourceLayers.PgmPilot
@@ -576,7 +575,7 @@ describe('AFVD Blueprint', () => {
 		expect(fullPart.pieces).toHaveLength(2)
 		expect(fullPart.adLibPieces).toHaveLength(0)
 		expect(fullPart.actions).toHaveLength(1)
-		const fullAdlibAction = fullPart.actions![0] as IBlueprintActionManifest
+		const fullAdlibAction = fullPart.actions[0]
 		expect(fullAdlibAction).toBeTruthy()
 		expect((fullAdlibAction.display as IBlueprintActionManifestDisplayContent).sourceLayerId).toBe(
 			SharedSourceLayers.PgmPilot

--- a/src/tv2_afvd_showstyle/__tests__/layers-check.ts
+++ b/src/tv2_afvd_showstyle/__tests__/layers-check.ts
@@ -8,7 +8,7 @@ import {
 	TSR
 } from '@tv2media/blueprints-integration'
 
-import { GetDSKSourceLayerNames, literal } from 'tv2-common'
+import { GetDSKSourceLayerNames } from 'tv2-common'
 import mappingsDefaults, { getMediaPlayerMappings } from '../../tv2_afvd_studio/migrations/mappings-defaults'
 import { ATEMModel } from '../../types/atem'
 import { getConfig } from '../helpers/config'
@@ -33,10 +33,10 @@ export function checkAllLayers(
 		.sort()
 	const allOutputLayers = _.map(OutputlayerDefaults, m => m._id)
 
-	const allMappings = literal<BlueprintMappings>({
+	const allMappings: BlueprintMappings = {
 		...mappingsDefaults,
 		...getMediaPlayerMappings(config.mediaPlayers)
-	})
+	}
 
 	const validateObject = (obj: TimelineObjectCoreExt) => {
 		const isAbstract = obj.content.deviceType === TSR.DeviceType.ABSTRACT

--- a/src/tv2_afvd_showstyle/getSegment.ts
+++ b/src/tv2_afvd_showstyle/getSegment.ts
@@ -62,8 +62,8 @@ export async function getSegment(
 	}
 }
 
-export function CreatePartContinuity(config: ShowStyleConfig, ingestSegment: IngestSegment) {
-	return literal<BlueprintResultPart>({
+export function CreatePartContinuity(config: ShowStyleConfig, ingestSegment: IngestSegment): BlueprintResultPart {
+	return {
 		part: {
 			externalId: `${ingestSegment.externalId}-CONTINUITY`,
 			title: 'CONTINUITY',
@@ -105,7 +105,7 @@ export function CreatePartContinuity(config: ShowStyleConfig, ingestSegment: Ing
 		],
 		adLibPieces: [],
 		actions: []
-	})
+	}
 }
 
 function insertSpecialPieces(

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -11,6 +11,7 @@ import {
 	AtemLLayerDSK,
 	CueDefinitionGraphic,
 	GraphicInternal,
+	GraphicPieceMetaData,
 	GraphicPilot,
 	literal,
 	PartDefinitionKam,
@@ -108,7 +109,7 @@ describe('grafik piece', () => {
 			cue.adlib ? { rank: 0 } : undefined
 		)
 		expect(pieces).toEqual([
-			literal<IBlueprintPiece>({
+			literal<IBlueprintPiece<GraphicPieceMetaData>>({
 				externalId: partId,
 				name: 'bund - Odense\n - Copenhagen',
 				enable: {
@@ -116,12 +117,12 @@ describe('grafik piece', () => {
 					duration: 4000
 				},
 				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData>({
+				metaData: {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
 					belongsToRemotePart: false
-				}),
+				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
 				content: literal<WithTimeline<GraphicsContent>>({
@@ -412,7 +413,7 @@ describe('grafik piece', () => {
 			cue.adlib ? { rank: 0 } : undefined
 		)
 		expect(pieces).toEqual([
-			literal<IBlueprintPiece>({
+			literal<IBlueprintPiece<GraphicPieceMetaData>>({
 				externalId: partId,
 				name: 'bund - Odense\n - Copenhagen',
 				enable: {
@@ -420,12 +421,12 @@ describe('grafik piece', () => {
 					duration: 4000
 				},
 				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData>({
+				metaData: {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
 					belongsToRemotePart: false
-				}),
+				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
 				content: literal<WithTimeline<GraphicsContent>>({
@@ -491,19 +492,19 @@ describe('grafik piece', () => {
 			cue.adlib ? { rank: 0 } : undefined
 		)
 		expect(pieces).toEqual([
-			literal<IBlueprintPiece>({
+			literal<IBlueprintPiece<GraphicPieceMetaData>>({
 				externalId: partId,
 				name: 'bund - Odense\n - Copenhagen',
 				enable: {
 					start: 10000
 				},
 				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData>({
+				metaData: {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
 					belongsToRemotePart: false
-				}),
+				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
 				content: literal<WithTimeline<GraphicsContent>>({
@@ -566,19 +567,19 @@ describe('grafik piece', () => {
 			cue.adlib ? { rank: 0 } : undefined
 		)
 		expect(pieces).toEqual([
-			literal<IBlueprintPiece>({
+			literal<IBlueprintPiece<GraphicPieceMetaData>>({
 				externalId: partId,
 				name: 'direkte - KØBENHAVN',
 				enable: {
 					start: 0
 				},
 				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData>({
+				metaData: {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
 					belongsToRemotePart: false
-				}),
+				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsIdent,
 				content: literal<WithTimeline<GraphicsContent>>({
@@ -641,7 +642,7 @@ describe('grafik piece', () => {
 			cue.adlib ? { rank: 0 } : undefined
 		)
 		expect(pieces).toEqual([
-			literal<IBlueprintPiece>({
+			literal<IBlueprintPiece<GraphicPieceMetaData>>({
 				externalId: partId,
 				name: 'arkiv - unnamed org',
 				enable: {
@@ -649,12 +650,12 @@ describe('grafik piece', () => {
 					duration: 4000
 				},
 				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData>({
+				metaData: {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
 					belongsToRemotePart: false
-				}),
+				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsIdent,
 				content: literal<WithTimeline<GraphicsContent>>({

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -16,15 +16,7 @@ import {
 	PartDefinitionKam,
 	PieceMetaData
 } from 'tv2-common'
-import {
-	AbstractLLayer,
-	AdlibTags,
-	CueType,
-	PartType,
-	SharedGraphicLLayer,
-	SharedOutputLayers,
-	SourceType
-} from 'tv2-constants'
+import { AdlibTags, CueType, PartType, SharedGraphicLLayer, SharedOutputLayers, SourceType } from 'tv2-constants'
 import { SegmentUserContext } from '../../../../__mocks__/context'
 import { parseConfig as parseStudioConfig } from '../../../../tv2_afvd_studio/helpers/config'
 import mappingsDefaults from '../../../../tv2_afvd_studio/migrations/mappings-defaults'
@@ -127,7 +119,8 @@ describe('grafik piece', () => {
 				metaData: literal<PieceMetaData>({
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
-					}
+					},
+					belongsToRemotePart: false
 				}),
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -430,7 +423,8 @@ describe('grafik piece', () => {
 				metaData: literal<PieceMetaData>({
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
-					}
+					},
+					belongsToRemotePart: false
 				}),
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -507,7 +501,8 @@ describe('grafik piece', () => {
 				metaData: literal<PieceMetaData>({
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
-					}
+					},
+					belongsToRemotePart: false
 				}),
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -577,14 +572,15 @@ describe('grafik piece', () => {
 				enable: {
 					start: 0
 				},
-				lifespan: PieceLifespan.OutOnSegmentEnd,
+				lifespan: PieceLifespan.WithinPart,
 				metaData: literal<PieceMetaData>({
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
-					}
+					},
+					belongsToRemotePart: false
 				}),
 				outputLayerId: SharedOutputLayers.OVERLAY,
-				sourceLayerId: SourceLayer.PgmGraphicsIdentPersistent,
+				sourceLayerId: SourceLayer.PgmGraphicsIdent,
 				content: literal<WithTimeline<GraphicsContent>>({
 					fileName: 'direkte',
 					path: 'direkte',
@@ -609,35 +605,6 @@ describe('grafik piece', () => {
 						dskEnableObj
 					])
 				})
-			}),
-			literal<IBlueprintPiece>({
-				externalId: partId,
-				name: 'direkte - KØBENHAVN',
-				enable: {
-					start: 0
-				},
-				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData>({
-					sisyfosPersistMetaData: {
-						sisyfosLayers: []
-					}
-				}),
-				outputLayerId: SharedOutputLayers.OVERLAY,
-				sourceLayerId: SourceLayer.PgmGraphicsIdent,
-				content: {
-					timelineObjects: [
-						literal<TSR.TimelineObjAbstractAny>({
-							id: '',
-							enable: {
-								while: '1'
-							},
-							layer: AbstractLLayer.IdentMarker,
-							content: {
-								deviceType: TSR.DeviceType.ABSTRACT
-							}
-						})
-					]
-				}
 			})
 		])
 	})
@@ -685,7 +652,8 @@ describe('grafik piece', () => {
 				metaData: literal<PieceMetaData>({
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
-					}
+					},
+					belongsToRemotePart: false
 				}),
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsIdent,
@@ -799,7 +767,6 @@ describe('grafik piece', () => {
 				}),
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsTop,
-				expectedDuration: 4000,
 				tags: ['flow_producer'],
 				uniquenessId: 'gfx_tlftoptlive - Line 1\n - Line 2_studio0_graphicsTop_overlay_flow',
 				content: literal<WithTimeline<GraphicsContent>>({

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/lyd.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/lyd.spec.ts
@@ -140,36 +140,6 @@ describe('lyd', () => {
 		expect(context.getNotes()[0].type).toEqual(NoteType.NOTIFY_USER_WARNING)
 	})
 
-	test('Lyd not configured', () => {
-		const parsedCue = ParseCue(['LYD=SN_MISSING', ';0.00-0.10'], CONFIG) as CueDefinitionLYD
-		const pieces: IBlueprintPiece[] = []
-		const adlibPieces: IBlueprintAdLibPiece[] = []
-		const actions: IBlueprintActionManifest[] = []
-
-		const context = makeMockContext()
-
-		EvaluateLYD(
-			context,
-			{
-				showStyle: (defaultShowStyleConfig as unknown) as ShowStyleConfig,
-				studio: (defaultStudioConfig as unknown) as StudioConfig,
-				sources: EMPTY_SOURCE_CONFIG,
-				mediaPlayers: [],
-				dsk: defaultDSKConfig,
-				selectedGraphicsSetup: DEFAULT_GRAPHICS_SETUP
-			},
-			pieces,
-			adlibPieces,
-			actions,
-			parsedCue,
-			MOCK_PART
-		)
-
-		expect(pieces.length).toEqual(0)
-		expect(context.getNotes().length).toEqual(1)
-		expect(context.getNotes()[0].type).toEqual(NoteType.NOTIFY_USER_WARNING)
-	})
-
 	test('Lyd adlib', () => {
 		const parsedCue = ParseCue(['LYD=SN_INTRO', ';x.xx'], CONFIG) as CueDefinitionLYD
 		const pieces: IBlueprintPiece[] = []

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -116,6 +116,7 @@ describe('telefon', () => {
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
 				lifespan: PieceLifespan.WithinPart,
 				metaData: literal<PieceMetaData>({
+					belongsToRemotePart: false,
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					}

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -12,9 +12,9 @@ import {
 	CueDefinitionGraphic,
 	CueDefinitionTelefon,
 	GraphicInternal,
+	GraphicPieceMetaData,
 	literal,
-	PartDefinitionKam,
-	PieceMetaData
+	PartDefinitionKam
 } from 'tv2-common'
 import { CueType, PartType, SharedGraphicLLayer, SharedOutputLayers, SourceType } from 'tv2-constants'
 import { SegmentUserContext } from '../../../../__mocks__/context'
@@ -106,7 +106,7 @@ describe('telefon', () => {
 			cue
 		)
 		expect(pieces).toEqual([
-			literal<IBlueprintPiece>({
+			literal<IBlueprintPiece<GraphicPieceMetaData>>({
 				externalId: partId,
 				name: 'TLF 1',
 				enable: {
@@ -115,12 +115,12 @@ describe('telefon', () => {
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
 				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData>({
+				metaData: {
 					belongsToRemotePart: false,
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					}
-				}),
+				},
 				content: literal<WithTimeline<GraphicsContent>>({
 					fileName: 'bund',
 					path: 'bund',

--- a/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
@@ -27,7 +27,7 @@ import { MakeContentDVE } from '../content/dve'
 export async function EvaluateAdLib(
 	context: IShowStyleUserContext,
 	config: BlueprintConfig,
-	adLibPieces: IBlueprintAdLibPiece[],
+	adLibPieces: Array<IBlueprintAdLibPiece<PieceMetaData>>,
 	actions: IBlueprintActionManifest[],
 	mediaSubscriptions: HackPartMediaObjectSubscription[],
 	partId: string,
@@ -100,33 +100,31 @@ export async function EvaluateAdLib(
 
 		const content = MakeContentDVE(context, config, partDefinition, cueDVE, rawTemplate, false, true)
 
-		adLibPieces.push(
-			literal<IBlueprintAdLibPiece>({
-				_rank: rank,
-				externalId: partId,
-				name: `DVE: ${parsedCue.variant}`,
-				sourceLayerId: SourceLayer.PgmDVE,
-				outputLayerId: SharedOutputLayers.PGM,
-				uniquenessId: getUniquenessIdDVE(cueDVE),
-				toBeQueued: true,
-				content: content.content,
-				invalid: !content.valid,
-				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData & DVEPieceMetaData>({
-					sources: cueDVE.sources,
-					config: rawTemplate,
-					userData: literal<ActionSelectDVE>({
-						type: AdlibActionType.SELECT_DVE,
-						config: cueDVE,
-						videoId: partDefinition.fields.videoId,
-						segmentExternalId: partDefinition.segmentExternalId
-					}),
-					sisyfosPersistMetaData: {
-						sisyfosLayers: []
-					}
+		adLibPieces.push({
+			_rank: rank,
+			externalId: partId,
+			name: `DVE: ${parsedCue.variant}`,
+			sourceLayerId: SourceLayer.PgmDVE,
+			outputLayerId: SharedOutputLayers.PGM,
+			uniquenessId: getUniquenessIdDVE(cueDVE),
+			toBeQueued: true,
+			content: content.content,
+			invalid: !content.valid,
+			lifespan: PieceLifespan.WithinPart,
+			metaData: literal<DVEPieceMetaData>({
+				sources: cueDVE.sources,
+				config: rawTemplate,
+				userData: literal<ActionSelectDVE>({
+					type: AdlibActionType.SELECT_DVE,
+					config: cueDVE,
+					videoId: partDefinition.fields.videoId,
+					segmentExternalId: partDefinition.segmentExternalId
 				}),
-				tags: [AdlibTags.ADLIB_FLOW_PRODUCER]
-			})
-		)
+				sisyfosPersistMetaData: {
+					sisyfosLayers: []
+				}
+			}),
+			tags: [AdlibTags.ADLIB_FLOW_PRODUCER]
+		})
 	}
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/clearGrafiks.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/clearGrafiks.ts
@@ -48,34 +48,32 @@ export function EvaluateClearGrafiks(
 		})
 	})
 
-	pieces.push(
-		literal<IBlueprintPiece>({
-			externalId: partId,
-			name: 'CLEAR',
-			...CreateTimingEnable(parsedCue, GetDefaultOut(config)),
-			outputLayerId: SharedOutputLayers.SEC,
-			sourceLayerId: SourceLayer.PgmAdlibGraphicCmd,
-			lifespan: PieceLifespan.WithinPart,
-			content: {
-				timelineObjects: config.studio.HTMLGraphics
-					? [
-							literal<TSR.TimelineObjVIZMSEClearAllElements>({
-								id: '',
-								enable: {
-									start: 0,
-									duration: 1000
-								},
-								priority: 100,
-								layer: SharedGraphicLLayer.GraphicLLayerAdLibs,
-								content: {
-									deviceType: TSR.DeviceType.VIZMSE,
-									type: TSR.TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
-									showId: config.selectedGraphicsSetup.OvlShowId
-								}
-							})
-					  ]
-					: []
-			}
-		})
-	)
+	pieces.push({
+		externalId: partId,
+		name: 'CLEAR',
+		...CreateTimingEnable(parsedCue, GetDefaultOut(config)),
+		outputLayerId: SharedOutputLayers.SEC,
+		sourceLayerId: SourceLayer.PgmAdlibGraphicCmd,
+		lifespan: PieceLifespan.WithinPart,
+		content: {
+			timelineObjects: config.studio.HTMLGraphics
+				? [
+						literal<TSR.TimelineObjVIZMSEClearAllElements>({
+							id: '',
+							enable: {
+								start: 0,
+								duration: 1000
+							},
+							priority: 100,
+							layer: SharedGraphicLLayer.GraphicLLayerAdLibs,
+							content: {
+								deviceType: TSR.DeviceType.VIZMSE,
+								type: TSR.TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
+								showId: config.selectedGraphicsSetup.OvlShowId
+							}
+						})
+				  ]
+				: []
+		}
+	})
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/clearGrafiks.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/clearGrafiks.ts
@@ -25,7 +25,6 @@ export function EvaluateClearGrafiks(
 
 	;[
 		SourceLayer.PgmGraphicsIdent,
-		SourceLayer.PgmGraphicsIdentPersistent,
 		SourceLayer.PgmGraphicsTop,
 		SourceLayer.PgmGraphicsLower,
 		SourceLayer.PgmGraphicsHeadline,

--- a/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
@@ -15,7 +15,6 @@ import {
 	getUniquenessIdDVE,
 	literal,
 	PartDefinition,
-	PieceMetaData,
 	TemplateIsValid
 } from 'tv2-common'
 import { AdlibActionType, SharedOutputLayers } from 'tv2-constants'
@@ -62,7 +61,7 @@ export function EvaluateDVE(
 	if (content.valid) {
 		if (adlib) {
 			adlibPieces.push(
-				literal<IBlueprintAdLibPiece>({
+				literal<IBlueprintAdLibPiece<DVEPieceMetaData>>({
 					_rank: rank || 0,
 					externalId: partDefinition.externalId,
 					name: `${partDefinition.storyName} DVE: ${parsedCue.template}`,
@@ -73,7 +72,7 @@ export function EvaluateDVE(
 					toBeQueued: true,
 					content: content.content,
 					prerollDuration: Number(config.studio.CasparPrerollDuration) || 0,
-					metaData: literal<DVEPieceMetaData & PieceMetaData>({
+					metaData: {
 						sources: parsedCue.sources,
 						config: rawTemplate,
 						userData: literal<ActionSelectDVE>({
@@ -85,7 +84,7 @@ export function EvaluateDVE(
 						sisyfosPersistMetaData: {
 							sisyfosLayers: []
 						}
-					})
+					}
 				})
 			)
 		} else {
@@ -93,7 +92,7 @@ export function EvaluateDVE(
 			start = start ? start : 0
 			const end = parsedCue.end ? CalculateTime(parsedCue.end) : undefined
 			pieces.push(
-				literal<IBlueprintPiece>({
+				literal<IBlueprintPiece<DVEPieceMetaData>>({
 					externalId: partDefinition.externalId,
 					name: `DVE: ${parsedCue.template}`,
 					enable: {
@@ -106,20 +105,20 @@ export function EvaluateDVE(
 					toBeQueued: true,
 					content: content.content,
 					prerollDuration: Number(config.studio.CasparPrerollDuration) || 0,
-					metaData: literal<PieceMetaData & DVEPieceMetaData>({
+					metaData: {
 						mediaPlayerSessions: [partDefinition.segmentExternalId],
 						sources: parsedCue.sources,
 						config: rawTemplate,
-						userData: literal<ActionSelectDVE>({
+						userData: {
 							type: AdlibActionType.SELECT_DVE,
 							config: parsedCue,
 							videoId: partDefinition.fields.videoId,
 							segmentExternalId: partDefinition.segmentExternalId
-						}),
+						},
 						sisyfosPersistMetaData: {
 							sisyfosLayers: []
 						}
-					})
+					}
 				})
 			)
 		}

--- a/src/tv2_afvd_showstyle/helpers/pieces/ekstern.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/ekstern.ts
@@ -5,7 +5,13 @@ import {
 	IBlueprintPiece,
 	ISegmentUserContext
 } from '@tv2media/blueprints-integration'
-import { CueDefinitionEkstern, EvaluateEksternBase, PartDefinition, TV2BlueprintConfig } from 'tv2-common'
+import {
+	CueDefinitionEkstern,
+	EvaluateEksternBase,
+	PartDefinition,
+	PieceMetaData,
+	TV2BlueprintConfig
+} from 'tv2-common'
 import { AtemLLayer } from '../../../tv2_afvd_studio/layers'
 import { SourceLayer } from '../../layers'
 
@@ -13,8 +19,8 @@ export function EvaluateEkstern(
 	context: ISegmentUserContext,
 	config: TV2BlueprintConfig,
 	part: IBlueprintPart,
-	pieces: IBlueprintPiece[],
-	adlibPieces: IBlueprintAdLibPiece[],
+	pieces: Array<IBlueprintPiece<PieceMetaData>>,
+	adlibPieces: Array<IBlueprintAdLibPiece<PieceMetaData>>,
 	_actions: IBlueprintActionManifest[],
 	partId: string,
 	parsedCue: CueDefinitionEkstern,

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphic.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphic.ts
@@ -33,7 +33,7 @@ export function EvaluateCueGraphic(
 	}
 
 	if (GraphicIsInternal(parsedCue)) {
-		CreateInternalGraphic(config, context, pieces, adlibPieces, actions, partId, parsedCue, partDefinition, adlib)
+		CreateInternalGraphic(config, context, pieces, adlibPieces, partId, parsedCue, partDefinition, adlib)
 	} else if (GraphicIsPilot(parsedCue)) {
 		EvaluateCueGraphicPilot(
 			config,

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
@@ -28,80 +28,72 @@ export function EvaluateCueBackgroundLoop(
 		const fileName = parsedCue.backgroundLoop
 		const path = `dve/${fileName}`
 		if (adlib) {
-			adlibPieces.push(
-				literal<IBlueprintAdLibPiece>({
-					_rank: rank || 0,
-					externalId: partId,
-					name: fileName,
-					outputLayerId: SharedOutputLayers.SEC,
-					sourceLayerId: SourceLayer.PgmDVEBackground,
-					lifespan: PieceLifespan.OutOnShowStyleEnd,
-					content: literal<WithTimeline<GraphicsContent>>({
-						fileName,
-						path,
-						ignoreMediaObjectStatus: true,
-						timelineObjects: dveLoopTimeline(path)
-					})
+			adlibPieces.push({
+				_rank: rank || 0,
+				externalId: partId,
+				name: fileName,
+				outputLayerId: SharedOutputLayers.SEC,
+				sourceLayerId: SourceLayer.PgmDVEBackground,
+				lifespan: PieceLifespan.OutOnShowStyleEnd,
+				content: literal<WithTimeline<GraphicsContent>>({
+					fileName,
+					path,
+					ignoreMediaObjectStatus: true,
+					timelineObjects: dveLoopTimeline(path)
 				})
-			)
+			})
 		} else {
-			pieces.push(
-				literal<IBlueprintPiece>({
-					externalId: partId,
-					name: fileName,
-					enable: {
-						start
-					},
-					outputLayerId: SharedOutputLayers.SEC,
-					sourceLayerId: SourceLayer.PgmDVEBackground,
-					lifespan: PieceLifespan.OutOnShowStyleEnd,
-					content: literal<WithTimeline<GraphicsContent>>({
-						fileName,
-						path,
-						ignoreMediaObjectStatus: true,
-						timelineObjects: dveLoopTimeline(path)
-					})
+			pieces.push({
+				externalId: partId,
+				name: fileName,
+				enable: {
+					start
+				},
+				outputLayerId: SharedOutputLayers.SEC,
+				sourceLayerId: SourceLayer.PgmDVEBackground,
+				lifespan: PieceLifespan.OutOnShowStyleEnd,
+				content: literal<WithTimeline<GraphicsContent>>({
+					fileName,
+					path,
+					ignoreMediaObjectStatus: true,
+					timelineObjects: dveLoopTimeline(path)
 				})
-			)
+			})
 		}
 	} else {
 		// Full
 		if (adlib) {
-			adlibPieces.push(
-				literal<IBlueprintAdLibPiece>({
-					_rank: rank || 0,
-					externalId: partId,
-					name: parsedCue.backgroundLoop,
-					outputLayerId: SharedOutputLayers.SEC,
-					sourceLayerId: SourceLayer.PgmFullBackground,
-					lifespan: PieceLifespan.OutOnShowStyleEnd,
-					content: literal<WithTimeline<GraphicsContent>>({
-						fileName: parsedCue.backgroundLoop,
-						path: parsedCue.backgroundLoop,
-						ignoreMediaObjectStatus: true,
-						timelineObjects: fullLoopTimeline(config, parsedCue)
-					})
+			adlibPieces.push({
+				_rank: rank || 0,
+				externalId: partId,
+				name: parsedCue.backgroundLoop,
+				outputLayerId: SharedOutputLayers.SEC,
+				sourceLayerId: SourceLayer.PgmFullBackground,
+				lifespan: PieceLifespan.OutOnShowStyleEnd,
+				content: literal<WithTimeline<GraphicsContent>>({
+					fileName: parsedCue.backgroundLoop,
+					path: parsedCue.backgroundLoop,
+					ignoreMediaObjectStatus: true,
+					timelineObjects: fullLoopTimeline(config, parsedCue)
 				})
-			)
+			})
 		} else {
-			pieces.push(
-				literal<IBlueprintPiece>({
-					externalId: partId,
-					name: parsedCue.backgroundLoop,
-					enable: {
-						start
-					},
-					outputLayerId: SharedOutputLayers.SEC,
-					sourceLayerId: SourceLayer.PgmFullBackground,
-					lifespan: PieceLifespan.OutOnShowStyleEnd,
-					content: literal<WithTimeline<GraphicsContent>>({
-						fileName: parsedCue.backgroundLoop,
-						path: parsedCue.backgroundLoop,
-						ignoreMediaObjectStatus: true,
-						timelineObjects: fullLoopTimeline(config, parsedCue)
-					})
+			pieces.push({
+				externalId: partId,
+				name: parsedCue.backgroundLoop,
+				enable: {
+					start
+				},
+				outputLayerId: SharedOutputLayers.SEC,
+				sourceLayerId: SourceLayer.PgmFullBackground,
+				lifespan: PieceLifespan.OutOnShowStyleEnd,
+				content: literal<WithTimeline<GraphicsContent>>({
+					fileName: parsedCue.backgroundLoop,
+					path: parsedCue.backgroundLoop,
+					ignoreMediaObjectStatus: true,
+					timelineObjects: fullLoopTimeline(config, parsedCue)
 				})
-			)
+			})
 		}
 	}
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
@@ -12,7 +12,6 @@ import {
 	generateExternalId,
 	GetTagForJingle,
 	GetTagForJingleNext,
-	literal,
 	PartDefinition,
 	t,
 	TimeFromFrames
@@ -52,61 +51,57 @@ export function EvaluateJingle(
 	}
 
 	if (adlib) {
-		const userData = literal<ActionSelectJingle>({
+		const userData: ActionSelectJingle = {
 			type: AdlibActionType.SELECT_JINGLE,
 			clip: parsedCue.clip,
 			segmentExternalId: part.segmentExternalId
-		})
-		actions.push(
-			literal<IBlueprintActionManifest>({
-				externalId: generateExternalId(context, userData),
-				actionId: AdlibActionType.SELECT_JINGLE,
-				userData,
-				userDataManifest: {},
-				display: {
-					_rank: rank ?? 0,
-					label: t(effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip),
-					sourceLayerId: SourceLayer.PgmJingle,
-					outputLayerId: SharedOutputLayers.JINGLE,
-					content: {
-						...createJingleContentAFVD(
-							config,
-							file,
-							jingle.StartAlpha,
-							jingle.LoadFirstFrame,
-							jingle.Duration,
-							jingle.EndAlpha
-						)
-					},
-					tags: [AdlibTags.ADLIB_FLOW_PRODUCER],
-					currentPieceTags: [GetTagForJingle(part.segmentExternalId, parsedCue.clip)],
-					nextPieceTags: [GetTagForJingleNext(part.segmentExternalId, parsedCue.clip)]
-				}
-			})
-		)
-	} else {
-		pieces.push(
-			literal<IBlueprintPiece>({
-				externalId: `${part.externalId}-JINGLE`,
-				name: effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip,
-				enable: {
-					start: 0
-				},
-				lifespan: PieceLifespan.WithinPart,
-				outputLayerId: SharedOutputLayers.JINGLE,
+		}
+		actions.push({
+			externalId: generateExternalId(context, userData),
+			actionId: AdlibActionType.SELECT_JINGLE,
+			userData,
+			userDataManifest: {},
+			display: {
+				_rank: rank ?? 0,
+				label: t(effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip),
 				sourceLayerId: SourceLayer.PgmJingle,
-				prerollDuration: config.studio.CasparPrerollDuration + TimeFromFrames(Number(jingle.StartAlpha)),
-				tags: [!effekt ? TallyTags.JINGLE : ''],
-				content: createJingleContentAFVD(
-					config,
-					file,
-					jingle.StartAlpha,
-					jingle.LoadFirstFrame,
-					jingle.Duration,
-					jingle.EndAlpha
-				)
-			})
-		)
+				outputLayerId: SharedOutputLayers.JINGLE,
+				content: {
+					...createJingleContentAFVD(
+						config,
+						file,
+						jingle.StartAlpha,
+						jingle.LoadFirstFrame,
+						jingle.Duration,
+						jingle.EndAlpha
+					)
+				},
+				tags: [AdlibTags.ADLIB_FLOW_PRODUCER],
+				currentPieceTags: [GetTagForJingle(part.segmentExternalId, parsedCue.clip)],
+				nextPieceTags: [GetTagForJingleNext(part.segmentExternalId, parsedCue.clip)]
+			}
+		})
+	} else {
+		pieces.push({
+			externalId: `${part.externalId}-JINGLE`,
+			name: effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip,
+			enable: {
+				start: 0
+			},
+			lifespan: PieceLifespan.WithinPart,
+			outputLayerId: SharedOutputLayers.JINGLE,
+			sourceLayerId: SourceLayer.PgmJingle,
+			prerollDuration: config.studio.CasparPrerollDuration + TimeFromFrames(Number(jingle.StartAlpha)),
+			tags: [!effekt ? TallyTags.JINGLE : ''],
+			content: createJingleContentAFVD(
+				config,
+				file,
+				jingle.StartAlpha,
+				jingle.LoadFirstFrame,
+				jingle.Duration,
+				jingle.EndAlpha
+			)
+		})
 	}
 }
 
@@ -118,7 +113,7 @@ export function createJingleContentAFVD(
 	duration: number,
 	alphaAtEnd: number
 ) {
-	const content = CreateJingleContentBase(config, file, alphaAtStart, loadFirstFrame, duration, alphaAtEnd, {
+	return CreateJingleContentBase(config, file, alphaAtStart, loadFirstFrame, duration, alphaAtEnd, {
 		Caspar: {
 			PlayerJingle: CasparLLayer.CasparPlayerJingle
 		},
@@ -129,6 +124,4 @@ export function createJingleContentAFVD(
 			PlayerJingle: SisyfosLLAyer.SisyfosSourceJingle
 		}
 	})
-
-	return content
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/routing.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/routing.ts
@@ -37,35 +37,33 @@ export function EvaluateCueRouting(
 		return
 	}
 
-	pieces.push(
-		literal<IBlueprintPiece>({
-			externalId: partId,
-			enable: {
-				start: time
-			},
-			name,
-			outputLayerId: SharedOutputLayers.AUX,
-			sourceLayerId: SourceLayer.VizFullIn1,
-			lifespan: PieceLifespan.WithinPart,
-			content: literal<WithTimeline<CameraContent>>({
-				studioLabel: '',
-				switcherInput: sourceInfo.port,
-				timelineObjects: _.compact<TSR.TSRTimelineObj[]>([
-					literal<TSR.TimelineObjAtemAUX>({
-						id: '',
-						enable: { start: 0 },
-						priority: 100,
-						layer: AtemLLayer.AtemAuxVizOvlIn1,
-						content: {
-							deviceType: TSR.DeviceType.ATEM,
-							type: TSR.TimelineContentTypeAtem.AUX,
-							aux: {
-								input: sourceInfo.port
-							}
+	pieces.push({
+		externalId: partId,
+		enable: {
+			start: time
+		},
+		name,
+		outputLayerId: SharedOutputLayers.AUX,
+		sourceLayerId: SourceLayer.VizFullIn1,
+		lifespan: PieceLifespan.WithinPart,
+		content: literal<WithTimeline<CameraContent>>({
+			studioLabel: '',
+			switcherInput: sourceInfo.port,
+			timelineObjects: _.compact<TSR.TSRTimelineObj[]>([
+				literal<TSR.TimelineObjAtemAUX>({
+					id: '',
+					enable: { start: 0 },
+					priority: 100,
+					layer: AtemLLayer.AtemAuxVizOvlIn1,
+					content: {
+						deviceType: TSR.DeviceType.ATEM,
+						type: TSR.TimelineContentTypeAtem.AUX,
+						aux: {
+							input: sourceInfo.port
 						}
-					})
-				])
-			})
+					}
+				})
+			])
 		})
-	)
+	})
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/showLifecycle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/showLifecycle.ts
@@ -1,4 +1,4 @@
-import { BlueprintResultPart, IBlueprintPiece, PieceLifespan, TSR } from '@tv2media/blueprints-integration'
+import { BlueprintResultPart, PieceLifespan, TSR } from '@tv2media/blueprints-integration'
 import { literal, TV2BlueprintConfig } from 'tv2-common'
 import { SharedOutputLayers } from 'tv2-constants'
 import { GraphicLLayer } from '../../../tv2_afvd_studio/layers'
@@ -11,43 +11,41 @@ export function CreateShowLifecyclePieces(
 	cleanupShowIds: string[]
 ) {
 	if (config.studio.GraphicsType === 'VIZ') {
-		part.pieces.push(
-			literal<IBlueprintPiece>({
-				externalId: part.part.externalId,
-				name: 'GFX Show Init',
-				enable: { start: 0 },
-				outputLayerId: SharedOutputLayers.SEC,
-				sourceLayerId: SourceLayer.GraphicsShowLifecycle,
-				lifespan: PieceLifespan.OutOnSegmentChange,
-				content: {
-					timelineObjects: [
-						literal<TSR.TimelineObjVIZMSEInitializeShows>({
-							id: '',
-							enable: {
-								while: '1'
-							},
-							layer: GraphicLLayer.GraphicLLayerInitialize,
-							content: {
-								deviceType: TSR.DeviceType.VIZMSE,
-								type: TSR.TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
-								showIds: initializeShowIds
-							}
-						}),
-						literal<TSR.TimelineObjVIZMSECleanupShows>({
-							id: '',
-							enable: {
-								while: '1'
-							},
-							layer: GraphicLLayer.GraphicLLayerCleanup,
-							content: {
-								deviceType: TSR.DeviceType.VIZMSE,
-								type: TSR.TimelineContentTypeVizMSE.CLEANUP_SHOWS,
-								showIds: cleanupShowIds
-							}
-						})
-					]
-				}
-			})
-		)
+		part.pieces.push({
+			externalId: part.part.externalId,
+			name: 'GFX Show Init',
+			enable: { start: 0 },
+			outputLayerId: SharedOutputLayers.SEC,
+			sourceLayerId: SourceLayer.GraphicsShowLifecycle,
+			lifespan: PieceLifespan.OutOnSegmentChange,
+			content: {
+				timelineObjects: [
+					literal<TSR.TimelineObjVIZMSEInitializeShows>({
+						id: '',
+						enable: {
+							while: '1'
+						},
+						layer: GraphicLLayer.GraphicLLayerInitialize,
+						content: {
+							deviceType: TSR.DeviceType.VIZMSE,
+							type: TSR.TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
+							showIds: initializeShowIds
+						}
+					}),
+					literal<TSR.TimelineObjVIZMSECleanupShows>({
+						id: '',
+						enable: {
+							while: '1'
+						},
+						layer: GraphicLLayer.GraphicLLayerCleanup,
+						content: {
+							deviceType: TSR.DeviceType.VIZMSE,
+							type: TSR.TimelineContentTypeVizMSE.CLEANUP_SHOWS,
+							showIds: cleanupShowIds
+						}
+					})
+				]
+			}
+		})
 	}
 }

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -4,7 +4,6 @@ import {
 	changeGFXTemplate,
 	GetDefaultAdLibTriggers,
 	GetDSKSourceLayerNames,
-	literal,
 	RemoveOldShortcuts,
 	removeSourceLayer,
 	SetShowstyleTransitionMigrationStep,
@@ -15,7 +14,6 @@ import {
 	UpsertValuesIntoTransitionTable
 } from 'tv2-common'
 import { SharedGraphicLLayer } from 'tv2-constants'
-import * as _ from 'underscore'
 import { remapVizDOvl, remapVizLLayer } from '../../tv2_offtube_showstyle/migrations'
 import { remapTableColumnValues } from '../../tv2_offtube_showstyle/migrations/util'
 import { ATEMModel } from '../../types/atem'
@@ -38,7 +36,7 @@ const SHOW_STYLE_ID = 'tv2_afvd_showstyle'
  * 0.1.0: Core 0.24.0
  */
 
-export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationStepShowStyle[]>([
+export const showStyleMigrations: MigrationStepShowStyle[] = [
 	...getCreateVariantMigrationSteps(),
 	...remapTableColumnValues('0.1.0', 'GFXTemplates', 'LayerMapping', remapVizLLayer),
 	// Rename "viz-d-ovl" to "OVL1"
@@ -246,4 +244,4 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 		GetDefaultStudioSourcesForAFVD,
 		false
 	)
-])
+]

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -119,7 +119,7 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	 */
 	// OVERLAY group
 	SetSourceLayerName('1.6.9', SourceLayer.PgmGraphicsIdent, 'GFX Ident'),
-	SetSourceLayerName('1.6.9', SourceLayer.PgmGraphicsIdentPersistent, 'GFX Ident Persistent (hidden)'),
+	SetSourceLayerName('1.6.9', 'studio0_graphicsIdent_persistent', 'GFX Ident Persistent (hidden)'),
 	SetSourceLayerName('1.6.9', SourceLayer.PgmGraphicsTop, 'GFX Top'),
 	SetSourceLayerName('1.6.9', SourceLayer.PgmGraphicsLower, 'GFX Lowerthirds'),
 	SetSourceLayerName('1.6.9', SourceLayer.PgmGraphicsHeadline, 'GFX Headline'),
@@ -183,7 +183,7 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	 * - Change source layer type for graphics that don't have previews
 	 */
 	SetSourceLayerProperties('1.7.1', SourceLayer.PgmGraphicsIdent, { type: SourceLayerType.LOWER_THIRD }),
-	SetSourceLayerProperties('1.7.1', SourceLayer.PgmGraphicsIdentPersistent, { type: SourceLayerType.LOWER_THIRD }),
+	SetSourceLayerProperties('1.7.1', 'studio0_graphicsIdent_persistent', { type: SourceLayerType.LOWER_THIRD }),
 	SetSourceLayerProperties('1.7.1', SourceLayer.PgmGraphicsTop, { type: SourceLayerType.LOWER_THIRD }),
 	SetSourceLayerProperties('1.7.1', SourceLayer.PgmGraphicsLower, { type: SourceLayerType.LOWER_THIRD }),
 	SetSourceLayerProperties('1.7.1', SourceLayer.PgmGraphicsHeadline, { type: SourceLayerType.LOWER_THIRD }),
@@ -228,6 +228,13 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 		},
 		{ LayerMapping: 'graphic_overlay_lower' }
 	),
+
+	/**
+	 * 1.7.5
+	 * - Remove persistent idents
+	 */
+	removeSourceLayer('1.7.5', 'AFVD', 'studio0_graphicsIdent_persistent'),
+
 	// Fill in any layers that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations
 	...getSourceLayerDefaultsMigrationSteps(VERSION),

--- a/src/tv2_afvd_showstyle/migrations/sourcelayer-defaults.ts
+++ b/src/tv2_afvd_showstyle/migrations/sourcelayer-defaults.ts
@@ -25,24 +25,6 @@ const OVERLAY: ISourceLayer[] = [
 		onPresenterScreen: false
 	},
 	{
-		_id: SourceLayer.PgmGraphicsIdentPersistent,
-		_rank: 10,
-		name: 'GFX Ident Persistent (hidden)',
-		abbreviation: 'G',
-		type: SourceLayerType.LOWER_THIRD,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		isClearable: true,
-
-		isSticky: false,
-
-		isQueueable: false,
-		isHidden: true,
-		allowDisable: false,
-		onPresenterScreen: false
-	},
-	{
 		_id: SourceLayer.PgmGraphicsTop,
 		_rank: 20,
 		name: 'GFX Top',

--- a/src/tv2_afvd_showstyle/migrations/util.ts
+++ b/src/tv2_afvd_showstyle/migrations/util.ts
@@ -13,7 +13,7 @@ import SourcelayerDefaults from './sourcelayer-defaults'
 export function getSourceLayerDefaultsMigrationSteps(versionStr: string, force?: boolean): MigrationStepShowStyle[] {
 	return _.compact(
 		_.map(SourcelayerDefaults, (defaultVal: ISourceLayer): MigrationStepShowStyle | null => {
-			return literal<MigrationStepShowStyle>({
+			return {
 				id: `${versionStr}.sourcelayer.defaults${force ? '.forced' : ''}.${defaultVal._id}`,
 				version: versionStr,
 				canBeRunAutomatically: true,
@@ -38,7 +38,7 @@ export function getSourceLayerDefaultsMigrationSteps(versionStr: string, force?:
 						context.insertSourceLayer(defaultVal._id, defaultVal)
 					}
 				}
-			})
+			}
 		})
 	)
 }
@@ -52,7 +52,7 @@ export function forceSourceLayerToDefaults(
 }
 
 export function forceSettingToDefaults(versionStr: string, setting: string): MigrationStepShowStyle {
-	return literal<MigrationStepShowStyle>({
+	return {
 		id: `${versionStr}.sourcelayer.defaults.${setting}.forced`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -85,7 +85,7 @@ export function forceSettingToDefaults(versionStr: string, setting: string): Mig
 				context.setBaseConfig(setting, defaultVal.defaultVal)
 			}
 		}
-	})
+	}
 }
 
 export function getOutputLayerDefaultsMigrationSteps(versionStr: string): MigrationStepShowStyle[] {

--- a/src/tv2_afvd_showstyle/parts/cueonly.ts
+++ b/src/tv2_afvd_showstyle/parts/cueonly.ts
@@ -12,7 +12,6 @@ import {
 	CueDefinition,
 	GetJinglePartProperties,
 	GraphicIsPilot,
-	literal,
 	PartDefinition,
 	PartTime
 } from 'tv2-common'
@@ -34,11 +33,11 @@ export async function CreatePartCueOnly(
 	const partDefinitionWithID = { ...partDefinition, ...{ externalId: id } }
 	const partTime = PartTime(config, partDefinitionWithID, totalWords, false)
 
-	let part = literal<IBlueprintPart>({
+	let part: IBlueprintPart = {
 		externalId: id,
 		title,
 		metaData: {}
-	})
+	}
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const pieces: IBlueprintPiece[] = []

--- a/src/tv2_afvd_showstyle/parts/evs.ts
+++ b/src/tv2_afvd_showstyle/parts/evs.ts
@@ -39,15 +39,15 @@ export async function CreatePartEVS(
 	const partTime = PartTime(config, partDefinition, totalWords, false)
 	const title = partDefinition.sourceDefinition.name
 
-	let part = literal<IBlueprintPart>({
+	let part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title,
 		metaData: {},
 		expectedDuration: partTime > 0 ? partTime : 0
-	})
+	}
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
-	const pieces: IBlueprintPiece[] = []
+	const pieces: Array<IBlueprintPiece<PieceMetaData>> = []
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
@@ -59,22 +59,20 @@ export async function CreatePartEVS(
 	}
 	const atemInput = sourceInfoReplay.port
 
-	pieces.push(
-		literal<IBlueprintPiece>({
-			externalId: partDefinition.externalId,
-			name: part.title,
-			enable: { start: 0 },
-			outputLayerId: SharedOutputLayers.PGM,
-			sourceLayerId: SourceLayer.PgmLocal,
-			lifespan: PieceLifespan.WithinPart,
-			metaData: literal<PieceMetaData>({
-				sisyfosPersistMetaData: {
-					sisyfosLayers: []
-				}
-			}),
-			content: makeContentEVS(config, atemInput, partDefinition, sourceInfoReplay)
-		})
-	)
+	pieces.push({
+		externalId: partDefinition.externalId,
+		name: part.title,
+		enable: { start: 0 },
+		outputLayerId: SharedOutputLayers.PGM,
+		sourceLayerId: SourceLayer.PgmLocal,
+		lifespan: PieceLifespan.WithinPart,
+		metaData: {
+			sisyfosPersistMetaData: {
+				sisyfosLayers: []
+			}
+		},
+		content: makeContentEVS(config, atemInput, partDefinition, sourceInfoReplay)
+	})
 
 	await EvaluateCues(
 		context,

--- a/src/tv2_afvd_showstyle/parts/grafik.ts
+++ b/src/tv2_afvd_showstyle/parts/grafik.ts
@@ -7,14 +7,7 @@ import {
 	IBlueprintPiece,
 	ISegmentUserContext
 } from '@tv2media/blueprints-integration'
-import {
-	AddScript,
-	ApplyFullGraphicPropertiesToPart,
-	GraphicIsPilot,
-	literal,
-	PartDefinition,
-	PartTime
-} from 'tv2-common'
+import { AddScript, ApplyFullGraphicPropertiesToPart, GraphicIsPilot, PartDefinition, PartTime } from 'tv2-common'
 import { CueType } from 'tv2-constants'
 import { BlueprintConfig } from '../helpers/config'
 import { EvaluateCues } from '../helpers/pieces/evaluateCues'
@@ -27,11 +20,11 @@ export async function CreatePartGrafik(
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(config, partDefinition, totalWords, false)
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title: partDefinition.type + ' - ' + partDefinition.rawType,
 		metaData: {}
-	})
+	}
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const pieces: IBlueprintPiece[] = []

--- a/src/tv2_afvd_showstyle/parts/intro.ts
+++ b/src/tv2_afvd_showstyle/parts/intro.ts
@@ -12,7 +12,6 @@ import {
 	CreatePartInvalid,
 	CueDefinitionJingle,
 	GetJinglePartProperties,
-	literal,
 	PartDefinition,
 	PartTime
 } from 'tv2-common'
@@ -61,11 +60,11 @@ export async function CreatePartIntro(
 		return CreatePartInvalid(partDefinition)
 	}
 
-	let part = literal<IBlueprintPart>({
+	let part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title: partDefinition.type + ' - ' + partDefinition.rawType,
 		metaData: {}
-	})
+	}
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const pieces: IBlueprintPiece[] = []

--- a/src/tv2_afvd_showstyle/parts/kam.ts
+++ b/src/tv2_afvd_showstyle/parts/kam.ts
@@ -45,52 +45,50 @@ export async function CreatePartKam(
 	const partTime = partKamBase.duration
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
-	const pieces: IBlueprintPiece[] = []
+	const pieces: Array<IBlueprintPiece<PieceMetaData>> = []
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
 	const jingleDSK = FindDSKJingle(config)
 
 	if (partDefinition.rawType.match(/kam cs ?3/i)) {
-		pieces.push(
-			literal<IBlueprintPiece>({
-				externalId: partDefinition.externalId,
-				name: 'CS 3 (JINGLE)',
-				enable: { start: 0 },
-				outputLayerId: SharedOutputLayers.PGM,
-				sourceLayerId: SourceLayer.PgmJingle,
-				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData>({
-					sisyfosPersistMetaData: {
-						sisyfosLayers: []
-					}
-				}),
-				content: literal<WithTimeline<VTContent>>({
-					ignoreMediaObjectStatus: true,
-					fileName: '',
-					path: '',
-					timelineObjects: literal<TimelineObjectCoreExt[]>([
-						literal<TSR.TimelineObjAtemME>({
-							id: ``,
-							enable: {
-								start: 0
-							},
-							priority: 1,
-							layer: AtemLLayer.AtemMEProgram,
-							content: {
-								deviceType: TSR.DeviceType.ATEM,
-								type: TSR.TimelineContentTypeAtem.ME,
-								me: {
-									input: jingleDSK.Fill,
-									transition: partDefinition.transition ? partDefinition.transition.style : TSR.AtemTransitionStyle.CUT,
-									transitionSettings: TransitionSettings(config, partDefinition)
-								}
+		pieces.push({
+			externalId: partDefinition.externalId,
+			name: 'CS 3 (JINGLE)',
+			enable: { start: 0 },
+			outputLayerId: SharedOutputLayers.PGM,
+			sourceLayerId: SourceLayer.PgmJingle,
+			lifespan: PieceLifespan.WithinPart,
+			metaData: {
+				sisyfosPersistMetaData: {
+					sisyfosLayers: []
+				}
+			},
+			content: literal<WithTimeline<VTContent>>({
+				ignoreMediaObjectStatus: true,
+				fileName: '',
+				path: '',
+				timelineObjects: literal<TimelineObjectCoreExt[]>([
+					literal<TSR.TimelineObjAtemME>({
+						id: ``,
+						enable: {
+							start: 0
+						},
+						priority: 1,
+						layer: AtemLLayer.AtemMEProgram,
+						content: {
+							deviceType: TSR.DeviceType.ATEM,
+							type: TSR.TimelineContentTypeAtem.ME,
+							me: {
+								input: jingleDSK.Fill,
+								transition: partDefinition.transition ? partDefinition.transition.style : TSR.AtemTransitionStyle.CUT,
+								transitionSettings: TransitionSettings(config, partDefinition)
 							}
-						})
-					])
-				})
+						}
+					})
+				])
 			})
-		)
+		})
 		part.expectedDuration = TimeFromINewsField(partDefinition.fields.totalTime) * 1000
 	} else {
 		const sourceInfoCam = findSourceInfo(config.sources, partDefinition.sourceDefinition)
@@ -102,49 +100,47 @@ export async function CreatePartKam(
 
 		part = { ...part, ...CreateEffektForpart(context, config, partDefinition, pieces) }
 
-		pieces.push(
-			literal<IBlueprintPiece>({
-				externalId: partDefinition.externalId,
-				name: part.title,
-				enable: { start: 0 },
-				outputLayerId: SharedOutputLayers.PGM,
-				sourceLayerId: SourceLayer.PgmCam,
-				lifespan: PieceLifespan.WithinPart,
-				metaData: literal<PieceMetaData>({
-					sisyfosPersistMetaData: {
-						sisyfosLayers: sourceInfoCam.sisyfosLayers ?? [],
-						acceptPersistAudio: sourceInfoCam.acceptPersistAudio
-					}
-				}),
-				content: {
-					studioLabel: '',
-					switcherInput: atemInput,
-					timelineObjects: literal<TimelineObjectCoreExt[]>([
-						literal<TSR.TimelineObjAtemME>({
-							id: ``,
-							enable: {
-								start: 0
-							},
-							priority: 1,
-							layer: AtemLLayer.AtemMEProgram,
-							content: {
-								deviceType: TSR.DeviceType.ATEM,
-								type: TSR.TimelineContentTypeAtem.ME,
-								me: {
-									input: Number(atemInput),
-									transition: partDefinition.transition ? partDefinition.transition.style : TSR.AtemTransitionStyle.CUT,
-									transitionSettings: TransitionSettings(config, partDefinition)
-								}
-							},
-							...(AddParentClass(config, partDefinition)
-								? { classes: [CameraParentClass('studio0', partDefinition.sourceDefinition.id)] }
-								: {})
-						}),
-						...GetSisyfosTimelineObjForCamera(config, sourceInfoCam, partDefinition.sourceDefinition.minusMic)
-					])
+		pieces.push({
+			externalId: partDefinition.externalId,
+			name: part.title,
+			enable: { start: 0 },
+			outputLayerId: SharedOutputLayers.PGM,
+			sourceLayerId: SourceLayer.PgmCam,
+			lifespan: PieceLifespan.WithinPart,
+			metaData: {
+				sisyfosPersistMetaData: {
+					sisyfosLayers: sourceInfoCam.sisyfosLayers ?? [],
+					acceptPersistAudio: sourceInfoCam.acceptPersistAudio
 				}
-			})
-		)
+			},
+			content: {
+				studioLabel: '',
+				switcherInput: atemInput,
+				timelineObjects: literal<TimelineObjectCoreExt[]>([
+					literal<TSR.TimelineObjAtemME>({
+						id: ``,
+						enable: {
+							start: 0
+						},
+						priority: 1,
+						layer: AtemLLayer.AtemMEProgram,
+						content: {
+							deviceType: TSR.DeviceType.ATEM,
+							type: TSR.TimelineContentTypeAtem.ME,
+							me: {
+								input: Number(atemInput),
+								transition: partDefinition.transition ? partDefinition.transition.style : TSR.AtemTransitionStyle.CUT,
+								transitionSettings: TransitionSettings(config, partDefinition)
+							}
+						},
+						...(AddParentClass(config, partDefinition)
+							? { classes: [CameraParentClass('studio0', partDefinition.sourceDefinition.id)] }
+							: {})
+					}),
+					...GetSisyfosTimelineObjForCamera(config, sourceInfoCam, partDefinition.sourceDefinition.minusMic)
+				])
+			}
+		})
 	}
 
 	await EvaluateCues(

--- a/src/tv2_afvd_showstyle/parts/live.ts
+++ b/src/tv2_afvd_showstyle/parts/live.ts
@@ -7,7 +7,7 @@ import {
 	IBlueprintPiece,
 	ISegmentUserContext
 } from '@tv2media/blueprints-integration'
-import { AddScript, CueDefinitionEkstern, literal, PartDefinition, PartTime } from 'tv2-common'
+import { AddScript, CueDefinitionEkstern, PartDefinition, PartTime } from 'tv2-common'
 import { CueType } from 'tv2-constants'
 import { BlueprintConfig } from '../../tv2_afvd_showstyle/helpers/config'
 import { EvaluateCues } from '../helpers/pieces/evaluateCues'
@@ -21,12 +21,12 @@ export async function CreatePartLive(
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(config, partDefinition, totalWords, false)
-	let part = literal<IBlueprintPart>({
+	let part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title: partDefinition.title || 'Ekstern',
 		metaData: {},
 		expectedDuration: partTime > 0 ? partTime : 0
-	})
+	}
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const pieces: IBlueprintPiece[] = []

--- a/src/tv2_afvd_showstyle/parts/teknik.ts
+++ b/src/tv2_afvd_showstyle/parts/teknik.ts
@@ -7,7 +7,7 @@ import {
 	IBlueprintPiece,
 	ISegmentUserContext
 } from '@tv2media/blueprints-integration'
-import { AddScript, literal, PartDefinition, PartTime } from 'tv2-common'
+import { AddScript, PartDefinition, PartTime } from 'tv2-common'
 import { BlueprintConfig } from '../helpers/config'
 import { EvaluateCues } from '../helpers/pieces/evaluateCues'
 import { SourceLayer } from '../layers'
@@ -19,11 +19,11 @@ export async function CreatePartTeknik(
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(config, partDefinition, totalWords, false)
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title: partDefinition.type + ' - ' + partDefinition.rawType,
 		metaData: {}
-	})
+	}
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const pieces: IBlueprintPiece[] = []

--- a/src/tv2_afvd_showstyle/parts/unknown.ts
+++ b/src/tv2_afvd_showstyle/parts/unknown.ts
@@ -11,7 +11,6 @@ import {
 	ApplyFullGraphicPropertiesToPart,
 	GetJinglePartProperties,
 	GraphicIsPilot,
-	literal,
 	PartDefinition,
 	PartTime
 } from 'tv2-common'
@@ -30,13 +29,13 @@ export async function CreatePartUnknown(
 ) {
 	const partTime = PartTime(config, partDefinition, totalWords, false)
 
-	let part = literal<IBlueprintPart>({
+	let part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title: partDefinition.type + ' - ' + partDefinition.rawType,
 		metaData: {},
 		autoNext: false,
 		expectedDuration: partTime
-	})
+	}
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const pieces: IBlueprintPiece[] = []

--- a/src/tv2_afvd_showstyle/postProcessTimelineObjects.ts
+++ b/src/tv2_afvd_showstyle/postProcessTimelineObjects.ts
@@ -9,7 +9,7 @@ import {
 	TimelineObjHoldMode,
 	TSR
 } from '@tv2media/blueprints-integration'
-import { AtemLLayerDSK, FindDSKJingle, literal, TimelineBlueprintExt } from 'tv2-common'
+import { AtemLLayerDSK, FindDSKJingle, TimelineBlueprintExt } from 'tv2-common'
 import * as _ from 'underscore'
 import { AtemLLayer } from '../tv2_afvd_studio/layers'
 import { BlueprintConfig } from './helpers/config'
@@ -72,7 +72,7 @@ export function postProcessPieceTimelineObjects(
 					(tlObj.content.me.input !== -1 || tlObj.metaData?.mediaPlayerSession !== undefined)
 				) {
 					// Create a lookahead-lookahead object for this me-program
-					const lookaheadObj = literal<TSR.TimelineObjAtemAUX & TimelineBlueprintExt>({
+					const lookaheadObj: TSR.TimelineObjAtemAUX & TimelineBlueprintExt = {
 						id: '',
 						enable: { start: 0 },
 						priority: tlObj.holdMode === TimelineObjHoldMode.ONLY ? 5 : 0, // Must be below lookahead, except when forced by hold
@@ -92,7 +92,7 @@ export function postProcessPieceTimelineObjects(
 							context: `Lookahead-lookahead for ${tlObj.id}`,
 							mediaPlayerSession: tlObj.metaData?.mediaPlayerSession // TODO - does this work the same?
 						}
-					})
+					}
 					extraObjs.push(lookaheadObj)
 				}
 
@@ -120,7 +120,7 @@ export function postProcessPieceTimelineObjects(
 					mixMinusSource = kamSources.length === 1 ? Number(kamSources[0].switcherInput) : null
 				}
 				if (mixMinusSource !== null && mixMinusSource !== -1) {
-					const mixMinusObj = literal<TSR.TimelineObjAtemAUX & TimelineBlueprintExt>({
+					const mixMinusObj: TSR.TimelineObjAtemAUX & TimelineBlueprintExt = {
 						..._.omit(tlObj, 'content'),
 						id: '',
 						layer: AtemLLayer.AtemAuxVideoMixMinus,
@@ -139,7 +139,7 @@ export function postProcessPieceTimelineObjects(
 							...tlObj.metaData,
 							context: `Mix-minus for ${tlObj.id}`
 						}
-					})
+					}
 					mixMinusObj.classes = mixMinusObj.classes?.filter(
 						c => !c.match(`studio0_parent_`) && !c.match('PLACEHOLDER_OBJECT_REMOVEME')
 					)
@@ -161,7 +161,7 @@ export function postProcessPieceTimelineObjects(
 					context.notifyUserWarning(`Unhandled Keyer properties for Clean keyer, it may look wrong`)
 				}
 
-				const cleanObj = literal<TSR.TimelineObjAtemME & TimelineBlueprintExt>({
+				const cleanObj: TSR.TimelineObjAtemME & TimelineBlueprintExt = {
 					..._.omit(tlObj, 'content', 'keyframes'),
 					id: '',
 					layer: AtemLLayer.AtemCleanUSKEffect,
@@ -180,7 +180,7 @@ export function postProcessPieceTimelineObjects(
 							]
 						}
 					}
-				})
+				}
 				extraObjs.push(cleanObj)
 			}
 		})

--- a/src/tv2_afvd_studio/config-manifests.ts
+++ b/src/tv2_afvd_studio/config-manifests.ts
@@ -12,7 +12,6 @@ import {
 	MakeConfigWithMediaFlow,
 	TableConfigItemSourceMapping
 } from 'tv2-common'
-import * as _ from 'underscore'
 import { AtemSourceIndex } from '../types/atem'
 import { defaultDSKConfig } from './helpers/config'
 import { SisyfosLLAyer } from './layers'

--- a/src/tv2_afvd_studio/getBaseline.ts
+++ b/src/tv2_afvd_studio/getBaseline.ts
@@ -11,7 +11,7 @@ import { SharedGraphicLLayer } from '../tv2-constants'
 import { AtemSourceIndex } from '../types/atem'
 import { getStudioConfig } from './helpers/config'
 import { AtemLLayer, SisyfosLLAyer } from './layers'
-import { SisyfosChannel, sisyfosChannels } from './sisyfosChannels'
+import { sisyfosChannels } from './sisyfosChannels'
 
 function filterMappings(
 	input: BlueprintMappings,
@@ -48,7 +48,7 @@ export function getBaseline(context: IStudioContext): BlueprintResultBaseline {
 	const mappedChannels: TSR.TimelineObjSisyfosChannels['content']['channels'] = []
 	for (const id in sisyfosMappings) {
 		if (sisyfosMappings[id]) {
-			const sisyfosChannel = sisyfosChannels[id as SisyfosLLAyer] as SisyfosChannel | undefined
+			const sisyfosChannel = sisyfosChannels[id as SisyfosLLAyer]
 			if (sisyfosChannel) {
 				mappedChannels.push({
 					mappedLayer: id,

--- a/src/tv2_afvd_studio/helpers/config.ts
+++ b/src/tv2_afvd_studio/helpers/config.ts
@@ -8,7 +8,6 @@ import {
 	TV2StudioConfigBase
 } from 'tv2-common'
 import { DSKRoles } from 'tv2-constants'
-import * as _ from 'underscore'
 import { ShowStyleConfig } from '../../tv2_afvd_showstyle/helpers/config'
 import { parseMediaPlayers, parseSources } from './sources'
 

--- a/src/tv2_afvd_studio/migrations/devices.ts
+++ b/src/tv2_afvd_studio/migrations/devices.ts
@@ -5,7 +5,6 @@ import {
 	MigrationStepStudio,
 	TSR
 } from '@tv2media/blueprints-integration'
-import { literal } from 'tv2-common'
 import * as _ from 'underscore'
 
 declare const VERSION: string // Injected by webpack
@@ -218,10 +217,10 @@ const devices: DeviceEntry[] = [
 	}
 ]
 
-export const deviceMigrations = literal<MigrationStepStudio[]>([
+export const deviceMigrations: MigrationStepStudio[] = [
 	// create all devices
 	..._.map(devices, createDevice),
 
 	// ensure all devices still look valid
 	..._.map(devices, validateDevice)
-])
+]

--- a/src/tv2_afvd_studio/migrations/index.ts
+++ b/src/tv2_afvd_studio/migrations/index.ts
@@ -2,7 +2,6 @@ import { MigrationStepStudio, TSR } from '@tv2media/blueprints-integration'
 import {
 	AddKeepAudio,
 	addSourceToSourcesConfig,
-	literal,
 	MoveClipSourcePath,
 	MoveSourcesToTable,
 	PrefixEvsWithEvs,
@@ -40,7 +39,7 @@ declare const VERSION: string // Injected by webpack
  * 0.1.0: Core 0.24.0
  */
 
-export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStudio[]>([
+export const studioMigrations: MigrationStepStudio[] = [
 	ensureStudioConfig(
 		'0.1.0',
 		'SourcesCam',
@@ -199,4 +198,4 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	// Fill in any mappings that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations
 	...getMappingsDefaultsMigrationSteps(VERSION)
-])
+]

--- a/src/tv2_afvd_studio/migrations/util.ts
+++ b/src/tv2_afvd_studio/migrations/util.ts
@@ -7,7 +7,6 @@ import {
 	MigrationStepStudio,
 	TSR
 } from '@tv2media/blueprints-integration'
-import { literal } from 'tv2-common'
 import * as _ from 'underscore'
 import { SisyfosLLAyer } from '../layers'
 import MappingsDefaults from './mappings-defaults'
@@ -132,9 +131,9 @@ export function removeMapping(version: string, oldMappingName: string): Migratio
 }
 
 export function getMappingsDefaultsMigrationSteps(versionStr: string): MigrationStepStudio[] {
-	const res = _.compact(
+	return _.compact(
 		_.map(MappingsDefaults, (defaultVal: BlueprintMapping, id: string): MigrationStepStudio | null => {
-			return literal<MigrationStepStudio>({
+			return {
 				id: `${versionStr}.mappings.defaults.${id}`,
 				version: versionStr,
 				canBeRunAutomatically: true,
@@ -151,11 +150,9 @@ export function getMappingsDefaultsMigrationSteps(versionStr: string): Migration
 						context.insertMapping(id, defaultVal)
 					}
 				}
-			})
+			}
 		})
 	)
-
-	return res
 }
 
 export function GetMappingDefaultMigrationStepForLayer(
@@ -163,7 +160,7 @@ export function GetMappingDefaultMigrationStepForLayer(
 	layer: string,
 	force?: boolean
 ): MigrationStepStudio {
-	return literal<MigrationStepStudio>({
+	return {
 		id: `${versionStr}.mappings.defaults.manualEnsure${layer}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -190,7 +187,7 @@ export function GetMappingDefaultMigrationStepForLayer(
 				context.insertMapping(layer, MappingsDefaults[layer])
 			}
 		}
-	})
+	}
 }
 
 /**
@@ -207,7 +204,7 @@ export function EnsureSisyfosMappingHasType(
 	layer: string,
 	mappingType: TSR.MappingSisyfosType.CHANNEL
 ): MigrationStepStudio {
-	return literal<MigrationStepStudio>({
+	return {
 		id: `${versionStr}.mutatesisyfosmappings.${layer}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -237,7 +234,7 @@ export function EnsureSisyfosMappingHasType(
 
 			context.updateMapping(layer, mapping)
 		}
-	})
+	}
 }
 
 export function GetSisyfosLayersForTableMigrationAFVD(configName: string, val: string): string[] {

--- a/src/tv2_afvd_studio/onTimelineGenerate.ts
+++ b/src/tv2_afvd_studio/onTimelineGenerate.ts
@@ -6,8 +6,7 @@ import {
 	PartEndState,
 	TimelinePersistentState
 } from '@tv2media/blueprints-integration'
-import { onTimelineGenerate } from 'tv2-common'
-import * as _ from 'underscore'
+import { onTimelineGenerate, PieceMetaData } from 'tv2-common'
 import { getConfig } from '../tv2_afvd_showstyle/helpers/config'
 import { AtemLLayer, CasparLLayer, SisyfosLLAyer } from './layers'
 
@@ -16,7 +15,7 @@ export function onTimelineGenerateAFVD(
 	timeline: OnGenerateTimelineObj[],
 	previousPersistentState: TimelinePersistentState | undefined,
 	previousPartEndState: PartEndState | undefined,
-	resolvedPieces: IBlueprintResolvedPieceInstance[]
+	resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>
 ): Promise<BlueprintResultTimeline> {
 	return onTimelineGenerate(
 		context,

--- a/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
@@ -1,7 +1,6 @@
 import {
 	IBlueprintPartDB,
 	IBlueprintPartInstance,
-	IBlueprintPieceDB,
 	IBlueprintPieceInstance,
 	PieceLifespan,
 	TSR
@@ -16,6 +15,7 @@ import {
 	ActionTakeWithTransition,
 	literal,
 	PartDefinitionUnknown,
+	PieceMetaData,
 	RemoteType,
 	SourceDefinitionKam,
 	SourceDefinitionRemote
@@ -67,9 +67,9 @@ const currentPartMock: IBlueprintPartInstance = {
 	rehearsal: false
 }
 
-const kamPieceInstance: IBlueprintPieceInstance = {
+const kamPieceInstance: IBlueprintPieceInstance<PieceMetaData> = {
 	_id: '',
-	piece: literal<IBlueprintPieceDB>({
+	piece: {
 		_id: 'KAM 1',
 		enable: {
 			start: 0
@@ -98,13 +98,13 @@ const kamPieceInstance: IBlueprintPieceInstance = {
 				})
 			]
 		}
-	}),
+	},
 	partInstanceId: ''
 }
 
-const playingServerPieceInstance: IBlueprintPieceInstance = {
+const playingServerPieceInstance: IBlueprintPieceInstance<PieceMetaData> = {
 	_id: '',
-	piece: literal<IBlueprintPieceDB>({
+	piece: {
 		_id: 'Playing Server',
 		enable: {
 			start: 0
@@ -117,13 +117,13 @@ const playingServerPieceInstance: IBlueprintPieceInstance = {
 		content: {
 			timelineObjects: []
 		}
-	}),
+	},
 	partInstanceId: ''
 }
 
-const selectedServerPieceInstance: IBlueprintPieceInstance = {
+const selectedServerPieceInstance: IBlueprintPieceInstance<PieceMetaData> = {
 	_id: '',
-	piece: literal<IBlueprintPieceDB>({
+	piece: {
 		_id: 'Selected Server',
 		enable: {
 			start: 0
@@ -136,7 +136,7 @@ const selectedServerPieceInstance: IBlueprintPieceInstance = {
 		content: {
 			timelineObjects: []
 		}
-	}),
+	},
 	partInstanceId: ''
 }
 
@@ -371,7 +371,7 @@ function validateNextPartExistsWithPreviousPartKeepaliveDuration(context: Action
 }
 
 function getATEMMEObj(piece: IBlueprintPieceInstance): TSR.TimelineObjAtemME {
-	const atemObj = (piece.piece.content!.timelineObjects as TSR.TSRTimelineObj[]).find(
+	const atemObj = (piece.piece.content.timelineObjects as TSR.TSRTimelineObj[]).find(
 		obj =>
 			obj.layer === OfftubeAtemLLayer.AtemMEClean &&
 			obj.content.deviceType === TSR.DeviceType.ATEM &&
@@ -554,39 +554,6 @@ describe('Combination Actions', () => {
 		validateSelectionRemoved(serverPieces)
 		validateSourcePiecesExistWithPrerollDuration(voPieces)
 		expect(voPieces.dataStore?.piece.name).toEqual('VOVOA')
-	})
-
-	it('Server -> DVE', async () => {
-		const context = new ActionExecutionContext(
-			'test',
-			mappingsDefaults,
-			parseStudioConfig,
-			parseShowStyleConfig,
-			RUNDOWN_ID,
-			SEGMENT_ID,
-			currentPartMock._id,
-			currentPartMock,
-			[kamPieceInstance]
-		)
-		context.studioConfig = defaultStudioConfig as any
-		context.showStyleConfig = defaultShowStyleConfig as any
-		;((context.studioConfig as unknown) as OfftubeStudioConfig).GraphicsType = 'HTML'
-
-		await executeActionOfftube(context, AdlibActionType.SELECT_SERVER_CLIP, selectServerClipAction)
-
-		let serverPieces = await getActiveServerPieces(context, 'next')
-
-		validateNextPartExistsWithDuration(context, SERVER_DURATION_A)
-		validateSourcePiecesExistWithPrerollDuration(serverPieces)
-
-		await executeActionOfftube(context, AdlibActionType.SELECT_DVE, selectDVEActionMorbarn)
-
-		serverPieces = await getActiveServerPieces(context, 'next')
-		const dvePieces = await getDVEPieces(context, 'next')
-
-		validateNextPartExistsWithDuration(context, 0)
-		validateOnlySelectionIsPreserved(serverPieces)
-		validateSourcePiecesExistWithPrerollDuration(dvePieces)
 	})
 
 	it('Server -> CAM', async () => {

--- a/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
@@ -90,7 +90,7 @@ export async function OfftubeEvaluateAdLib(
 			return
 		}
 
-		if (!TemplateIsValid(rawTemplate.DVEJSON as string)) {
+		if (!TemplateIsValid(rawTemplate.DVEJSON)) {
 			context.notifyUserWarning(`Invalid DVE template ${parsedCue.variant}`)
 			return
 		}
@@ -105,30 +105,28 @@ export async function OfftubeEvaluateAdLib(
 
 		const adlibContent = OfftubeMakeContentDVE(context, config, partDefinition, cueDVE, rawTemplate, false, true)
 
-		const userData = literal<ActionSelectDVE>({
+		const userData: ActionSelectDVE = {
 			type: AdlibActionType.SELECT_DVE,
 			config: cueDVE,
 			videoId: partDefinition.fields.videoId,
 			segmentExternalId: partDefinition.segmentExternalId
+		}
+		actions.push({
+			externalId: generateExternalId(context, userData),
+			actionId: AdlibActionType.SELECT_DVE,
+			userData,
+			userDataManifest: {},
+			display: {
+				sourceLayerId: OfftubeSourceLayer.PgmDVE,
+				outputLayerId: OfftubeOutputLayers.PGM,
+				uniquenessId: getUniquenessIdDVE(cueDVE),
+				label: t(`${partDefinition.storyName}`),
+				tags: [AdlibTags.ADLIB_KOMMENTATOR, AdlibTags.ADLIB_FLOW_PRODUCER],
+				content: literal<SplitsContent>({
+					...adlibContent.content
+				})
+			}
 		})
-		actions.push(
-			literal<IBlueprintActionManifest>({
-				externalId: generateExternalId(context, userData),
-				actionId: AdlibActionType.SELECT_DVE,
-				userData,
-				userDataManifest: {},
-				display: {
-					sourceLayerId: OfftubeSourceLayer.PgmDVE,
-					outputLayerId: OfftubeOutputLayers.PGM,
-					uniquenessId: getUniquenessIdDVE(cueDVE),
-					label: t(`${partDefinition.storyName}`),
-					tags: [AdlibTags.ADLIB_KOMMENTATOR, AdlibTags.ADLIB_FLOW_PRODUCER],
-					content: literal<SplitsContent>({
-						...adlibContent.content
-					})
-				}
-			})
-		)
 	}
 }
 

--- a/src/tv2_offtube_showstyle/cues/OfftubeEkstern.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeEkstern.ts
@@ -5,7 +5,7 @@ import {
 	IBlueprintPiece,
 	ISegmentUserContext
 } from '@tv2media/blueprints-integration'
-import { CueDefinitionEkstern, EvaluateEksternBase, PartDefinition } from 'tv2-common'
+import { CueDefinitionEkstern, EvaluateEksternBase, PartDefinition, PieceMetaData } from 'tv2-common'
 import { OfftubeAtemLLayer } from '../../tv2_offtube_studio/layers'
 import { OfftubeShowstyleBlueprintConfig } from '../helpers/config'
 import { OfftubeSourceLayer } from '../layers'
@@ -14,8 +14,8 @@ export function OfftubeEvaluateEkstern(
 	context: ISegmentUserContext,
 	config: OfftubeShowstyleBlueprintConfig,
 	part: IBlueprintPart,
-	pieces: IBlueprintPiece[],
-	_adlibPieces: IBlueprintAdLibPiece[],
+	pieces: Array<IBlueprintPiece<PieceMetaData>>,
+	_adlibPieces: Array<IBlueprintAdLibPiece<PieceMetaData>>,
 	_actions: IBlueprintActionManifest[],
 	partId: string,
 	parsedCue: CueDefinitionEkstern,

--- a/src/tv2_offtube_showstyle/cues/OfftubeGraphicBackgroundLoop.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeGraphicBackgroundLoop.ts
@@ -27,66 +27,62 @@ export function OfftubeEvaluateCueBackgroundLoop(
 	const path = `dve/${fileName}`
 	const start = (parsedCue.start ? CalculateTime(parsedCue.start) : 0) ?? 0
 	if (adlib) {
-		adlibPieces.push(
-			literal<IBlueprintAdLibPiece>({
-				_rank: rank || 0,
-				externalId: partId,
-				name: fileName,
-				outputLayerId: SharedOutputLayers.SEC,
-				sourceLayerId: OfftubeSourceLayer.PgmDVEBackground,
-				lifespan: PieceLifespan.OutOnShowStyleEnd,
-				content: literal<WithTimeline<GraphicsContent>>({
-					fileName,
-					path,
-					ignoreMediaObjectStatus: true,
-					timelineObjects: _.compact<TSR.TSRTimelineObj[]>([
-						literal<TSR.TimelineObjCCGMedia>({
-							id: '',
-							enable: { start: 0 },
-							priority: 100,
-							layer: OfftubeCasparLLayer.CasparCGDVELoop,
-							content: {
-								deviceType: TSR.DeviceType.CASPARCG,
-								type: TSR.TimelineContentTypeCasparCg.MEDIA,
-								file: path,
-								loop: true
-							}
-						})
-					])
-				})
+		adlibPieces.push({
+			_rank: rank || 0,
+			externalId: partId,
+			name: fileName,
+			outputLayerId: SharedOutputLayers.SEC,
+			sourceLayerId: OfftubeSourceLayer.PgmDVEBackground,
+			lifespan: PieceLifespan.OutOnShowStyleEnd,
+			content: literal<WithTimeline<GraphicsContent>>({
+				fileName,
+				path,
+				ignoreMediaObjectStatus: true,
+				timelineObjects: _.compact<TSR.TSRTimelineObj[]>([
+					literal<TSR.TimelineObjCCGMedia>({
+						id: '',
+						enable: { start: 0 },
+						priority: 100,
+						layer: OfftubeCasparLLayer.CasparCGDVELoop,
+						content: {
+							deviceType: TSR.DeviceType.CASPARCG,
+							type: TSR.TimelineContentTypeCasparCg.MEDIA,
+							file: path,
+							loop: true
+						}
+					})
+				])
 			})
-		)
+		})
 	} else {
-		pieces.push(
-			literal<IBlueprintPiece>({
-				externalId: partId,
-				name: fileName,
-				enable: {
-					start
-				},
-				outputLayerId: SharedOutputLayers.SEC,
-				sourceLayerId: OfftubeSourceLayer.PgmDVEBackground,
-				lifespan: PieceLifespan.OutOnShowStyleEnd,
-				content: literal<WithTimeline<GraphicsContent>>({
-					fileName,
-					path,
-					ignoreMediaObjectStatus: true,
-					timelineObjects: _.compact<TSR.TSRTimelineObj[]>([
-						literal<TSR.TimelineObjCCGMedia>({
-							id: '',
-							enable: { start: 0 },
-							priority: 100,
-							layer: OfftubeCasparLLayer.CasparCGDVELoop,
-							content: {
-								deviceType: TSR.DeviceType.CASPARCG,
-								type: TSR.TimelineContentTypeCasparCg.MEDIA,
-								file: path,
-								loop: true
-							}
-						})
-					])
-				})
+		pieces.push({
+			externalId: partId,
+			name: fileName,
+			enable: {
+				start
+			},
+			outputLayerId: SharedOutputLayers.SEC,
+			sourceLayerId: OfftubeSourceLayer.PgmDVEBackground,
+			lifespan: PieceLifespan.OutOnShowStyleEnd,
+			content: literal<WithTimeline<GraphicsContent>>({
+				fileName,
+				path,
+				ignoreMediaObjectStatus: true,
+				timelineObjects: _.compact<TSR.TSRTimelineObj[]>([
+					literal<TSR.TimelineObjCCGMedia>({
+						id: '',
+						enable: { start: 0 },
+						priority: 100,
+						layer: OfftubeCasparLLayer.CasparCGDVELoop,
+						content: {
+							deviceType: TSR.DeviceType.CASPARCG,
+							type: TSR.TimelineContentTypeCasparCg.MEDIA,
+							file: path,
+							loop: true
+						}
+					})
+				])
 			})
-		)
+		})
 	}
 }

--- a/src/tv2_offtube_showstyle/cues/OfftubeGraphics.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeGraphics.ts
@@ -54,7 +54,7 @@ export function OfftubeEvaluateGrafikCaspar(
 			segmentExternalId: partDefinition.segmentExternalId
 		})
 	} else if (GraphicIsInternal(parsedCue)) {
-		CreateInternalGraphic(config, context, pieces, adlibPieces, actions, partId, parsedCue, partDefinition, adlib)
+		CreateInternalGraphic(config, context, pieces, adlibPieces, partId, parsedCue, partDefinition, adlib)
 	}
 }
 

--- a/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
@@ -13,7 +13,6 @@ import {
 	GetJinglePartProperties,
 	GetTagForJingle,
 	GetTagForJingleNext,
-	literal,
 	PartDefinition,
 	PieceMetaData,
 	t,
@@ -27,7 +26,7 @@ import { OfftubeOutputLayers, OfftubeSourceLayer } from '../layers'
 export function OfftubeEvaluateJingle(
 	context: ISegmentUserContext,
 	config: OfftubeShowstyleBlueprintConfig,
-	pieces: IBlueprintPiece[],
+	pieces: Array<IBlueprintPiece<PieceMetaData>>,
 	_adlibPieces: IBlueprintAdLibPiece[],
 	actions: IBlueprintActionManifest[],
 	parsedCue: CueDefinitionJingle,
@@ -60,70 +59,66 @@ export function OfftubeEvaluateJingle(
 		return
 	}
 
-	const userData = literal<ActionSelectJingle>({
+	const userData: ActionSelectJingle = {
 		type: AdlibActionType.SELECT_JINGLE,
 		clip: parsedCue.clip,
 		segmentExternalId: part.segmentExternalId
-	})
-	actions.push(
-		literal<IBlueprintActionManifest>({
-			externalId: generateExternalId(context, userData),
-			actionId: AdlibActionType.SELECT_JINGLE,
-			userData,
-			userDataManifest: {},
-			display: {
-				label: t(effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip),
-				sourceLayerId: OfftubeSourceLayer.PgmJingle,
-				outputLayerId: OfftubeOutputLayers.JINGLE,
-				content: {
-					...createJingleContentOfftube(
-						config,
-						file,
-						jingle.StartAlpha,
-						jingle.LoadFirstFrame,
-						jingle.Duration,
-						jingle.EndAlpha
-					)
-				},
-				tags: [AdlibTags.OFFTUBE_100pc_SERVER, AdlibTags.ADLIB_KOMMENTATOR],
-				currentPieceTags: [GetTagForJingle(part.segmentExternalId, parsedCue.clip)],
-				nextPieceTags: [GetTagForJingleNext(part.segmentExternalId, parsedCue.clip)]
-			}
-		})
-	)
-
-	pieces.push(
-		literal<IBlueprintPiece>({
-			externalId: `${part.externalId}-JINGLE`,
-			name: effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip,
-			enable: {
-				start: 0
-			},
-			lifespan: PieceLifespan.WithinPart,
-			outputLayerId: SharedOutputLayers.JINGLE,
+	}
+	actions.push({
+		externalId: generateExternalId(context, userData),
+		actionId: AdlibActionType.SELECT_JINGLE,
+		userData,
+		userDataManifest: {},
+		display: {
+			label: t(effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip),
 			sourceLayerId: OfftubeSourceLayer.PgmJingle,
-			metaData: literal<PieceMetaData>({
-				sisyfosPersistMetaData: {
-					sisyfosLayers: []
-				}
-			}),
-			prerollDuration: config.studio.CasparPrerollDuration + TimeFromFrames(Number(jingle.StartAlpha)),
-			content: createJingleContentOfftube(
-				config,
-				file,
-				jingle.StartAlpha,
-				jingle.LoadFirstFrame,
-				jingle.Duration,
-				jingle.EndAlpha
-			),
-			tags: [
-				GetTagForJingle(part.segmentExternalId, parsedCue.clip),
-				GetTagForJingleNext(part.segmentExternalId, parsedCue.clip),
-				TallyTags.JINGLE_IS_LIVE,
-				!effekt ? TallyTags.JINGLE : ''
-			]
-		})
-	)
+			outputLayerId: OfftubeOutputLayers.JINGLE,
+			content: {
+				...createJingleContentOfftube(
+					config,
+					file,
+					jingle.StartAlpha,
+					jingle.LoadFirstFrame,
+					jingle.Duration,
+					jingle.EndAlpha
+				)
+			},
+			tags: [AdlibTags.OFFTUBE_100pc_SERVER, AdlibTags.ADLIB_KOMMENTATOR],
+			currentPieceTags: [GetTagForJingle(part.segmentExternalId, parsedCue.clip)],
+			nextPieceTags: [GetTagForJingleNext(part.segmentExternalId, parsedCue.clip)]
+		}
+	})
+
+	pieces.push({
+		externalId: `${part.externalId}-JINGLE`,
+		name: effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip,
+		enable: {
+			start: 0
+		},
+		lifespan: PieceLifespan.WithinPart,
+		outputLayerId: SharedOutputLayers.JINGLE,
+		sourceLayerId: OfftubeSourceLayer.PgmJingle,
+		metaData: {
+			sisyfosPersistMetaData: {
+				sisyfosLayers: []
+			}
+		},
+		prerollDuration: config.studio.CasparPrerollDuration + TimeFromFrames(Number(jingle.StartAlpha)),
+		content: createJingleContentOfftube(
+			config,
+			file,
+			jingle.StartAlpha,
+			jingle.LoadFirstFrame,
+			jingle.Duration,
+			jingle.EndAlpha
+		),
+		tags: [
+			GetTagForJingle(part.segmentExternalId, parsedCue.clip),
+			GetTagForJingleNext(part.segmentExternalId, parsedCue.clip),
+			TallyTags.JINGLE_IS_LIVE,
+			!effekt ? TallyTags.JINGLE : ''
+		]
+	})
 }
 
 export function createJingleContentOfftube(

--- a/src/tv2_offtube_showstyle/cues/OfftubePgmClean.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubePgmClean.ts
@@ -34,33 +34,31 @@ export function OfftubeEvaluatePgmClean(
 		return
 	}
 
-	pieces.push(
-		literal<IBlueprintPiece>({
-			externalId: partId,
-			name,
-			enable: {
-				start: 0
-			},
-			outputLayerId: SharedOutputLayers.AUX,
-			sourceLayerId: OfftubeSourceLayer.AuxPgmClean,
-			lifespan: PieceLifespan.OutOnShowStyleEnd,
-			content: literal<WithTimeline<BaseContent>>({
-				timelineObjects: literal<TimelineObjectCoreExt[]>([
-					literal<TSR.TimelineObjAtemAUX>({
-						id: '',
-						enable: { while: '1' },
-						priority: 0,
-						layer: OfftubeAtemLLayer.AtemAuxClean,
-						content: {
-							deviceType: TSR.DeviceType.ATEM,
-							type: TSR.TimelineContentTypeAtem.AUX,
-							aux: {
-								input: sourceInfo.port
-							}
+	pieces.push({
+		externalId: partId,
+		name,
+		enable: {
+			start: 0
+		},
+		outputLayerId: SharedOutputLayers.AUX,
+		sourceLayerId: OfftubeSourceLayer.AuxPgmClean,
+		lifespan: PieceLifespan.OutOnShowStyleEnd,
+		content: literal<WithTimeline<BaseContent>>({
+			timelineObjects: literal<TimelineObjectCoreExt[]>([
+				literal<TSR.TimelineObjAtemAUX>({
+					id: '',
+					enable: { while: '1' },
+					priority: 0,
+					layer: OfftubeAtemLLayer.AtemAuxClean,
+					content: {
+						deviceType: TSR.DeviceType.ATEM,
+						type: TSR.TimelineContentTypeAtem.AUX,
+						aux: {
+							input: sourceInfo.port
 						}
-					})
-				])
-			})
+					}
+				})
+			])
 		})
-	)
+	})
 }

--- a/src/tv2_offtube_showstyle/getRundown.ts
+++ b/src/tv2_offtube_showstyle/getRundown.ts
@@ -259,55 +259,51 @@ function getGlobalAdlibActionsOfftube(
 
 	function makeCutCameraActions(info: SourceInfo, queue: boolean, rank: number) {
 		const sourceDefinition = SourceInfoToSourceDefinition(info) as SourceDefinitionKam
-		const userData = literal<ActionCutToCamera>({
+		const userData: ActionCutToCamera = {
 			type: AdlibActionType.CUT_TO_CAMERA,
 			queue,
 			sourceDefinition
+		}
+		blueprintActions.push({
+			externalId: generateExternalId(_context, userData),
+			actionId: AdlibActionType.CUT_TO_CAMERA,
+			userData,
+			userDataManifest: {},
+			display: {
+				_rank: rank,
+				label: t(sourceDefinition.name),
+				sourceLayerId: OfftubeSourceLayer.PgmCam,
+				outputLayerId: SharedOutputLayers.PGM,
+				content: {},
+				tags: queue ? [AdlibTags.OFFTUBE_SET_CAM_NEXT, AdlibTags.ADLIB_QUEUE_NEXT] : [AdlibTags.ADLIB_CUT_DIRECT],
+				currentPieceTags: [GetTagForKam(sourceDefinition)],
+				nextPieceTags: [GetTagForKam(sourceDefinition)]
+			}
 		})
-		blueprintActions.push(
-			literal<IBlueprintActionManifest>({
-				externalId: generateExternalId(_context, userData),
-				actionId: AdlibActionType.CUT_TO_CAMERA,
-				userData,
-				userDataManifest: {},
-				display: {
-					_rank: rank,
-					label: t(sourceDefinition.name),
-					sourceLayerId: OfftubeSourceLayer.PgmCam,
-					outputLayerId: SharedOutputLayers.PGM,
-					content: {},
-					tags: queue ? [AdlibTags.OFFTUBE_SET_CAM_NEXT, AdlibTags.ADLIB_QUEUE_NEXT] : [AdlibTags.ADLIB_CUT_DIRECT],
-					currentPieceTags: [GetTagForKam(sourceDefinition)],
-					nextPieceTags: [GetTagForKam(sourceDefinition)]
-				}
-			})
-		)
 	}
 
 	function makeRemoteAction(sourceInfo: SourceInfo, rank: number) {
 		const sourceDefinition = SourceInfoToSourceDefinition(sourceInfo) as SourceDefinitionRemote
-		const userData = literal<ActionCutToRemote>({
+		const userData: ActionCutToRemote = {
 			type: AdlibActionType.CUT_TO_REMOTE,
 			sourceDefinition
+		}
+		blueprintActions.push({
+			externalId: generateExternalId(_context, userData),
+			actionId: AdlibActionType.CUT_TO_REMOTE,
+			userData,
+			userDataManifest: {},
+			display: {
+				_rank: rank,
+				label: t(`${sourceDefinition.name}`),
+				sourceLayerId: OfftubeSourceLayer.PgmLive,
+				outputLayerId: OfftubeOutputLayers.PGM,
+				content: {},
+				tags: [AdlibTags.OFFTUBE_SET_REMOTE_NEXT, AdlibTags.ADLIB_QUEUE_NEXT],
+				currentPieceTags: [GetTagForLive(sourceDefinition)],
+				nextPieceTags: [GetTagForLive(sourceDefinition)]
+			}
 		})
-		blueprintActions.push(
-			literal<IBlueprintActionManifest>({
-				externalId: generateExternalId(_context, userData),
-				actionId: AdlibActionType.CUT_TO_REMOTE,
-				userData,
-				userDataManifest: {},
-				display: {
-					_rank: rank,
-					label: t(`${sourceDefinition.name}`),
-					sourceLayerId: OfftubeSourceLayer.PgmLive,
-					outputLayerId: OfftubeOutputLayers.PGM,
-					content: {},
-					tags: [AdlibTags.OFFTUBE_SET_REMOTE_NEXT, AdlibTags.ADLIB_QUEUE_NEXT],
-					currentPieceTags: [GetTagForLive(sourceDefinition)],
-					nextPieceTags: [GetTagForLive(sourceDefinition)]
-				}
-			})
-		)
 	}
 
 	function makeAdlibBoxesActions(
@@ -318,63 +314,59 @@ function getGlobalAdlibActionsOfftube(
 		for (let box = 0; box < NUMBER_OF_DVE_BOXES; box++) {
 			const sourceDefinition = SourceInfoToSourceDefinition(info)
 			const layer = type === SourceInfoType.KAM ? OfftubeSourceLayer.PgmCam : OfftubeSourceLayer.PgmLive
-			const userData = literal<ActionCutSourceToBox>({
+			const userData: ActionCutSourceToBox = {
 				type: AdlibActionType.CUT_SOURCE_TO_BOX,
 				name: sourceDefinition.name,
 				box,
 				sourceDefinition
+			}
+			blueprintActions.push({
+				externalId: generateExternalId(_context, userData),
+				actionId: AdlibActionType.CUT_SOURCE_TO_BOX,
+				userData,
+				userDataManifest: {},
+				display: {
+					_rank: rank + 0.1 * box,
+					label: t(`${sourceDefinition.name} inp ${box + 1}`),
+					sourceLayerId: layer,
+					outputLayerId: OfftubeOutputLayers.PGM,
+					content: {},
+					tags: [AdlibTagCutToBox(box)]
+				}
 			})
-			blueprintActions.push(
-				literal<IBlueprintActionManifest>({
-					externalId: generateExternalId(_context, userData),
-					actionId: AdlibActionType.CUT_SOURCE_TO_BOX,
-					userData,
-					userDataManifest: {},
-					display: {
-						_rank: rank + 0.1 * box,
-						label: t(`${sourceDefinition.name} inp ${box + 1}`),
-						sourceLayerId: layer,
-						outputLayerId: OfftubeOutputLayers.PGM,
-						content: {},
-						tags: [AdlibTagCutToBox(box)]
-					}
-				})
-			)
 		}
 	}
 
 	function makeServerAdlibBoxesActions(rank: number) {
 		for (let box = 0; box < NUMBER_OF_DVE_BOXES; box++) {
-			const userData = literal<ActionCutSourceToBox>({
+			const userData: ActionCutSourceToBox = {
 				type: AdlibActionType.CUT_SOURCE_TO_BOX,
 				name: `SERVER`,
 				box,
 				sourceDefinition: { sourceType: SourceType.SERVER }
+			}
+			blueprintActions.push({
+				externalId: generateExternalId(_context, userData),
+				actionId: AdlibActionType.CUT_SOURCE_TO_BOX,
+				userData,
+				userDataManifest: {},
+				display: {
+					_rank: rank + 0.1 * box,
+					label: t(`Server inp ${box + 1}`),
+					sourceLayerId: OfftubeSourceLayer.PgmServer,
+					outputLayerId: SharedOutputLayers.SEC,
+					content: {},
+					tags: [AdlibTagCutToBox(box)]
+				}
 			})
-			blueprintActions.push(
-				literal<IBlueprintActionManifest>({
-					externalId: generateExternalId(_context, userData),
-					actionId: AdlibActionType.CUT_SOURCE_TO_BOX,
-					userData,
-					userDataManifest: {},
-					display: {
-						_rank: rank + 0.1 * box,
-						label: t(`Server inp ${box + 1}`),
-						sourceLayerId: OfftubeSourceLayer.PgmServer,
-						outputLayerId: SharedOutputLayers.SEC,
-						content: {},
-						tags: [AdlibTagCutToBox(box)]
-					}
-				})
-			)
 		}
 	}
 
-	function makeCommentatorSelectServerAction() {
-		const userData = literal<ActionCommentatorSelectServer>({
+	function makeCommentatorSelectServerAction(): IBlueprintActionManifest {
+		const userData: ActionCommentatorSelectServer = {
 			type: AdlibActionType.COMMENTATOR_SELECT_SERVER
-		})
-		return literal<IBlueprintActionManifest>({
+		}
+		return {
 			externalId: generateExternalId(_context, userData),
 			actionId: AdlibActionType.COMMENTATOR_SELECT_SERVER,
 			userData,
@@ -389,16 +381,16 @@ function getGlobalAdlibActionsOfftube(
 				currentPieceTags: [TallyTags.SERVER_IS_LIVE],
 				nextPieceTags: [TallyTags.SERVER_IS_LIVE]
 			}
-		})
+		}
 	}
 
 	blueprintActions.push(makeCommentatorSelectServerAction())
 
-	function makeCommentatorSelectDveAction() {
-		const userData = literal<ActionCommentatorSelectDVE>({
+	function makeCommentatorSelectDveAction(): IBlueprintActionManifest {
+		const userData: ActionCommentatorSelectDVE = {
 			type: AdlibActionType.COMMENTATOR_SELECT_DVE
-		})
-		return literal<IBlueprintActionManifest>({
+		}
+		return {
 			externalId: generateExternalId(_context, userData),
 			actionId: AdlibActionType.COMMENTATOR_SELECT_DVE,
 			userData,
@@ -413,16 +405,16 @@ function getGlobalAdlibActionsOfftube(
 				currentPieceTags: [TallyTags.DVE_IS_LIVE],
 				nextPieceTags: [TallyTags.DVE_IS_LIVE]
 			}
-		})
+		}
 	}
 
 	blueprintActions.push(makeCommentatorSelectDveAction())
 
-	function makeCommentatorSelectFullAction() {
-		const userData = literal<ActionCommentatorSelectFull>({
+	function makeCommentatorSelectFullAction(): IBlueprintActionManifest {
+		const userData: ActionCommentatorSelectFull = {
 			type: AdlibActionType.COMMENTATOR_SELECT_FULL
-		})
-		return literal<IBlueprintActionManifest>({
+		}
+		return {
 			externalId: generateExternalId(_context, userData),
 			actionId: AdlibActionType.COMMENTATOR_SELECT_FULL,
 			userData,
@@ -437,18 +429,18 @@ function getGlobalAdlibActionsOfftube(
 				currentPieceTags: [TallyTags.FULL_IS_LIVE],
 				nextPieceTags: [TallyTags.FULL_IS_LIVE]
 			}
-		})
+		}
 	}
 
 	blueprintActions.push(makeCommentatorSelectFullAction())
 
-	function makeClearGraphicsAltudAction() {
-		const userData = literal<ActionClearGraphics>({
+	function makeClearGraphicsAltudAction(): IBlueprintActionManifest {
+		const userData: ActionClearGraphics = {
 			type: AdlibActionType.CLEAR_GRAPHICS,
 			sendCommands: false,
 			label: 'GFX Altud'
-		})
-		return literal<IBlueprintActionManifest>({
+		}
+		return {
 			externalId: generateExternalId(_context, userData),
 			actionId: AdlibActionType.CLEAR_GRAPHICS,
 			userData,
@@ -463,18 +455,18 @@ function getGlobalAdlibActionsOfftube(
 				currentPieceTags: [TallyTags.GFX_ALTUD],
 				nextPieceTags: [TallyTags.GFX_ALTUD]
 			}
-		})
+		}
 	}
 
 	blueprintActions.push(makeClearGraphicsAltudAction())
 
 	blueprintActions.push(...GetTransitionAdLibActions(config, 800))
 
-	function makeRecallLastDveAction() {
-		const userData = literal<ActionRecallLastDVE>({
+	function makeRecallLastDveAction(): IBlueprintActionManifest {
+		const userData: ActionRecallLastDVE = {
 			type: AdlibActionType.RECALL_LAST_DVE
-		})
-		return literal<IBlueprintActionManifest>({
+		}
+		return {
 			externalId: generateExternalId(_context, userData),
 			actionId: AdlibActionType.RECALL_LAST_DVE,
 			userData,
@@ -486,31 +478,29 @@ function getGlobalAdlibActionsOfftube(
 				outputLayerId: 'pgm',
 				tags: [AdlibTags.ADLIB_RECALL_LAST_DVE]
 			}
-		})
+		}
 	}
 
 	blueprintActions.push(makeRecallLastDveAction())
 
 	_.each(config.showStyle.DVEStyles, (dveConfig, i) => {
-		const userData = literal<ActionSelectDVELayout>({
+		const userData: ActionSelectDVELayout = {
 			type: AdlibActionType.SELECT_DVE_LAYOUT,
 			config: dveConfig
+		}
+		blueprintActions.push({
+			externalId: generateExternalId(_context, userData),
+			actionId: AdlibActionType.SELECT_DVE_LAYOUT,
+			userData,
+			userDataManifest: {},
+			display: {
+				_rank: 200 + i,
+				label: t(dveConfig.DVEName),
+				sourceLayerId: OfftubeSourceLayer.PgmDVEAdLib,
+				outputLayerId: SharedOutputLayers.PGM,
+				tags: [AdlibTags.ADLIB_SELECT_DVE_LAYOUT, dveConfig.DVEName]
+			}
 		})
-		blueprintActions.push(
-			literal<IBlueprintActionManifest>({
-				externalId: generateExternalId(_context, userData),
-				actionId: AdlibActionType.SELECT_DVE_LAYOUT,
-				userData,
-				userDataManifest: {},
-				display: {
-					_rank: 200 + i,
-					label: t(dveConfig.DVEName),
-					sourceLayerId: OfftubeSourceLayer.PgmDVEAdLib,
-					outputLayerId: SharedOutputLayers.PGM,
-					tags: [AdlibTags.ADLIB_SELECT_DVE_LAYOUT, dveConfig.DVEName]
-				}
-			})
-		)
 	})
 
 	config.sources.cameras
@@ -531,11 +521,11 @@ function getGlobalAdlibActionsOfftube(
 			makeAdlibBoxesActions(o, SourceInfoType.KAM, globalRank++)
 		})
 
-	function makeRecallLastLiveAction() {
-		const userData = literal<ActionRecallLastLive>({
+	function makeRecallLastLiveAction(): IBlueprintActionManifest {
+		const userData: ActionRecallLastLive = {
 			type: AdlibActionType.RECALL_LAST_LIVE
-		})
-		return literal<IBlueprintActionManifest>({
+		}
+		return {
 			externalId: generateExternalId(_context, userData),
 			actionId: AdlibActionType.RECALL_LAST_LIVE,
 			userData,
@@ -547,7 +537,7 @@ function getGlobalAdlibActionsOfftube(
 				outputLayerId: SharedOutputLayers.PGM,
 				tags: [AdlibTags.ADLIB_RECALL_LAST_LIVE]
 			}
-		})
+		}
 	}
 
 	blueprintActions.push(makeRecallLastLiveAction())
@@ -578,11 +568,11 @@ function getGlobalAdlibActionsOfftube(
 
 	makeServerAdlibBoxesActions(globalRank++)
 
-	function makeCommentatorSelectJingleAction() {
-		const userData = literal<ActionCommentatorSelectJingle>({
+	function makeCommentatorSelectJingleAction(): IBlueprintActionManifest {
+		const userData: ActionCommentatorSelectJingle = {
 			type: AdlibActionType.COMMENTATOR_SELECT_JINGLE
-		})
-		return literal<IBlueprintActionManifest>({
+		}
+		return {
 			externalId: generateExternalId(_context, userData),
 			actionId: AdlibActionType.COMMENTATOR_SELECT_JINGLE,
 			userData,
@@ -597,7 +587,7 @@ function getGlobalAdlibActionsOfftube(
 				currentPieceTags: [TallyTags.JINGLE_IS_LIVE],
 				nextPieceTags: [TallyTags.JINGLE_IS_LIVE]
 			}
-		})
+		}
 	}
 
 	blueprintActions.push(makeCommentatorSelectJingleAction())

--- a/src/tv2_offtube_showstyle/getSegment.ts
+++ b/src/tv2_offtube_showstyle/getSegment.ts
@@ -2,7 +2,6 @@ import {
 	BlueprintResultPart,
 	BlueprintResultSegment,
 	CameraContent,
-	IBlueprintPiece,
 	IngestSegment,
 	ISegmentUserContext,
 	PieceLifespan,
@@ -53,15 +52,18 @@ export async function getSegment(
 	}
 }
 
-function CreatePartContinuity(config: OfftubeShowstyleBlueprintConfig, ingestSegment: IngestSegment) {
-	return literal<BlueprintResultPart>({
+function CreatePartContinuity(
+	config: OfftubeShowstyleBlueprintConfig,
+	ingestSegment: IngestSegment
+): BlueprintResultPart {
+	return {
 		part: {
 			externalId: `${ingestSegment.externalId}-CONTINUITY`,
 			title: 'CONTINUITY',
 			untimed: true
 		},
 		pieces: [
-			literal<IBlueprintPiece>({
+			{
 				externalId: `${ingestSegment.externalId}-CONTINUITY`,
 				enable: {
 					start: 0
@@ -92,9 +94,9 @@ function CreatePartContinuity(config: OfftubeShowstyleBlueprintConfig, ingestSeg
 						})
 					])
 				})
-			})
+			}
 		],
 		adLibPieces: [],
 		actions: []
-	})
+	}
 }

--- a/src/tv2_offtube_showstyle/migrations/hotkeys.ts
+++ b/src/tv2_offtube_showstyle/migrations/hotkeys.ts
@@ -24,7 +24,7 @@ export function GetDefaultStudioSourcesForOfftube(context: MigrationContextShowS
 
 	const camera = manifestOfftubeSourcesCam.defaultVal.map(source => source.SourceName) as string[]
 	const remote = manifestOfftubeSourcesRM.defaultVal.map(source => source.SourceName) as string[]
-	const feed = manifestOfftubeSourcesFeed.defaultVal.map(source => `F${source.SourceName}`) as string[]
+	const feed = manifestOfftubeSourcesFeed.defaultVal.map(source => `F${source.SourceName}`)
 	const local: string[] = []
 
 	return {

--- a/src/tv2_offtube_showstyle/migrations/index.ts
+++ b/src/tv2_offtube_showstyle/migrations/index.ts
@@ -155,7 +155,7 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	 */
 	// OVERLAY group
 	SetSourceLayerName('1.6.9', OfftubeSourceLayer.PgmGraphicsIdent, 'GFX Ident'),
-	SetSourceLayerName('1.6.9', OfftubeSourceLayer.PgmGraphicsIdentPersistent, 'GFX Ident Persistent (hidden)'),
+	SetSourceLayerName('1.6.9', 'studio0_graphicsIdent_persistent', 'GFX Ident Persistent (hidden)'),
 	SetSourceLayerName('1.6.9', OfftubeSourceLayer.PgmGraphicsTop, 'GFX Top'),
 	SetSourceLayerName('1.6.9', OfftubeSourceLayer.PgmGraphicsLower, 'GFX Lowerthirds'),
 	SetSourceLayerName('1.6.9', OfftubeSourceLayer.PgmGraphicsHeadline, 'GFX Headline'),
@@ -213,17 +213,13 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	 * - Change source layer type for graphics that don't have previews
 	 */
 	SetSourceLayerProperties('1.7.1', OfftubeSourceLayer.PgmGraphicsIdent, { type: SourceLayerType.LOWER_THIRD }),
-	SetSourceLayerProperties('1.7.1', OfftubeSourceLayer.PgmGraphicsIdentPersistent, {
+	SetSourceLayerProperties('1.7.1', 'studio0_graphicsIdent_persistent', {
 		type: SourceLayerType.LOWER_THIRD
 	}),
 	SetSourceLayerProperties('1.7.1', OfftubeSourceLayer.PgmGraphicsTop, { type: SourceLayerType.LOWER_THIRD }),
 	SetSourceLayerProperties('1.7.1', OfftubeSourceLayer.PgmGraphicsLower, { type: SourceLayerType.LOWER_THIRD }),
 	SetSourceLayerProperties('1.7.1', OfftubeSourceLayer.PgmGraphicsHeadline, { type: SourceLayerType.LOWER_THIRD }),
 	SetSourceLayerProperties('1.7.1', OfftubeSourceLayer.PgmGraphicsTLF, { type: SourceLayerType.LOWER_THIRD }),
-
-	...getSourceLayerDefaultsMigrationSteps(VERSION),
-	...getOutputLayerDefaultsMigrationSteps(VERSION),
-	GetDefaultAdLibTriggers(VERSION, SHOW_STYLE_ID, {}, GetDefaultStudioSourcesForOfftube, false),
 
 	/**
 	 * 1.7.2
@@ -264,5 +260,15 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 			LayerMapping: 'graphic_overlay_tema'
 		},
 		{ LayerMapping: 'graphic_overlay_lower' }
-	)
+	),
+
+	/**
+	 * 1.7.5
+	 * - Remove persistent idents
+	 */
+	removeSourceLayer('1.7.5', 'AFVD', 'studio0_graphicsIdent_persistent'),
+
+	...getSourceLayerDefaultsMigrationSteps(VERSION),
+	...getOutputLayerDefaultsMigrationSteps(VERSION),
+	GetDefaultAdLibTriggers(VERSION, SHOW_STYLE_ID, {}, GetDefaultStudioSourcesForOfftube, false)
 ])

--- a/src/tv2_offtube_showstyle/migrations/index.ts
+++ b/src/tv2_offtube_showstyle/migrations/index.ts
@@ -4,7 +4,6 @@ import {
 	changeGFXTemplate,
 	GetDefaultAdLibTriggers,
 	GetDSKSourceLayerNames,
-	literal,
 	RemoveOldShortcuts,
 	removeSourceLayer,
 	renameSourceLayer,
@@ -16,7 +15,6 @@ import {
 	UpsertValuesIntoTransitionTable
 } from 'tv2-common'
 import { SharedGraphicLLayer, SharedSourceLayers } from 'tv2-constants'
-import * as _ from 'underscore'
 import { ATEMModel } from '../../types/atem'
 import { OfftubeSourceLayer } from '../layers'
 import { GetDefaultStudioSourcesForOfftube } from './hotkeys'
@@ -71,7 +69,7 @@ const SHOW_STYLE_ID = 'tv2_offtube_showstyle'
  * 0.1.0: Core 0.24.0
  */
 
-export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationStepShowStyle[]>([
+export const showStyleMigrations: MigrationStepShowStyle[] = [
 	// Fill in any layers that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations
 	...getCreateVariantMigrationSteps(),
@@ -271,4 +269,4 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 	...getSourceLayerDefaultsMigrationSteps(VERSION),
 	...getOutputLayerDefaultsMigrationSteps(VERSION),
 	GetDefaultAdLibTriggers(VERSION, SHOW_STYLE_ID, {}, GetDefaultStudioSourcesForOfftube, false)
-])
+]

--- a/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
+++ b/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
@@ -22,21 +22,6 @@ const OVERLAY: ISourceLayer[] = [
 		onPresenterScreen: false
 	},
 	{
-		_id: OfftubeSourceLayer.PgmGraphicsIdentPersistent,
-		_rank: 10,
-		name: 'GFX Ident Persistent (hidden)',
-		abbreviation: 'G',
-		type: SourceLayerType.LOWER_THIRD,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		isSticky: false,
-		isQueueable: false,
-		isHidden: true,
-		allowDisable: false,
-		onPresenterScreen: false
-	},
-	{
 		_id: OfftubeSourceLayer.PgmGraphicsTop,
 		_rank: 20,
 		name: 'GFX Top',

--- a/src/tv2_offtube_showstyle/migrations/util.ts
+++ b/src/tv2_offtube_showstyle/migrations/util.ts
@@ -14,7 +14,7 @@ import SourcelayerDefaults from './sourcelayer-defaults'
 export function getSourceLayerDefaultsMigrationSteps(versionStr: string, force?: boolean): MigrationStepShowStyle[] {
 	return _.compact(
 		_.map(SourcelayerDefaults, (defaultVal: ISourceLayer): MigrationStepShowStyle | null => {
-			return literal<MigrationStepShowStyle>({
+			return {
 				id: `${versionStr}.sourcelayer.defaults${force ? '.forced' : ''}.${defaultVal._id}`,
 				version: versionStr,
 				canBeRunAutomatically: true,
@@ -39,13 +39,13 @@ export function getSourceLayerDefaultsMigrationSteps(versionStr: string, force?:
 						context.insertSourceLayer(defaultVal._id, defaultVal)
 					}
 				}
-			})
+			}
 		})
 	)
 }
 
 export function forceSettingToDefaults(versionStr: string, setting: string): MigrationStepShowStyle {
-	return literal<MigrationStepShowStyle>({
+	return {
 		id: `${versionStr}.sourcelayer.defaults.${setting}.forced`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -78,13 +78,13 @@ export function forceSettingToDefaults(versionStr: string, setting: string): Mig
 				context.setBaseConfig(setting, defaultVal.defaultVal)
 			}
 		}
-	})
+	}
 }
 
 export function getOutputLayerDefaultsMigrationSteps(versionStr: string): MigrationStepShowStyle[] {
 	return _.compact(
 		_.map(OutputlayerDefaults, (defaultVal: IOutputLayer): MigrationStepShowStyle | null => {
-			return literal<MigrationStepShowStyle>({
+			return {
 				id: `${versionStr}.outputlayer.defaults.${defaultVal._id}`,
 				version: versionStr,
 				canBeRunAutomatically: true,
@@ -99,7 +99,7 @@ export function getOutputLayerDefaultsMigrationSteps(versionStr: string): Migrat
 						context.insertOutputLayer(defaultVal._id, defaultVal)
 					}
 				}
-			})
+			}
 		})
 	)
 }
@@ -112,7 +112,7 @@ function remapTableColumnValuesInner(
 ): { changed: number; table: TableConfigItemValue } {
 	let changed = 0
 
-	table.map(row => {
+	table.forEach(row => {
 		const val = row[columnId]
 
 		if (val) {
@@ -123,8 +123,6 @@ function remapTableColumnValuesInner(
 				changed++
 			}
 		}
-
-		return row
 	})
 
 	return { changed, table }

--- a/src/tv2_offtube_showstyle/onTimelineGenerate.ts
+++ b/src/tv2_offtube_showstyle/onTimelineGenerate.ts
@@ -7,7 +7,13 @@ import {
 	TimelinePersistentState,
 	TSR
 } from '@tv2media/blueprints-integration'
-import { disablePilotWipeAfterJingle, onTimelineGenerate, PartEndStateExt, TimelineBlueprintExt } from 'tv2-common'
+import {
+	disablePilotWipeAfterJingle,
+	onTimelineGenerate,
+	PartEndStateExt,
+	PieceMetaData,
+	TimelineBlueprintExt
+} from 'tv2-common'
 import { SharedGraphicLLayer, TallyTags } from 'tv2-constants'
 import { OfftubeAtemLLayer, OfftubeCasparLLayer, OfftubeSisyfosLLayer } from '../tv2_offtube_studio/layers'
 import { getConfig } from './helpers/config'
@@ -17,7 +23,7 @@ export function onTimelineGenerateOfftube(
 	timeline: OnGenerateTimelineObj[],
 	previousPersistentState: TimelinePersistentState | undefined,
 	previousPartEndState: PartEndState | undefined,
-	resolvedPieces: IBlueprintResolvedPieceInstance[]
+	resolvedPieces: Array<IBlueprintResolvedPieceInstance<PieceMetaData>>
 ): Promise<BlueprintResultTimeline> {
 	const previousPartEndState2 = previousPartEndState as PartEndStateExt | undefined
 	disablePilotWipeAfterJingle(timeline, previousPartEndState2, resolvedPieces)

--- a/src/tv2_offtube_showstyle/parts/OfftubeDVE.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeDVE.ts
@@ -7,7 +7,7 @@ import {
 	IBlueprintPiece,
 	ISegmentUserContext
 } from '@tv2media/blueprints-integration'
-import { AddScript, literal, PartDefinitionDVE, PartTime } from 'tv2-common'
+import { AddScript, PartDefinitionDVE, PartTime } from 'tv2-common'
 import { OfftubeShowstyleBlueprintConfig } from '../helpers/config'
 import { OfftubeEvaluateCues } from '../helpers/EvaluateCues'
 import { OfftubeSourceLayer } from '../layers'
@@ -20,12 +20,12 @@ export async function OfftubeCreatePartDVE(
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(config, partDefinition, totalWords, false)
 
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title: partDefinition.title || `DVE`,
 		autoNext: false,
 		expectedDuration: partTime
-	})
+	}
 	const pieces: IBlueprintPiece[] = []
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const actions: IBlueprintActionManifest[] = []

--- a/src/tv2_offtube_showstyle/parts/OfftubeGrafik.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeGrafik.ts
@@ -6,7 +6,7 @@ import {
 	IBlueprintPiece,
 	ISegmentUserContext
 } from '@tv2media/blueprints-integration'
-import { AddScript, ApplyFullGraphicPropertiesToPart, literal, PartDefinition, PartTime } from 'tv2-common'
+import { AddScript, ApplyFullGraphicPropertiesToPart, PartDefinition, PartTime } from 'tv2-common'
 import { OfftubeShowstyleBlueprintConfig } from '../helpers/config'
 import { OfftubeEvaluateCues } from '../helpers/EvaluateCues'
 import { OfftubeSourceLayer } from '../layers'
@@ -20,13 +20,13 @@ export async function OfftubeCreatePartGrafik(
 ) {
 	const partTime = PartTime(config, partDefinition, totalWords)
 
-	const part = literal<IBlueprintPart>({
+	const part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title: partDefinition.title || partDefinition.type + ' - ' + partDefinition.rawType,
 		metaData: {},
 		autoNext: false,
 		expectedDuration: partTime
-	})
+	}
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const pieces: IBlueprintPiece[] = []

--- a/src/tv2_offtube_showstyle/parts/OfftubeUnknown.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeUnknown.ts
@@ -11,7 +11,6 @@ import {
 	ApplyFullGraphicPropertiesToPart,
 	GetJinglePartProperties,
 	GraphicIsPilot,
-	literal,
 	PartDefinition,
 	PartTime
 } from 'tv2-common'
@@ -29,13 +28,13 @@ export async function CreatePartUnknown(
 ) {
 	const partTime = PartTime(config, partDefinition, totalWords)
 
-	let part = literal<IBlueprintPart>({
+	let part: IBlueprintPart = {
 		externalId: partDefinition.externalId,
 		title: partDefinition.title || partDefinition.type + ' - ' + partDefinition.rawType,
 		metaData: {},
 		autoNext: false,
 		expectedDuration: partTime
-	})
+	}
 
 	const adLibPieces: IBlueprintAdLibPiece[] = []
 	const pieces: IBlueprintPiece[] = []

--- a/src/tv2_offtube_showstyle/postProcessTimelineObjects.ts
+++ b/src/tv2_offtube_showstyle/postProcessTimelineObjects.ts
@@ -7,7 +7,7 @@ import {
 	TimelineObjHoldMode,
 	TSR
 } from '@tv2media/blueprints-integration'
-import { literal, TimelineBlueprintExt, TV2BlueprintConfig } from 'tv2-common'
+import { TimelineBlueprintExt, TV2BlueprintConfig } from 'tv2-common'
 import { ControlClasses } from 'tv2-constants'
 import _ = require('underscore')
 import { OfftubeAbstractLLayer, OfftubeAtemLLayer } from '../tv2_offtube_studio/layers'
@@ -60,7 +60,7 @@ export function postProcessPieceTimelineObjects(
 				) {
 					if (tlObj.classes?.includes(ControlClasses.AbstractLookahead)) {
 						// Create a lookahead-lookahead object for this me-program
-						const lookaheadObj = literal<TSR.TimelineObjAbstractAny & TimelineBlueprintExt>({
+						const lookaheadObj: TSR.TimelineObjAbstractAny & TimelineBlueprintExt = {
 							id: '',
 							enable: { start: 0 },
 							priority: tlObj.holdMode === TimelineObjHoldMode.ONLY ? 5 : 0, // Must be below lookahead, except when forced by hold
@@ -74,11 +74,11 @@ export function postProcessPieceTimelineObjects(
 								mediaPlayerSession: tlObj.metaData?.mediaPlayerSession
 							},
 							classes: ['ab_on_preview']
-						})
+						}
 						extraObjs.push(lookaheadObj)
 					} else {
 						// Create a lookahead-lookahead object for this me-program
-						const lookaheadObj = literal<TSR.TimelineObjAtemME & TimelineBlueprintExt>({
+						const lookaheadObj: TSR.TimelineObjAtemME & TimelineBlueprintExt = {
 							id: '',
 							enable: { start: 0 },
 							priority: tlObj.holdMode === TimelineObjHoldMode.ONLY ? 5 : 0, // Must be below lookahead, except when forced by hold
@@ -97,7 +97,7 @@ export function postProcessPieceTimelineObjects(
 								mediaPlayerSession: tlObj.metaData?.mediaPlayerSession
 							},
 							classes: ['ab_on_preview']
-						})
+						}
 						extraObjs.push(lookaheadObj)
 					}
 				}

--- a/src/tv2_offtube_studio/getBaseline.ts
+++ b/src/tv2_offtube_studio/getBaseline.ts
@@ -10,7 +10,7 @@ import * as _ from 'underscore'
 import { AtemSourceIndex } from '../types/atem'
 import { OfftubeStudioBlueprintConfig } from './helpers/config'
 import { OfftubeAtemLLayer, OfftubeSisyfosLLayer } from './layers'
-import { SisyfosChannel, sisyfosChannels } from './sisyfosChannels'
+import { sisyfosChannels } from './sisyfosChannels'
 
 function filterMappings(
 	input: BlueprintMappings,
@@ -30,14 +30,14 @@ function filterMappings(
 
 export function getBaseline(context: IStudioContext): BlueprintResultBaseline {
 	const mappings = context.getStudioMappings()
-	const config = (context.getStudioConfig() as unknown) as OfftubeStudioBlueprintConfig
+	const config = context.getStudioConfig() as OfftubeStudioBlueprintConfig
 
 	const sisyfosMappings = filterMappings(mappings, (_id, v) => v.device === TSR.DeviceType.SISYFOS)
 
 	const mappedChannels: TSR.TimelineObjSisyfosChannels['content']['channels'] = []
 	for (const id in sisyfosMappings) {
 		if (sisyfosMappings[id]) {
-			const sisyfosChannel = sisyfosChannels[id as OfftubeSisyfosLLayer] as SisyfosChannel | undefined
+			const sisyfosChannel = sisyfosChannels[id as OfftubeSisyfosLLayer]
 			if (sisyfosChannel) {
 				mappedChannels.push({
 					mappedLayer: id,

--- a/src/tv2_offtube_studio/migrations/devices.ts
+++ b/src/tv2_offtube_studio/migrations/devices.ts
@@ -5,7 +5,6 @@ import {
 	MigrationStepStudio,
 	TSR
 } from '@tv2media/blueprints-integration'
-import { literal } from 'tv2-common'
 import * as _ from 'underscore'
 
 declare const VERSION: string // Injected by webpack
@@ -218,10 +217,10 @@ const devices: DeviceEntry[] = [
 	}
 ]
 
-export const deviceMigrations = literal<MigrationStepStudio[]>([
+export const deviceMigrations: MigrationStepStudio[] = [
 	// create all devices
 	..._.map(devices, createDevice),
 
 	// ensure all devices still look valid
 	..._.map(devices, validateDevice)
-])
+]

--- a/src/tv2_offtube_studio/migrations/index.ts
+++ b/src/tv2_offtube_studio/migrations/index.ts
@@ -6,7 +6,6 @@ import {
 } from '@tv2media/blueprints-integration'
 import {
 	AddKeepAudio,
-	literal,
 	MoveClipSourcePath,
 	MoveSourcesToTable,
 	RemoveConfig,
@@ -41,7 +40,7 @@ function renameAudioSources(versionStr: string, renaming: Map<string, string>): 
 	const steps: MigrationStepStudio[] = []
 	for (const layer in renaming) {
 		if (layer in renaming) {
-			const res = literal<MigrationStepStudio>({
+			const res: MigrationStepStudio = {
 				id: `${versionStr}.studioConfig.renameAudioSources.${layer}`,
 				version: versionStr,
 				canBeRunAutomatically: true,
@@ -64,7 +63,7 @@ function renameAudioSources(versionStr: string, renaming: Map<string, string>): 
 						}
 					}
 				}
-			})
+			}
 
 			steps.push(res)
 		}
@@ -74,7 +73,7 @@ function renameAudioSources(versionStr: string, renaming: Map<string, string>): 
 }
 
 function ensureMappingDeleted(versionStr: string, mapping: string): MigrationStepStudio {
-	const res = literal<MigrationStepStudio>({
+	return {
 		id: `${versionStr}.studioConfig.ensureMappingDeleted.${mapping}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -92,9 +91,7 @@ function ensureMappingDeleted(versionStr: string, mapping: string): MigrationSte
 				context.removeMapping(mapping)
 			}
 		}
-	})
-
-	return res
+	}
 }
 
 function remapTableColumnValuesInner(
@@ -105,7 +102,7 @@ function remapTableColumnValuesInner(
 ): { changed: number; table: TableConfigItemValue } {
 	let changed = 0
 
-	table.map(row => {
+	table.forEach(row => {
 		const val = row[columnId]
 
 		if (val) {
@@ -127,8 +124,6 @@ function remapTableColumnValuesInner(
 				}
 			}
 		}
-
-		return row
 	})
 
 	return { changed, table }
@@ -142,7 +137,7 @@ function remapTableColumnValues(
 	remapping: Map<string, string>
 ): MigrationStepStudio[] {
 	return [
-		literal<MigrationStepStudio>({
+		{
 			id: `${versionStr}.remapTableColumnValue.${tableId}.${columnId}`,
 			version: versionStr,
 			canBeRunAutomatically: true,
@@ -179,7 +174,7 @@ function remapTableColumnValues(
 
 				context.setConfig(tableId, ret.table)
 			}
-		})
+		}
 	]
 }
 
@@ -190,7 +185,7 @@ const audioSourceRenaming: Map<string, string> = new Map([
 	['sisyfos_source_world_feed_surround', OfftubeSisyfosLLayer.SisyfosSourceLive_3]
 ])
 
-export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStudio[]>([
+export const studioMigrations: MigrationStepStudio[] = [
 	ensureStudioConfig(
 		'0.1.0',
 		'SourcesCam',
@@ -370,4 +365,4 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	// Fill in any mappings that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations
 	...getMappingsDefaultsMigrationSteps(VERSION)
-])
+]

--- a/src/tv2_offtube_studio/migrations/util.ts
+++ b/src/tv2_offtube_studio/migrations/util.ts
@@ -6,7 +6,6 @@ import {
 	MigrationStepInputFilteredResult,
 	MigrationStepStudio
 } from '@tv2media/blueprints-integration'
-import { literal } from 'tv2-common'
 import * as _ from 'underscore'
 import { OfftubeSisyfosLLayer } from '../layers'
 import MappingsDefaults from './mappings-defaults'
@@ -131,9 +130,9 @@ export function removeMapping(version: string, oldMappingName: string): Migratio
 }
 
 export function getMappingsDefaultsMigrationSteps(versionStr: string): MigrationStepStudio[] {
-	const res = _.compact(
+	return _.compact(
 		_.map(MappingsDefaults, (defaultVal: BlueprintMapping, id: string): MigrationStepStudio | null => {
-			return literal<MigrationStepStudio>({
+			return {
 				id: `${versionStr}.mappings.defaults.${id}`,
 				version: versionStr,
 				canBeRunAutomatically: true,
@@ -150,11 +149,9 @@ export function getMappingsDefaultsMigrationSteps(versionStr: string): Migration
 						context.insertMapping(id, defaultVal)
 					}
 				}
-			})
+			}
 		})
 	)
-
-	return res
 }
 
 export function GetMappingDefaultMigrationStepForLayer(
@@ -162,7 +159,7 @@ export function GetMappingDefaultMigrationStepForLayer(
 	layer: string,
 	force?: boolean
 ): MigrationStepStudio {
-	return literal<MigrationStepStudio>({
+	return {
 		id: `${versionStr}.mappings.defaults.manualEnsure${layer}`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -189,7 +186,7 @@ export function GetMappingDefaultMigrationStepForLayer(
 				context.insertMapping(layer, MappingsDefaults[layer])
 			}
 		}
-	})
+	}
 }
 
 export function GetSisyfosLayersForTableMigrationOfftube(configName: string, val: string): string[] {

--- a/src/tv2_system/migrations/hotkeys.ts
+++ b/src/tv2_system/migrations/hotkeys.ts
@@ -6,12 +6,11 @@ import {
 	PlayoutActions,
 	TriggerType
 } from '@tv2media/blueprints-integration'
-import { literal } from 'tv2-common'
 
-export function RemoveDefaultCoreShortcuts(versionStr: string) {
+export function RemoveDefaultCoreShortcuts(versionStr: string): MigrationStepSystem {
 	const defaultTriggerIds = DEFAULT_CORE_TRIGGERS.map(trigger => trigger._id)
 
-	return literal<MigrationStepSystem>({
+	return {
 		id: `${versionStr}.disableCoreDefaultTriggers`,
 		version: versionStr,
 		canBeRunAutomatically: true,
@@ -34,7 +33,7 @@ export function RemoveDefaultCoreShortcuts(versionStr: string) {
 				}
 			}
 		}
-	})
+	}
 }
 
 // copy-pasted from core migrations

--- a/src/tv2_system/migrations/index.ts
+++ b/src/tv2_system/migrations/index.ts
@@ -1,9 +1,6 @@
 import { MigrationStepSystem } from '@tv2media/blueprints-integration'
-import { literal } from 'tv2-common'
 import { RemoveDefaultCoreShortcuts } from './hotkeys'
 
 declare const VERSION: string // Injected by webpack
 
-export const systemMigrations: MigrationStepSystem[] = literal<MigrationStepSystem[]>([
-	RemoveDefaultCoreShortcuts(VERSION)
-])
+export const systemMigrations: MigrationStepSystem[] = [RemoveDefaultCoreShortcuts(VERSION)]


### PR DESCRIPTION
Removes some sticky ident logic because they are supposed to be brought back only when recalling Last Live, which being an adlib action, is capable of finding the associated ident as well - no need for extra timelineObject `enable` & `class` rules. Also stops  within-part graphics in the `CutToCamera` action to make it work and look more like a Part would.