### PR TITLE
SOF-1121 Set max duration on transition effects

### DIFF
--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -178,6 +178,8 @@ const ACCEPTED_RED_TEXT = [/\b(SERVER|ATTACK|TEKNIK|GRAFIK|EPSIO|VOV?|VOSB)+\b/i
 const REMOTE_CUE = /^(LIVE|FEED) ?([^\s]+)(?: (.+))?$/i
 const ENGINE_CUE = /ENGINE ?([^\s]+)/i
 
+const MAX_ALLOWED_TRANSITION_FRAMES = 250
+
 export function ParseBody(
 	config: TV2BlueprintConfig,
 	segmentId: string,
@@ -566,11 +568,16 @@ export function getTransitionProperties(typeStr: string): Pick<PartdefinitionTyp
 	if (transitionMatch) {
 		definition.transition = {
 			style: AtemTransitionStyleFromString(transitionMatch[1].toUpperCase()),
-			duration: transitionMatch[2] ? Number(transitionMatch[2]) : undefined
+			duration: transitionMatch[2] ? getTimeForTransition(transitionMatch[2]) : undefined
 		}
 	}
 
 	return definition
+}
+
+function getTimeForTransition(timeString: string): number {
+	const time = Number(timeString)
+	return time > MAX_ALLOWED_TRANSITION_FRAMES ? MAX_ALLOWED_TRANSITION_FRAMES : time
 }
 
 function extractTypeProperties(typeStr: string): PartdefinitionTypes {

--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -577,7 +577,7 @@ export function getTransitionProperties(typeStr: string): Pick<PartdefinitionTyp
 
 function getTimeForTransition(timeString: string): number {
 	const time = Number(timeString)
-	return time > MAX_ALLOWED_TRANSITION_FRAMES ? MAX_ALLOWED_TRANSITION_FRAMES : time
+	return Math.min(time, MAX_ALLOWED_TRANSITION_FRAMES)
 }
 
 function extractTypeProperties(typeStr: string): PartdefinitionTypes {

--- a/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
@@ -2,6 +2,8 @@ import { IBlueprintRundownDB, PlaylistTimingType, TSR } from '@tv2media/blueprin
 import {
 	CueDefinitionBackgroundLoop,
 	CueDefinitionGraphicDesign,
+	getTransitionProperties,
+	PartdefinitionTypes,
 	stripRedundantCuesWhenLayoutCueIsPresent,
 	UnparsedCue
 } from 'tv2-common'
@@ -3491,6 +3493,32 @@ describe('Body parser', () => {
 			const result: PartDefinition[] = stripRedundantCuesWhenLayoutCueIsPresent(definitions)
 
 			expect(result).toEqual(definitions)
+		})
+	})
+
+	describe('getTransitionProperties', () => {
+		it('has a Dip transition lasting 4 frames, transition.duration is 4', () => {
+			const iNewsCue = 'SOME PART DIP 4'
+
+			const result: Pick<PartdefinitionTypes, 'effekt' | 'transition'> = getTransitionProperties(iNewsCue)
+
+			expect(result.transition!.duration).toBe(4)
+		})
+
+		it('has a Dip transition lasting 10 frames, transition.duration is 10', () => {
+			const iNewsCue = 'SOME PART DIP 10'
+
+			const result: Pick<PartdefinitionTypes, 'effekt' | 'transition'> = getTransitionProperties(iNewsCue)
+
+			expect(result.transition!.duration).toBe(10)
+		})
+
+		it('has a Dip transition lasting more than the max allowed 250 frames, transition.duration is 250', () => {
+			const iNewsCue = 'SOME PART DIP 231342143'
+
+			const result: Pick<PartdefinitionTypes, 'effekt' | 'transition'> = getTransitionProperties(iNewsCue)
+
+			expect(result.transition!.duration).toBe(250)
 		})
 	})
 })


### PR DESCRIPTION
Now limit the duration of a transition to 250 frames if we receive a longer transition than the Atem allows