### PR TITLE
fix: SOF-767 re-enable server resume

### DIFF
--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -423,7 +423,6 @@ async function executeActionSelectServerClip<
 	triggerMode?: ServerSelectMode,
 	sessionToContinue?: string
 ) {
-	triggerMode = ServerSelectMode.RESET /** @todo: remove for Server Resume */
 	const file = userData.file
 	const partDefinition = userData.partDefinition
 	const config = settings.getConfig(context)

--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -96,6 +96,7 @@ function GetServerTimeline(
 			loop: partProps.adLibPix,
 			seek: contentProps.seek,
 			length: contentProps.seek ? contentProps.clipDuration : undefined,
+			inPoint: contentProps.seek ? 0 : undefined,
 			playing: true
 		},
 		metaData: {
@@ -111,6 +112,7 @@ function GetServerTimeline(
 	const mediaOffObj = JSON.parse(JSON.stringify(mediaObj)) as TSR.TimelineObjCCGMedia & TimelineBlueprintExt
 	mediaOffObj.enable = { while: `!${serverEnableClass}` }
 	mediaOffObj.content.playing = false
+	mediaOffObj.content.noStarttime = true
 
 	const audioEnable = {
 		while: serverEnableClass

--- a/src/tv2-common/pieces/adlibServer.ts
+++ b/src/tv2-common/pieces/adlibServer.ts
@@ -12,7 +12,7 @@ import {
 	TV2StudioConfigBase
 } from 'tv2-common'
 import { AdlibActionType, AdlibTags, SharedOutputLayers } from 'tv2-constants'
-import { t } from '../helpers'
+import { getServerAdLibTriggerModes, t } from '../helpers'
 
 export interface AdlibServerOfftubeOptions {
 	/** By passing in this object, you're creating a server according to the OFFTUBE showstyle. */
@@ -68,7 +68,7 @@ export async function CreateAdlibServer<
 			currentPieceTags: [GetTagForServer(partDefinition.segmentExternalId, file, !!voLayer)],
 			nextPieceTags: [GetTagForServerNext(partDefinition.segmentExternalId, file, !!voLayer)],
 			uniquenessId: `${voLayer ? 'vo' : 'server'}_${partDefinition.storyName}_${file}`
-		}
-		// triggerModes: getServerAdLibTriggerModes() /** @todo: uncomment for Server Resume */
+		},
+		triggerModes: getServerAdLibTriggerModes()
 	})
 }


### PR DESCRIPTION
Re-enables Server Resume and adds some parameters to the timeline object, to make looping work correctly with CasparCG 2.1