### PR TITLE
Update kommentator and qFlow layout

### DIFF
--- a/shelf-layouts/Kommentator.json
+++ b/shelf-layouts/Kommentator.json
@@ -161,22 +161,6 @@
       "toggleOnSingleClick": true
     },
     {
-      "_id": "LiFso7gPYn2SPwHwg",
-      "type": "external_frame",
-      "name": "Mic tally",
-      "currentSegment": false,
-      "displayStyle": "buttons",
-      "rank": 0,
-      "rundownBaseline": false,
-      "default": false,
-      "x": 0,
-      "y": 0,
-      "width": 22,
-      "height": 7,
-      "url": "https://sisyfos.sofsrv04-od.tv2.local?view=mic-tally",
-      "scale": 0
-    },
-    {
       "_id": "6GDpdq547HjjZL9YK",
       "type": "adlib_region",
       "name": "Preview",
@@ -416,23 +400,46 @@
       "showPartTitle": true
     },
     {
-      "_id" : "jLzHen2LoGEMxE68N",
-      "type" : "mini_rundown",
-      "name" : "Mini rundown",
-      "currentSegment" : false,
-      "displayStyle" : "buttons",
-      "rank" : 0,
-      "rundownBaseline" : false,
-      "showThumbnailsInList" : false,
-      "hideDuplicates" : false,
-      "default" : false,
-      "nextInCurrentPart" : false,
-      "oneNextPerSourceLayer" : false,
-      "x" : 7,
-      "y" : 0,
-      "width" : 14,
-      "height" : 7,
-      "scale" : 0
+      "_id": "h9xDp3HvzLaSo4yJi",
+      "type": "mini_rundown",
+      "name": "Mini rundown",
+      "currentSegment": false,
+      "displayStyle": "buttons",
+      "rank": 0,
+      "rundownBaseline": false,
+      "showThumbnailsInList": false,
+      "hideDuplicates": false,
+      "default": false,
+      "nextInCurrentPart": false,
+      "oneNextPerSourceLayer": false,
+      "x": 3,
+      "y": 3.8,
+      "width": 16,
+      "height": 3,
+      "scale": 0
+    },
+    {
+      "_id": "dkKTHZAwF98aKkD47",
+      "type": "external_frame",
+      "name": "Mic tally",
+      "currentSegment": false,
+      "displayStyle": "buttons",
+      "rank": 0,
+      "rundownBaseline": false,
+      "showThumbnailsInList": false,
+      "hideDuplicates": false,
+      "default": false,
+      "nextInCurrentPart": false,
+      "oneNextPerSourceLayer": false,
+      "url": "http://sofqb06-od:1176/?view=mic-tally",
+      "x": 3,
+      "y": 0,
+      "width": 16,
+      "height": 5,
+      "customClasses": [
+        ""
+      ],
+      "scale": 0
     }
   ],
   "type": "dashboard_layout",
@@ -440,7 +447,7 @@
     {
       "_id": "PTJBfPjrxPMwY4cqW",
       "label": "Activate",
-      "type": "ready_on_air",
+      "type": "klar_on_air",
       "x": -1,
       "y": 0,
       "width": 14,
@@ -449,26 +456,27 @@
     },
     {
       "_id": "m4ouEduSAvNXm6WZh",
-      "label": "▲ Previous Segment",
+      "label": "▲",
       "type": "move_previous_segment",
       "x": 0,
-      "y": 0,
-      "width": 6,
+      "y": 4,
+      "width": 2,
       "height": 1,
       "labelToggled": ""
     },
     {
       "_id": "FgyddcqkKFhSQeMBS",
-      "label": "▼ Next Segment",
+      "label": "▼",
       "type": "move_next_segment",
       "x": 0,
-      "y": 2,
-      "width": 6,
+      "y": 6,
+      "width": 2,
       "height": 1,
       "labelToggled": ""
     }
   ],
   "exposeAsStandalone": true,
+  "regionId": "shelf_layouts",
   "exposeAsShelf": true,
   "iconColor": "#8e44ad",
   "icon": {
@@ -484,6 +492,5 @@
   },
   "openByDefault": true,
   "startingHeight": 80,
-  "disableContextMenu": true,
-  "regionId": "shelf_layouts"
+  "disableContextMenu": true
 }

--- a/shelf-layouts/Q flow.json
+++ b/shelf-layouts/Q flow.json
@@ -8,13 +8,13 @@
       "type": "filter",
       "name": "ADLIB BUTTONS",
       "currentSegment": false,
-      "displayStyle": "list",
+      "displayStyle": "buttons",
       "rank": 0,
       "rundownBaseline": false,
       "default": false,
       "x": 0,
       "y": 0,
-      "width": -1,
+      "width": -12,
       "height": 6,
       "buttonWidthScale": 1.5,
       "buttonHeightScale": 1.5,
@@ -28,12 +28,11 @@
         "studio0_offtube_graphicsHeadline",
         "studio0_offtube_jingle",
         "studio0_offtube_dve",
-        "studio0_selected_clip",
-        "studio0_selected_voiceover",
+        "studio0_offtube_clip",
+        "studio0_offtube_voiceover",
         "studio0_offtube_graphicsFull",
         "studio0_offtube_aux_studio_screen",
         "studio0_graphicsIdent",
-        "studio0_graphicsIdent_persistent",
         "studio0_graphicsTop",
         "studio0_graphicsLower",
         "studio0_graphicsHeadline",
@@ -44,7 +43,13 @@
         "studio0_dve",
         "studio0_clip",
         "studio0_voiceover",
-        "studio0_full"
+        "studio0_full",
+        "studio0_jingle",
+        "studio0_dve_adlib",
+        "studio0_audio_bed",
+        "studio0_pilotOverlay",
+        "studio0_pilot",
+        "studio0_selected_graphicsFull"
       ],
       "assignHotKeys": true,
       "tags": [
@@ -68,14 +73,48 @@
     {
       "_id": "tGynaBdafH5dZnttN",
       "type": "keyboard_preview",
-      "name": "New Panel",
+      "name": "Keyboard Panel",
       "currentSegment": false,
       "displayStyle": "list",
       "rank": 0,
       "rundownBaseline": false,
       "default": false,
       "y": 9,
-      "x": 0
+      "x": 0,
+      "width": -13.5,
+      "scale": 0.6,
+      "height": 20
+    },
+    {
+      "_id": "CaGXs2ZdPtFMRM47S",
+      "type": "filter",
+      "name": "Static Buttons",
+      "currentSegment": false,
+      "displayStyle": "buttons",
+      "rank": 0,
+      "rundownBaseline": "only",
+      "showThumbnailsInList": false,
+      "hideDuplicates": false,
+      "default": false,
+      "x": -1,
+      "y": 0,
+      "width": 10,
+      "height": 22,
+      "buttonWidthScale": 1.5,
+      "buttonHeightScale": 1.5,
+      "sourceLayerIds": [
+        "studio0_adlib_graphic_cmd",
+        "studio0_sisyfos_adlibs",
+        "studio0_jingle",
+        "studio0_dsk_cmd",
+        "studio0_dsk_2_cmd",
+        "studio0_dsk_3_cmd",
+        "studio0_dsk_4_cmd",
+        "studio0_adlib_jingle"
+      ],
+      "tags": [
+        "static_button"
+      ]
     }
   ],
   "type": "dashboard_layout",
@@ -92,5 +131,6 @@
       "M464 32H48C21.49 32 0 53.49 0 80v352c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V80c0-26.51-21.49-48-48-48zM224 416H64V160h160v256zm224 0H288V160h160v256z"
     ]
   },
-  "iconColor": "#14c942"
+  "iconColor": "#14c942",
+  "regionId": "shelf_layouts"
 }

--- a/shelf-layouts/Q flow.json
+++ b/shelf-layouts/Q flow.json
@@ -107,10 +107,7 @@
         "studio0_sisyfos_adlibs",
         "studio0_jingle",
         "studio0_dsk_cmd",
-        "studio0_dsk_2_cmd",
-        "studio0_dsk_3_cmd",
-        "studio0_dsk_4_cmd",
-        "studio0_adlib_jingle"
+        "studio0_dsk_1_cmd"
       ],
       "tags": [
         "static_button"


### PR DESCRIPTION
Update layout values to fit with the new scaling of release 42.

Not sure if the sourceLayerIds of the qFlow layout is the exact correct ones. If you notice some missing or some that shouldn't be there, let me know.