### PR TITLE
SOF-1171 Not creating 'cam cs 3' when there is whitespace

### DIFF
--- a/src/tv2_afvd_showstyle/parts/kam.ts
+++ b/src/tv2_afvd_showstyle/parts/kam.ts
@@ -51,7 +51,7 @@ export async function CreatePartKam(
 
 	const jingleDSK = FindDSKJingle(config)
 
-	if (partDefinition.rawType.match(/kam cs ?3/i)) {
+	if (/cs/i.test(partDefinition.sourceDefinition.id)) {
 		pieces.push({
 			externalId: partDefinition.externalId,
 			name: 'CS 3 (JINGLE)',

--- a/src/tv2_afvd_showstyle/parts/kam.ts
+++ b/src/tv2_afvd_showstyle/parts/kam.ts
@@ -51,7 +51,7 @@ export async function CreatePartKam(
 
 	const jingleDSK = FindDSKJingle(config)
 
-	if (/cs/i.test(partDefinition.sourceDefinition.id)) {
+	if (/\bcs *\d*/i.test(partDefinition.sourceDefinition.id)) {
 		pieces.push({
 			externalId: partDefinition.externalId,
 			name: 'CS 3 (JINGLE)',

--- a/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
@@ -51,7 +51,7 @@ export async function OfftubeCreatePartKam(
 
 	const jingleDSK = FindDSKJingle(config)
 
-	if (/cs/i.test(partDefinition.sourceDefinition.id)) {
+	if (/\bcs *\d*/i.test(partDefinition.sourceDefinition.id)) {
 		pieces.push({
 			externalId: partDefinition.externalId,
 			name: 'CS 3 (JINGLE)',

--- a/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
@@ -51,7 +51,7 @@ export async function OfftubeCreatePartKam(
 
 	const jingleDSK = FindDSKJingle(config)
 
-	if (/cs ?3/i.test(partDefinition.sourceDefinition.id)) {
+	if (/cs/i.test(partDefinition.sourceDefinition.id)) {
 		pieces.push({
 			externalId: partDefinition.externalId,
 			name: 'CS 3 (JINGLE)',


### PR DESCRIPTION
Only look for 'cs' when creating the cam cs 3 part. 
Galleries now uses sourceDefintion for determining to create a cam cs 3 part instead of rawType