### PR TITLE
Sof 1092/create gfx design template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv2-sofie-blueprints-inews",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "repository": "https://github.com/olzzon/tv2-sofie-blueprints-inews",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv2-sofie-blueprints-inews",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "repository": "https://github.com/olzzon/tv2-sofie-blueprints-inews",
   "license": "MIT",
   "private": true,

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -26,6 +26,12 @@ export interface TableConfigItemGFXTemplates {
 	IsDesign: boolean
 }
 
+export interface TableConfigItemGFXDesignTemplates {
+	INewsName: string
+	INewsStyleColumn?: string
+	VizTemplate: string
+}
+
 export interface TableConfigItemAdLibTransitions {
 	Transition: string
 }

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -28,7 +28,7 @@ export interface TableConfigItemGFXTemplates {
 
 export interface TableConfigItemGfxDesignTemplate {
 	INewsName: string
-	INewsStyleColumn?: string
+	INewsStyleColumn: string
 	VizTemplate: string
 }
 

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -148,6 +148,7 @@ export interface TV2ShowstyleBlueprintConfigBase {
 	BreakerConfig: TableConfigItemBreakers[]
 	DVEStyles: DVEConfigInput[]
 	GFXTemplates: TableConfigItemGFXTemplates[]
+	GFXDesignTemplates: TableConfigItemGFXDesignTemplates[]
 	Transitions: TableConfigItemAdLibTransitions[]
 	ShowstyleTransition: string
 	MakeAdlibsForFulls: boolean

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -26,7 +26,7 @@ export interface TableConfigItemGFXTemplates {
 	IsDesign: boolean
 }
 
-export interface TableConfigItemGFXDesignTemplates {
+export interface TableConfigItemGfxDesignTemplate {
 	INewsName: string
 	INewsStyleColumn?: string
 	VizTemplate: string
@@ -148,7 +148,7 @@ export interface TV2ShowstyleBlueprintConfigBase {
 	BreakerConfig: TableConfigItemBreakers[]
 	DVEStyles: DVEConfigInput[]
 	GFXTemplates: TableConfigItemGFXTemplates[]
-	GFXDesignTemplates: TableConfigItemGFXDesignTemplates[]
+	GfxDesignTemplates: TableConfigItemGfxDesignTemplate[]
 	Transitions: TableConfigItemAdLibTransitions[]
 	ShowstyleTransition: string
 	MakeAdlibsForFulls: boolean

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -917,7 +917,7 @@ function findGraphicDesignConfiguration(
 	layout: string
 ): TableConfigItemGfxDesignTemplate | undefined {
 	return config.showStyle.GfxDesignTemplates.find(
-		tmpl => tmpl.INewsStyleColumn && tmpl.INewsStyleColumn.toUpperCase() === layout.toUpperCase()
+		template => template.INewsStyleColumn && template.INewsStyleColumn.toUpperCase() === layout.toUpperCase()
 	)
 }
 

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -336,10 +336,14 @@ function parsekg(
 		  )
 		: undefined
 
-	if (graphicConfig && graphicConfig.IsDesign) {
+	const graphicDesignConfig = code
+		? config.showStyle.GFXDesignTemplates.find(tmpl => tmpl.INewsName.toUpperCase() === graphic.template.toUpperCase())
+		: undefined
+
+	if (!graphicConfig && graphicDesignConfig) {
 		return literal<CueDefinitionGraphicDesign>({
 			type: CueType.GraphicDesign,
-			design: graphicConfig.VizTemplate,
+			design: graphicDesignConfig.VizTemplate,
 			iNewsCommand: kgCue.iNewsCommand,
 			start: kgCue.start,
 			end: kgCue.end,

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -335,19 +335,13 @@ function parsekg(
 
 	kgCue.graphic = graphic
 
-	const graphicConfig = code
-		? config.showStyle.GFXTemplates.find(
-				tmpl =>
-					tmpl.INewsCode.replace(/^KG=?/gi, '#KG').toUpperCase() === code.replace(/^KG=?/gi, '#KG').toUpperCase() &&
-					tmpl.INewsName.toUpperCase() === graphic.template.toUpperCase()
+	const graphicDesignConfig = code
+		? config.showStyle.GfxDesignTemplates.find(
+				template => template.INewsName.toUpperCase() === graphic.template.toUpperCase()
 		  )
 		: undefined
 
-	const graphicDesignConfig = code
-		? config.showStyle.GfxDesignTemplates.find(tmpl => tmpl.INewsName.toUpperCase() === graphic.template.toUpperCase())
-		: undefined
-
-	if (!graphicConfig && graphicDesignConfig) {
+	if (graphicDesignConfig) {
 		return literal<CueDefinitionGraphicDesign>({
 			type: CueType.GraphicDesign,
 			design: graphicDesignConfig.VizTemplate,
@@ -356,7 +350,17 @@ function parsekg(
 			end: kgCue.end,
 			adlib: kgCue.adlib
 		})
-	} else if (graphicConfig && !!graphicConfig.VizTemplate.match(/^VCP$/i)) {
+	}
+
+	const graphicConfig = code
+		? config.showStyle.GFXTemplates.find(
+				template =>
+					template.INewsCode.replace(/^KG=?/gi, '#KG').toUpperCase() === code.replace(/^KG=?/gi, '#KG').toUpperCase() &&
+					template.INewsName.toUpperCase() === graphic.template.toUpperCase()
+		  )
+		: undefined
+
+	if (graphicConfig && !!graphicConfig.VizTemplate.match(/^VCP$/i)) {
 		return literal<CueDefinitionUnpairedTarget>({
 			type: CueType.UNPAIRED_TARGET,
 			target: graphicConfig.VizDestination.match(/OVL/i)

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -1,7 +1,7 @@
 import {
 	GetPieceLifespanForGraphic,
 	literal,
-	TableConfigItemGFXDesignTemplates,
+	TableConfigItemGfxDesignTemplate,
 	TableConfigSchema,
 	TV2BlueprintConfig,
 	UnparsedCue
@@ -344,7 +344,7 @@ function parsekg(
 		: undefined
 
 	const graphicDesignConfig = code
-		? config.showStyle.GFXDesignTemplates.find(tmpl => tmpl.INewsName.toUpperCase() === graphic.template.toUpperCase())
+		? config.showStyle.GfxDesignTemplates.find(tmpl => tmpl.INewsName.toUpperCase() === graphic.template.toUpperCase())
 		: undefined
 
 	if (!graphicConfig && graphicDesignConfig) {
@@ -911,8 +911,8 @@ function parseDesignLayout(cue: string[], config: TV2BlueprintConfig): CueDefini
 function findGraphicDesignConfiguration(
 	config: TV2BlueprintConfig,
 	layout: string
-): TableConfigItemGFXDesignTemplates | undefined {
-	return config.showStyle.GFXDesignTemplates.find(
+): TableConfigItemGfxDesignTemplate | undefined {
+	return config.showStyle.GfxDesignTemplates.find(
 		tmpl => tmpl.INewsStyleColumn && tmpl.INewsStyleColumn.toUpperCase() === layout.toUpperCase()
 	)
 }

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -1,10 +1,10 @@
-import { 
-	GetPieceLifespanForGraphic, 
-	literal, 
-	TableConfigSchema, 
+import {
+	GetPieceLifespanForGraphic,
+	literal,
 	TableConfigItemGFXDesignTemplates,
-	TV2BlueprintConfig, 
-	UnparsedCue 
+	TableConfigSchema,
+	TV2BlueprintConfig,
+	UnparsedCue
 } from 'tv2-common'
 import { CueType, GraphicEngine, PartType, SourceType } from 'tv2-constants'
 import {

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -1,4 +1,11 @@
-import { GetInfiniteModeForGraphic, literal, TableConfigSchema, TV2BlueprintConfig, UnparsedCue } from 'tv2-common'
+import {
+	GetInfiniteModeForGraphic,
+	literal,
+	TableConfigItemGFXDesignTemplates,
+	TableConfigSchema,
+	TV2BlueprintConfig,
+	UnparsedCue
+} from 'tv2-common'
 import { CueType, GraphicEngine, PartType, SourceType } from 'tv2-constants'
 import {
 	getSourceDefinition,
@@ -883,20 +890,31 @@ export function parseTime(line: string): Pick<CueDefinitionBase, 'start' | 'end'
 function parseDesignLayout(cue: string[], config: TV2BlueprintConfig): CueDefinitionGraphicDesign | undefined {
 	const array = cue[0].split('DESIGN_LAYOUT=')
 	const layout = array[1]
-	const tableConfigSchema = findSchemaConfiguration(config, layout)
-	if (!tableConfigSchema) {
+
+	const designConfig = findGraphicDesignConfiguration(config, layout)
+
+	if (!designConfig) {
 		return undefined
 	}
 
 	return literal<CueDefinitionGraphicDesign>({
 		type: CueType.GraphicDesign,
-		design: tableConfigSchema.vizTemplateName,
+		design: designConfig.VizTemplate,
 		iNewsCommand: layout,
 		start: {
 			frames: 1
 		},
 		isFromLayout: true
 	})
+}
+
+function findGraphicDesignConfiguration(
+	config: TV2BlueprintConfig,
+	layout: string
+): TableConfigItemGFXDesignTemplates | undefined {
+	return config.showStyle.GFXDesignTemplates.find(
+		tmpl => tmpl.INewsStyleColumn && tmpl.INewsStyleColumn.toUpperCase() === layout.toUpperCase()
+	)
 }
 
 function findSchemaConfiguration(config: TV2BlueprintConfig, designIdentifier: string): TableConfigSchema | undefined {

--- a/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
@@ -644,8 +644,7 @@ describe('Cue parser', () => {
 		)
 	})
 
-	test('KG=DESIGN_FODBOLD', () => {
-		// Now tests to find made up "DESIGN_FODBOLD_22" to avoid finding non-transferred value in GFX Template
+	test('Find KG=DESIGN_FODBOLD in design templates', () => {
 		const cueGrafik = ['KG=DESIGN_FODBOLD_22', ';0.00.01']
 		const result = ParseCue(cueGrafik, config)
 		expect(result).toEqual(

--- a/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
@@ -665,12 +665,13 @@ describe('Cue parser', () => {
 	})
 
 	test('KG=DESIGN_FODBOLD', () => {
-		const cueGrafik = ['KG=DESIGN_FODBOLD_20', ';0.00.01']
+		// Now tests to find made up "DESIGN_FODBOLD_22" to avoid finding non-transferred value in GFX Template
+		const cueGrafik = ['KG=DESIGN_FODBOLD_22', ';0.00.01']
 		const result = ParseCue(cueGrafik, config)
 		expect(result).toEqual(
 			literal<CueDefinitionGraphicDesign>({
 				type: CueType.GraphicDesign,
-				design: 'DESIGN_FODBOLD_20',
+				design: 'DESIGN_FODBOLD_22',
 				start: {
 					frames: 1,
 					seconds: 0

--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -152,15 +152,19 @@ export function mapGFXTemplateToDesignTemplateAndDeleteOriginals(
 				return false
 			}
 
-			return gfxTemplates.some(g => g.IsDesign)
+			return gfxTemplates.some(template => template.IsDesign)
 		},
 		migrate: (context: MigrationContextShowStyle) => {
 			const gfxTemplates = (context.getBaseConfig(from) as unknown) as TableConfigItemGFXTemplates[]
 			const designTemplates = ((context.getBaseConfig(to) as unknown) as TableConfigItemGfxDesignTemplate[]) ?? []
 
-			gfxTemplates.filter(g => g.IsDesign).map(g => designTemplates.push(g))
+			gfxTemplates
+				.filter(template => template.IsDesign)
+				.map(template => {
+					designTemplates.push({ ...template, INewsStyleColumn: '' })
+				})
 
-			const newGFXTemplates = gfxTemplates.filter(g => !g.IsDesign)
+			const newGFXTemplates = gfxTemplates.filter(template => !template.IsDesign)
 
 			context.setBaseConfig(from, (newGFXTemplates as unknown) as ConfigItemValue)
 			context.setBaseConfig(to, (designTemplates as unknown) as ConfigItemValue)

--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -143,7 +143,7 @@ export function mapGFXTemplateToDesignTemplate(versionStr: string, studio: strin
 				return false
 			}
 
-			if (!designTemplates || !designTemplates.length) {
+			if (designTemplates && designTemplates.length) {
 				return false
 			}
 

--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -7,7 +7,11 @@ import {
 	MigrationStepStudio,
 	TableConfigItemValue
 } from '@tv2media/blueprints-integration'
-import { TableConfigItemGFXTemplates, TableConfigItemSourceMappingWithSisyfos, TableConfigItemGFXDesignTemplates} from 'tv2-common'
+import {
+	TableConfigItemGFXDesignTemplates,
+	TableConfigItemGFXTemplates,
+	TableConfigItemSourceMappingWithSisyfos
+} from 'tv2-common'
 import _ = require('underscore')
 import { literal } from '../util'
 
@@ -127,13 +131,9 @@ export function mapGFXTemplateToDesignTemplate(versionStr: string, studio: strin
 		version: versionStr,
 		canBeRunAutomatically: true,
 		validate: (context: MigrationContextShowStyle) => {
-			const gfxTemplates = (context.getBaseConfig(from) as unknown) as
-				| TableConfigItemGFXTemplates[]
-				| undefined
+			const gfxTemplates = (context.getBaseConfig(from) as unknown) as TableConfigItemGFXTemplates[] | undefined
 
-			const designTemplates = (context.getBaseConfig(to) as unknown) as
-				| TableConfigItemGFXDesignTemplates[]
-				| undefined
+			const designTemplates = (context.getBaseConfig(to) as unknown) as TableConfigItemGFXDesignTemplates[] | undefined
 
 			if (!gfxTemplates || !gfxTemplates.length) {
 				return false
@@ -162,19 +162,17 @@ export function removeDesignChangesFromGFXTemplate(versionStr: string, studio: s
 		version: versionStr,
 		canBeRunAutomatically: true,
 		validate: (context: MigrationContextShowStyle) => {
-			const gfxTemplates = (context.getBaseConfig(configId) as unknown) as
-				| TableConfigItemGFXTemplates[]
-				| undefined
+			const gfxTemplates = (context.getBaseConfig(configId) as unknown) as TableConfigItemGFXTemplates[] | undefined
 
 			if (!gfxTemplates || !gfxTemplates.length) {
 				return false
 			}
-			
+
 			return gfxTemplates.some(g => g.IsDesign)
 		},
 		migrate: (context: MigrationContextShowStyle) => {
 			const gfxTemplates = (context.getBaseConfig(configId) as unknown) as TableConfigItemGFXTemplates[]
-			
+
 			const newGFXTemplate = gfxTemplates.filter(g => !g.IsDesign)
 
 			context.setBaseConfig(configId, (newGFXTemplate as unknown) as ConfigItemValue)

--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -127,7 +127,6 @@ export function mapGFXTemplateToDesignTemplate(versionStr: string, studio: strin
 		version: versionStr,
 		canBeRunAutomatically: true,
 		validate: (context: MigrationContextShowStyle) => {
-			
 			const gfxTemplates = (context.getBaseConfig(from) as unknown) as
 				| TableConfigItemGFXTemplates[]
 				| undefined
@@ -163,7 +162,6 @@ export function removeDesignChangesFromGFXTemplate(versionStr: string, studio: s
 		version: versionStr,
 		canBeRunAutomatically: true,
 		validate: (context: MigrationContextShowStyle) => {
-			
 			const gfxTemplates = (context.getBaseConfig(configId) as unknown) as
 				| TableConfigItemGFXTemplates[]
 				| undefined

--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -164,9 +164,9 @@ export function mapGFXTemplateToDesignTemplateAndDeleteOriginals(
 					designTemplates.push({ ...template, INewsStyleColumn: '' })
 				})
 
-			const newGFXTemplates = gfxTemplates.filter(template => !template.IsDesign)
+			const newGfxTemplates = gfxTemplates.filter(template => !template.IsDesign)
 
-			context.setBaseConfig(from, (newGFXTemplates as unknown) as ConfigItemValue)
+			context.setBaseConfig(from, (newGfxTemplates as unknown) as ConfigItemValue)
 			context.setBaseConfig(to, (designTemplates as unknown) as ConfigItemValue)
 		}
 	})

--- a/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
@@ -729,7 +729,6 @@ describe('AFVD Blueprint', () => {
 	})
 
 	it('Changes design and background loops', async () => {
-		// Changed to use the made up "DESIGN_FODBOLD_22" so as to avoid finding a non-transferred design in GFXTemplate
 		const ingestSegment = makeIngestSegment(
 			[
 				['KG=DESIGN_FODBOLD_22', ';0.00.01'],

--- a/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
@@ -730,9 +730,10 @@ describe('AFVD Blueprint', () => {
 	})
 
 	it('Changes design and background loops', async () => {
+		// Changed to use the made up "DESIGN_FODBOLD_22" so as to avoid finding a non-transferred design in GFXTemplate
 		const ingestSegment = makeIngestSegment(
 			[
-				['KG=DESIGN_FODBOLD_20', ';0.00.01'],
+				['KG=DESIGN_FODBOLD_22', ';0.00.01'],
 				['VIZ=dve-triopage', 'GRAFIK=BG_LOADER_FODBOLD_20', ';0.00'],
 				['VIZ=full-triopage', 'GRAFIK=BG_LOADER_FODBOLD_20', ';0.00.01']
 			],

--- a/src/tv2_afvd_showstyle/__tests__/config-manifest.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/config-manifest.spec.ts
@@ -6,7 +6,7 @@ const blankShowStyleConfig: ShowStyleConfig = {
 	MakeAdlibsForFulls: true,
 	DVEStyles: [],
 	GFXTemplates: [],
-	GFXDesignTemplates: [],
+	GfxDesignTemplates: [],
 	WipesConfig: [],
 	BreakerConfig: [],
 	DefaultTemplateDuration: 4,

--- a/src/tv2_afvd_showstyle/__tests__/config-manifest.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/config-manifest.spec.ts
@@ -6,6 +6,7 @@ const blankShowStyleConfig: ShowStyleConfig = {
 	MakeAdlibsForFulls: true,
 	DVEStyles: [],
 	GFXTemplates: [],
+	GfxDesignTemplates: [],
 	WipesConfig: [],
 	BreakerConfig: [],
 	DefaultTemplateDuration: 4,

--- a/src/tv2_afvd_showstyle/__tests__/config-manifest.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/config-manifest.spec.ts
@@ -6,7 +6,7 @@ const blankShowStyleConfig: ShowStyleConfig = {
 	MakeAdlibsForFulls: true,
 	DVEStyles: [],
 	GFXTemplates: [],
-	GfxDesignTemplates: [],
+	GFXDesignTemplates: [],
 	WipesConfig: [],
 	BreakerConfig: [],
 	DefaultTemplateDuration: 4,

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -231,6 +231,7 @@ export const defaultShowStyleConfig: ShowStyleConfig = {
 			}
 		])
 	],
+	GFXDesignTemplates: [],
 	LYDConfig: [
 		{
 			_id: '',

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -231,7 +231,7 @@ export const defaultShowStyleConfig: ShowStyleConfig = {
 			}
 		])
 	],
-	GFXDesignTemplates: [
+	GfxDesignTemplates: [
 		{
 			INewsName: 'DESIGN_FODBOLD_22',
 			INewsStyleColumn: '',

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -231,7 +231,13 @@ export const defaultShowStyleConfig: ShowStyleConfig = {
 			}
 		])
 	],
-	GFXDesignTemplates: [],
+	GFXDesignTemplates: [
+		{
+			INewsName: 'DESIGN_FODBOLD_22',
+			INewsStyleColumn: '',
+			VizTemplate: 'DESIGN_FODBOLD_22'
+		}
+	],
 	LYDConfig: [
 		{
 			_id: '',

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -262,6 +262,47 @@ export const schemaConfigManifest: ConfigManifestEntry[] = [
 	}
 ]
 
+export const gfxDesignTemplates: ConfigManifestEntry[] = [
+	{
+		id: 'GFXDesignTemplates',
+		name: 'GFX Design Templates',
+		description: '"',
+		type: ConfigManifestEntryType.TABLE,
+		required: true,
+		defaultVal: [],
+		columns: [
+			{
+				id: 'INewsName',
+				name: 'iNews Name (*)',
+				description: 'The name after the code',
+				type: ConfigManifestEntryType.STRING,
+				required: false,
+				defaultVal: '',
+				rank: 0
+			},
+			{
+				id: 'INewsStyleColumn',
+				name: 'iNews Style Column',
+				description: '',
+				type: ConfigManifestEntryType.STRING,
+				required: false,
+				defaultVal: '',
+				rank: 1
+
+			},
+			{
+				id: 'VizTemplate',
+				name: 'Viz Template Name (**)',
+				description: 'The name of the Viz Template',
+				type: ConfigManifestEntryType.STRING,
+				required: true,
+				defaultVal: '',
+				rank: 2
+			}
+		]
+	}
+]
+
 export const showStyleConfigManifest: ConfigManifestEntry[] = [
 	{
 		id: 'MakeAdlibsForFulls',
@@ -383,6 +424,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 			}
 		]
 	},
+	...gfxDesignTemplates,
 	...graphicsSetups,
 	...schemaConfigManifest,
 	{

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -264,7 +264,7 @@ export const schemaConfigManifest: ConfigManifestEntry[] = [
 
 export const gfxDesignTemplates: ConfigManifestEntry[] = [
 	{
-		id: 'GFXDesignTemplates',
+		id: 'GfxDesignTemplates',
 		name: 'GFX Design Templates',
 		description: '',
 		type: ConfigManifestEntryType.TABLE,

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -266,7 +266,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 	{
 		id: 'GFXDesignTemplates',
 		name: 'GFX Design Templates',
-		description: '"',
+		description: '',
 		type: ConfigManifestEntryType.TABLE,
 		required: true,
 		defaultVal: [],
@@ -287,8 +287,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 				type: ConfigManifestEntryType.STRING,
 				required: false,
 				defaultVal: '',
-				rank: 1
-
+				rank: 1			
 			},
 			{
 				id: 'VizTemplate',

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -287,7 +287,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 				type: ConfigManifestEntryType.STRING,
 				required: false,
 				defaultVal: '',
-				rank: 1			
+				rank: 1
 			},
 			{
 				id: 'VizTemplate',

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -273,8 +273,8 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 		columns: [
 			{
 				id: 'INewsName',
-				name: 'iNews Name (*)',
-				description: 'The name after the code',
+				name: 'iNews Name',
+				description: 'The name of the design',
 				type: ConfigManifestEntryType.STRING,
 				required: false,
 				defaultVal: '',
@@ -283,7 +283,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 			{
 				id: 'INewsStyleColumn',
 				name: 'iNews Style Column',
-				description: '',
+				description: 'The selected style',
 				type: ConfigManifestEntryType.STRING,
 				required: false,
 				defaultVal: '',
@@ -291,7 +291,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 			},
 			{
 				id: 'VizTemplate',
-				name: 'Viz Template Name (**)',
+				name: 'Viz Template Name',
 				description: 'The name of the Viz Template',
 				type: ConfigManifestEntryType.STRING,
 				required: true,

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -235,7 +235,11 @@ export const showStyleMigrations: MigrationStepShowStyle[] = [
 	 */
 	removeSourceLayer('1.7.5', 'AFVD', 'studio0_graphicsIdent_persistent'),
 
-	mapGFXTemplateToDesignTemplateAndDeleteOriginals('1.7.5', 'AFVD', 'GFXTemplates', 'GfxDesignTemplates'),
+	/**
+	 * 1.7.6
+	 * - Map designs from GFXTemplates to GfxDesignTemplates and delete them from GFXTemplates
+	 */
+	mapGFXTemplateToDesignTemplateAndDeleteOriginals('1.7.6', 'AFVD', 'GFXTemplates', 'GfxDesignTemplates'),
 
 	// Fill in any layers that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -4,8 +4,8 @@ import {
 	changeGFXTemplate,
 	GetDefaultAdLibTriggers,
 	GetDSKSourceLayerNames,
-	mapGFXTemplateToDesignTemplate,
-	removeDesignChangesFromGFXTemplate,
+	mapGFXTemplateToDesignTemplateAndDeleteOriginals,
+	// removeDesignChangesFromGFXTemplate,
 	RemoveOldShortcuts,
 	removeSourceLayer,
 	SetShowstyleTransitionMigrationStep,
@@ -235,9 +235,7 @@ export const showStyleMigrations: MigrationStepShowStyle[] = [
 	 */
 	removeSourceLayer('1.7.5', 'AFVD', 'studio0_graphicsIdent_persistent'),
 
-	mapGFXTemplateToDesignTemplate('1.7.5', 'AFVD', 'GFXTemplates', 'GFXDesignTemplates'),
-
-	removeDesignChangesFromGFXTemplate('1.7.5', 'AFVD', 'GFXTemplates'),
+	mapGFXTemplateToDesignTemplateAndDeleteOriginals('1.7.5', 'AFVD', 'GFXTemplates', 'GfxDesignTemplates'),
 
 	// Fill in any layers that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -5,6 +5,8 @@ import {
 	GetDefaultAdLibTriggers,
 	GetDSKSourceLayerNames,
 	literal,
+	mapGFXTemplateToDesignTemplate,
+	removeDesignChangesFromGFXTemplate,
 	RemoveOldShortcuts,
 	removeSourceLayer,
 	SetShowstyleTransitionMigrationStep,
@@ -228,6 +230,20 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 		},
 		{ LayerMapping: 'graphic_overlay_lower' }
 	),
+
+	mapGFXTemplateToDesignTemplate(
+		'1.7.5',
+		'AFVD', 
+		'GFXTemplates',
+		'GFXDesignTemplates'
+	),
+
+	removeDesignChangesFromGFXTemplate(
+		'1.7.5',
+		'AFVD',
+		'GFXTemplates'
+	),
+
 	// Fill in any layers that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations
 	...getSourceLayerDefaultsMigrationSteps(VERSION),

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -231,18 +231,9 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 		{ LayerMapping: 'graphic_overlay_lower' }
 	),
 
-	mapGFXTemplateToDesignTemplate(
-		'1.7.5',
-		'AFVD', 
-		'GFXTemplates',
-		'GFXDesignTemplates'
-	),
+	mapGFXTemplateToDesignTemplate('1.7.5', 'AFVD', 'GFXTemplates', 'GFXDesignTemplates'),
 
-	removeDesignChangesFromGFXTemplate(
-		'1.7.5',
-		'AFVD',
-		'GFXTemplates'
-	),
+	removeDesignChangesFromGFXTemplate('1.7.5', 'AFVD', 'GFXTemplates'),
 
 	// Fill in any layers that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -5,7 +5,6 @@ import {
 	GetDefaultAdLibTriggers,
 	GetDSKSourceLayerNames,
 	mapGFXTemplateToDesignTemplateAndDeleteOriginals,
-	// removeDesignChangesFromGFXTemplate,
 	RemoveOldShortcuts,
 	removeSourceLayer,
 	SetShowstyleTransitionMigrationStep,

--- a/src/tv2_offtube_showstyle/__tests__/config-manifest.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/config-manifest.spec.ts
@@ -5,7 +5,7 @@ import { OfftubeShowStyleConfig } from '../helpers/config'
 const blankShowStyleConfig: OfftubeShowStyleConfig = {
 	DVEStyles: [],
 	GFXTemplates: [],
-	GFXDesignTemplates: [],
+	GfxDesignTemplates: [],
 	WipesConfig: [],
 	BreakerConfig: [],
 	DefaultTemplateDuration: 4,

--- a/src/tv2_offtube_showstyle/__tests__/config-manifest.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/config-manifest.spec.ts
@@ -5,6 +5,7 @@ import { OfftubeShowStyleConfig } from '../helpers/config'
 const blankShowStyleConfig: OfftubeShowStyleConfig = {
 	DVEStyles: [],
 	GFXTemplates: [],
+	GFXDesignTemplates: [],
 	WipesConfig: [],
 	BreakerConfig: [],
 	DefaultTemplateDuration: 4,

--- a/src/tv2_offtube_showstyle/config-manifests.ts
+++ b/src/tv2_offtube_showstyle/config-manifests.ts
@@ -168,15 +168,6 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 				required: false,
 				defaultVal: '',
 				rank: 1
-			},
-			{
-				id: 'VizTemplate',
-				name: 'Viz Template Name',
-				description: 'The name of the Viz Template',
-				type: ConfigManifestEntryType.STRING,
-				required: true,
-				defaultVal: '',
-				rank: 2
 			}
 		]
 	}

--- a/src/tv2_offtube_showstyle/config-manifests.ts
+++ b/src/tv2_offtube_showstyle/config-manifests.ts
@@ -142,6 +142,46 @@ export const dveStylesManifest: ConfigManifestEntry = {
 	]
 }
 
+export const gfxDesignTemplates: ConfigManifestEntry[] = [
+	{
+		id: 'GFXDesignTemplates',
+		name: 'GFX Design Templates',
+		description: '',
+		type: ConfigManifestEntryType.TABLE,
+		required: true,
+		defaultVal: [],
+		columns: [
+			{
+				id: 'INewsName',
+				name: 'iNews Name (*)',
+				description: 'The name after the code',
+				type: ConfigManifestEntryType.STRING,
+				required: false,
+				defaultVal: '',
+				rank: 0
+			},
+			{
+				id: 'INewsStyleColumn',
+				name: 'iNews Style Column',
+				description: '',
+				type: ConfigManifestEntryType.STRING,
+				required: false,
+				defaultVal: '',
+				rank: 1
+			},
+			{
+				id: 'VizTemplate',
+				name: 'Viz Template Name (**)',
+				description: 'The name of the Viz Template',
+				type: ConfigManifestEntryType.STRING,
+				required: true,
+				defaultVal: '',
+				rank: 2
+			}
+		]
+	}
+]
+
 export const showStyleConfigManifest: ConfigManifestEntry[] = [
 	{
 		id: 'MakeAdlibsForFulls',
@@ -261,6 +301,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 			}
 		]
 	},
+	...gfxDesignTemplates,
 	{
 		/*
 		Wipes Config

--- a/src/tv2_offtube_showstyle/config-manifests.ts
+++ b/src/tv2_offtube_showstyle/config-manifests.ts
@@ -144,7 +144,7 @@ export const dveStylesManifest: ConfigManifestEntry = {
 
 export const gfxDesignTemplates: ConfigManifestEntry[] = [
 	{
-		id: 'GFXDesignTemplates',
+		id: 'GfxDesignTemplates',
 		name: 'GFX Design Templates',
 		description: '',
 		type: ConfigManifestEntryType.TABLE,

--- a/src/tv2_offtube_showstyle/config-manifests.ts
+++ b/src/tv2_offtube_showstyle/config-manifests.ts
@@ -153,8 +153,8 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 		columns: [
 			{
 				id: 'INewsName',
-				name: 'iNews Name (*)',
-				description: 'The name after the code',
+				name: 'iNews Name',
+				description: 'The name of the design',
 				type: ConfigManifestEntryType.STRING,
 				required: false,
 				defaultVal: '',
@@ -163,7 +163,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 			{
 				id: 'INewsStyleColumn',
 				name: 'iNews Style Column',
-				description: '',
+				description: 'The selected style',
 				type: ConfigManifestEntryType.STRING,
 				required: false,
 				defaultVal: '',
@@ -171,7 +171,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 			},
 			{
 				id: 'VizTemplate',
-				name: 'Viz Template Name (**)',
+				name: 'Viz Template Name',
 				description: 'The name of the Viz Template',
 				type: ConfigManifestEntryType.STRING,
 				required: true,


### PR DESCRIPTION
This PR adds the GFX Design table, and migrates the entries from GFX templates into it. ParseCue has been altered to ensure that it fits the purpose, and unlike it was originally described, the Style will have priority over Name. 