### PR TITLE
fix: SOF-767 set `length` only when `seek` is truthy

### DIFF
--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -95,7 +95,7 @@ function GetServerTimeline(
 			file: contentProps.file,
 			loop: partProps.adLibPix,
 			seek: contentProps.seek,
-			length: contentProps.clipDuration,
+			length: contentProps.seek ? contentProps.clipDuration : undefined,
 			playing: true
 		},
 		metaData: {


### PR DESCRIPTION
We don't need it when `seek` is not set. (Caspar needs it just for the purpose of `seek` working, but the values are incompatible with version 2.3 - it would need more work to get Server Resume compatible with that version)