### PR TITLE
fix: SOF-1134 color source shown briefly before DVE

### DIFF
--- a/src/tv2-common/actions/actionTypes.ts
+++ b/src/tv2-common/actions/actionTypes.ts
@@ -32,6 +32,7 @@ export interface ActionSelectFullGrafik extends ActionBase {
 export interface ActionSelectDVE extends ActionBase {
 	type: AdlibActionType.SELECT_DVE
 	config: CueDefinitionDVE
+	name: string
 	videoId: string | undefined
 	segmentExternalId: string
 }

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -612,7 +612,7 @@ async function executeActionSelectDVE<
 
 	let dvePiece: IBlueprintPiece<DVEPieceMetaData> = {
 		externalId,
-		name: `${parsedCue.template}`,
+		name: userData.name,
 		enable: {
 			start,
 			...(end ? { duration: end - start } : {})
@@ -813,6 +813,7 @@ async function executeActionSelectDVELayout<
 					labels: [],
 					iNewsCommand: `DVE=${userData.config.DVEName}`
 				},
+				name: userData.config.DVEName,
 				videoId: undefined,
 				segmentExternalId: ''
 			}
@@ -1971,6 +1972,7 @@ async function scheduleLastPlayedDVE<
 	await executeActionSelectDVE(context, settings, actionId, {
 		type: AdlibActionType.SELECT_DVE,
 		config: lastPlayedDVEMeta.userData.config,
+		name: lastPlayedDVE.piece.name,
 		segmentExternalId: externalId,
 		videoId: lastPlayedDVEMeta.userData.videoId
 	})
@@ -1998,6 +2000,7 @@ async function scheduleNextScriptedDVE<
 	await executeActionSelectDVE(context, settings, actionId, {
 		type: AdlibActionType.SELECT_DVE,
 		config: dveMeta.userData.config,
+		name: nextScriptedDVE.name,
 		segmentExternalId: externalId,
 		videoId: dveMeta.userData.videoId
 	})

--- a/src/tv2-common/evaluateCues.ts
+++ b/src/tv2-common/evaluateCues.ts
@@ -94,7 +94,6 @@ export interface EvaluateCuesShowstyleOptions {
 		context: ISegmentUserContext,
 		config: TV2BlueprintConfig,
 		pieces: IBlueprintPiece[],
-		adlibPieces: IBlueprintAdLibPiece[],
 		actions: IBlueprintActionManifest[],
 		partDefinition: PartDefinition,
 		parsedCue: CueDefinitionDVE,
@@ -104,10 +103,8 @@ export interface EvaluateCuesShowstyleOptions {
 	EvaluateCueAdLib?: (
 		context: ISegmentUserContext,
 		config: TV2BlueprintConfig,
-		adLibPieces: IBlueprintAdLibPiece[],
 		actions: IBlueprintActionManifest[],
 		mediaSubscriptions: HackPartMediaObjectSubscription[],
-		partId: string,
 		parsedCue: CueDefinitionAdLib,
 		partDefinition: PartDefinition,
 		rank: number
@@ -256,7 +253,6 @@ export async function EvaluateCuesBase(
 							context,
 							config,
 							pieces,
-							adLibPieces,
 							actions,
 							partDefinition,
 							cue,
@@ -265,17 +261,7 @@ export async function EvaluateCuesBase(
 						)
 						// Always make an adlib for DVEs
 						if (!shouldAdlib) {
-							showStyleOptions.EvaluateCueDVE(
-								context,
-								config,
-								pieces,
-								adLibPieces,
-								actions,
-								partDefinition,
-								cue,
-								true,
-								adLibRank
-							)
+							showStyleOptions.EvaluateCueDVE(context, config, pieces, actions, partDefinition, cue, true, adLibRank)
 						}
 					}
 					break
@@ -284,10 +270,8 @@ export async function EvaluateCuesBase(
 						await showStyleOptions.EvaluateCueAdLib(
 							context,
 							config,
-							adLibPieces,
 							actions,
 							mediaSubscriptions,
-							partDefinition.externalId,
 							cue,
 							partDefinition,
 							adLibRank

--- a/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
@@ -1,7 +1,6 @@
 import {
 	HackPartMediaObjectSubscription,
 	IBlueprintActionManifest,
-	IBlueprintAdLibPiece,
 	IShowStyleUserContext
 } from '@tv2media/blueprints-integration'
 import {
@@ -13,7 +12,6 @@ import {
 	GetDVETemplate,
 	getUniquenessIdDVE,
 	PartDefinition,
-	PieceMetaData,
 	t,
 	TemplateIsValid
 } from 'tv2-common'
@@ -26,10 +24,8 @@ import { MakeContentDVE } from '../content/dve'
 export async function EvaluateAdLib(
 	context: IShowStyleUserContext,
 	config: BlueprintConfig,
-	_adLibPieces: Array<IBlueprintAdLibPiece<PieceMetaData>>,
 	actions: IBlueprintActionManifest[],
 	mediaSubscriptions: HackPartMediaObjectSubscription[],
-	_partId: string,
 	parsedCue: CueDefinitionAdLib,
 	partDefinition: PartDefinition,
 	rank: number

--- a/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
@@ -2,20 +2,19 @@ import {
 	HackPartMediaObjectSubscription,
 	IBlueprintActionManifest,
 	IBlueprintAdLibPiece,
-	IShowStyleUserContext,
-	PieceLifespan
+	IShowStyleUserContext
 } from '@tv2media/blueprints-integration'
 import {
 	ActionSelectDVE,
 	CreateAdlibServer,
 	CueDefinitionAdLib,
 	CueDefinitionDVE,
-	DVEPieceMetaData,
+	generateExternalId,
 	GetDVETemplate,
 	getUniquenessIdDVE,
-	literal,
 	PartDefinition,
 	PieceMetaData,
+	t,
 	TemplateIsValid
 } from 'tv2-common'
 import { AdlibActionType, AdlibTags, CueType, SharedOutputLayers } from 'tv2-constants'
@@ -27,10 +26,10 @@ import { MakeContentDVE } from '../content/dve'
 export async function EvaluateAdLib(
 	context: IShowStyleUserContext,
 	config: BlueprintConfig,
-	adLibPieces: Array<IBlueprintAdLibPiece<PieceMetaData>>,
+	_adLibPieces: Array<IBlueprintAdLibPiece<PieceMetaData>>,
 	actions: IBlueprintActionManifest[],
 	mediaSubscriptions: HackPartMediaObjectSubscription[],
-	partId: string,
+	_partId: string,
 	parsedCue: CueDefinitionAdLib,
 	partDefinition: PartDefinition,
 	rank: number
@@ -100,31 +99,26 @@ export async function EvaluateAdLib(
 
 		const content = MakeContentDVE(context, config, partDefinition, cueDVE, rawTemplate, false, true)
 
-		adLibPieces.push({
-			_rank: rank,
-			externalId: partId,
-			name: `DVE: ${parsedCue.variant}`,
-			sourceLayerId: SourceLayer.PgmDVE,
-			outputLayerId: SharedOutputLayers.PGM,
-			uniquenessId: getUniquenessIdDVE(cueDVE),
-			toBeQueued: true,
-			content: content.content,
-			invalid: !content.valid,
-			lifespan: PieceLifespan.WithinPart,
-			metaData: literal<DVEPieceMetaData>({
-				sources: cueDVE.sources,
-				config: rawTemplate,
-				userData: literal<ActionSelectDVE>({
-					type: AdlibActionType.SELECT_DVE,
-					config: cueDVE,
-					videoId: partDefinition.fields.videoId,
-					segmentExternalId: partDefinition.segmentExternalId
-				}),
-				sisyfosPersistMetaData: {
-					sisyfosLayers: []
-				}
-			}),
-			tags: [AdlibTags.ADLIB_FLOW_PRODUCER]
+		const userData: ActionSelectDVE = {
+			type: AdlibActionType.SELECT_DVE,
+			config: cueDVE,
+			name: `DVE: ${cueDVE.template}`,
+			videoId: partDefinition.fields.videoId,
+			segmentExternalId: partDefinition.segmentExternalId
+		}
+		actions.push({
+			externalId: generateExternalId(context, userData),
+			actionId: AdlibActionType.SELECT_DVE,
+			userData,
+			userDataManifest: {},
+			display: {
+				sourceLayerId: SourceLayer.PgmDVE,
+				outputLayerId: SharedOutputLayers.PGM,
+				uniquenessId: getUniquenessIdDVE(cueDVE),
+				label: t(`${partDefinition.storyName}`),
+				tags: [AdlibTags.ADLIB_FLOW_PRODUCER],
+				content: content.content
+			}
 		})
 	}
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
@@ -1,6 +1,5 @@
 import {
 	IBlueprintActionManifest,
-	IBlueprintAdLibPiece,
 	IBlueprintPiece,
 	ISegmentUserContext,
 	PieceLifespan
@@ -28,7 +27,6 @@ export function EvaluateDVE(
 	context: ISegmentUserContext,
 	config: BlueprintConfig,
 	pieces: IBlueprintPiece[],
-	_adlibPieces: IBlueprintAdLibPiece[],
 	actions: IBlueprintActionManifest[],
 	partDefinition: PartDefinition,
 	parsedCue: CueDefinitionDVE,
@@ -88,7 +86,7 @@ export function EvaluateDVE(
 			let start = parsedCue.start ? CalculateTime(parsedCue.start) : 0
 			start = start ? start : 0
 			const end = parsedCue.end ? CalculateTime(parsedCue.end) : undefined
-			const pieceName =  `DVE: ${parsedCue.template}`
+			const pieceName = `DVE: ${parsedCue.template}`
 			pieces.push(
 				literal<IBlueprintPiece<DVEPieceMetaData>>({
 					externalId: partDefinition.externalId,

--- a/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
@@ -198,6 +198,7 @@ const selectDVEActionMorbarn = literal<ActionSelectDVE>({
 		labels: ['Live'],
 		iNewsCommand: 'DVE=MORBARN'
 	},
+	name: 'morbarn',
 	videoId: undefined,
 	segmentExternalId: SEGMENT_ID_EXTERNAL
 })
@@ -214,6 +215,7 @@ const selectDVEActionBarnmor = literal<ActionSelectDVE>({
 		labels: ['Live'],
 		iNewsCommand: 'DVE=BARNMOR'
 	},
+	name: 'barnmor',
 	videoId: undefined,
 	segmentExternalId: SEGMENT_ID_EXTERNAL
 })

--- a/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
@@ -108,6 +108,7 @@ export async function OfftubeEvaluateAdLib(
 		const userData: ActionSelectDVE = {
 			type: AdlibActionType.SELECT_DVE,
 			config: cueDVE,
+			name: `DVE: ${cueDVE.template}`,
 			videoId: partDefinition.fields.videoId,
 			segmentExternalId: partDefinition.segmentExternalId
 		}

--- a/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
@@ -1,7 +1,6 @@
 import {
 	HackPartMediaObjectSubscription,
 	IBlueprintActionManifest,
-	IBlueprintAdLibPiece,
 	ISegmentUserContext,
 	SplitsContent,
 	TimelineObjectCoreExt,
@@ -30,10 +29,8 @@ import { OfftubeOutputLayers, OfftubeSourceLayer } from '../layers'
 export async function OfftubeEvaluateAdLib(
 	context: ISegmentUserContext,
 	config: OfftubeShowstyleBlueprintConfig,
-	_adLibPieces: IBlueprintAdLibPiece[],
 	actions: IBlueprintActionManifest[],
 	mediaSubscriptions: HackPartMediaObjectSubscription[],
-	_partId: string,
 	parsedCue: CueDefinitionAdLib,
 	partDefinition: PartDefinition,
 	rank: number

--- a/src/tv2_offtube_showstyle/cues/OfftubeDVE.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeDVE.ts
@@ -78,7 +78,7 @@ export function OfftubeEvaluateDVE(
 		const end = parsedCue.end ? CalculateTime(parsedCue.end) : undefined
 		pieces.push({
 			externalId: partDefinition.externalId,
-			name: `${parsedCue.template}`,
+			name: parsedCue.template,
 			enable: {
 				start,
 				...(end ? { duration: end - start } : {})
@@ -99,6 +99,7 @@ export function OfftubeEvaluateDVE(
 				userData: {
 					type: AdlibActionType.SELECT_DVE,
 					config: parsedCue,
+					name: parsedCue.template,
 					videoId: partDefinition.fields.videoId,
 					segmentExternalId: partDefinition.segmentExternalId
 				},
@@ -116,6 +117,7 @@ export function OfftubeEvaluateDVE(
 		const userData: ActionSelectDVE = {
 			type: AdlibActionType.SELECT_DVE,
 			config: parsedCue,
+			name: `DVE: ${parsedCue.template}`,
 			videoId: partDefinition.fields.videoId,
 			segmentExternalId: partDefinition.segmentExternalId
 		}

--- a/src/tv2_offtube_showstyle/cues/OfftubeDVE.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeDVE.ts
@@ -1,6 +1,5 @@
 import {
 	IBlueprintActionManifest,
-	IBlueprintAdLibPiece,
 	IBlueprintPiece,
 	ISegmentUserContext,
 	PieceLifespan,
@@ -30,7 +29,6 @@ export function OfftubeEvaluateDVE(
 	context: ISegmentUserContext,
 	config: OfftubeShowstyleBlueprintConfig,
 	pieces: IBlueprintPiece[],
-	_adlibPieces: IBlueprintAdLibPiece[],
 	actions: IBlueprintActionManifest[],
 	partDefinition: PartDefinition,
 	parsedCue: CueDefinitionDVE,


### PR DESCRIPTION
Fixed by replacing DVE AdLib Pieces with AdLib Actions. The former seem to be affected by some `prerollDuration` bug in core, which probably does not make sense to look into before we reach NRKs release42 and can update superfly-timeline to a newer version.