### PR TITLE
fix: SOF-1192 readd the Template Name column and update descriptions

### DIFF
--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -16,6 +16,7 @@ export interface TableConfigItemBreakers {
 }
 
 export interface TableConfigItemGfxTemplate {
+	/** Name of the Viz Template. For HTML graphics it's the Graphic name. */
 	VizTemplate: string
 	SourceLayer: string
 	LayerMapping: string
@@ -28,6 +29,7 @@ export interface TableConfigItemGfxTemplate {
 export interface TableConfigItemGfxDesignTemplate {
 	INewsName: string
 	INewsStyleColumn: string
+	/** Name of the Viz template trigering design change. For HTML graphics it coresponds to a CSS class. */
 	VizTemplate: string
 }
 

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -201,7 +201,7 @@ export const schemaConfigManifest: ConfigManifestEntry[] = [
 			},
 			{
 				id: 'vizTemplateName',
-				name: 'Viz Template Name',
+				name: 'GFX Template Name',
 				description: 'The name of the Viz template',
 				rank: 2,
 				required: true,
@@ -253,7 +253,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 			},
 			{
 				id: 'VizTemplate',
-				name: 'Viz Template Name',
+				name: 'GFX Template Name',
 				description: 'The name of the Viz Template',
 				type: ConfigManifestEntryType.STRING,
 				required: true,
@@ -345,7 +345,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 		id: 'GFXTemplates',
 		name: 'GFX Templates',
 		description:
-			'This table can contain info in two ways. Things marked (**) are always required. If you want to do the mapping from iNews-code, then all (*)-elements are aslo required. VizTemplate is what the graphic is called in viz. Source layer is the ID of the Sofie Source layer in the UI (i.e. "studio0_graphicsTema"). Layer mapping is the Sofie studio layer mapping (i.e "viz_layer_tema").  iNews command can be something like "KG=", then iNews Name is the thing that follows in iNes i.e. "ident_nyhederne"',
+			'This table can contain info in two ways. Things marked (**) are always required. If you want to do the mapping from iNews-code, then all (*)-elements are also required. GFX Template Name is what the graphic is called in viz. Source layer is the ID of the Sofie Source layer in the UI (i.e. "studio0_graphicsTema"). Layer mapping is the Sofie studio layer mapping (i.e "viz_layer_tema").  iNews command can be something like "KG=", then iNews Name is the thing that follows in iNews i.e. "ident_nyhederne"',
 		type: ConfigManifestEntryType.TABLE,
 		required: true,
 		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })),
@@ -370,7 +370,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 			},
 			{
 				id: 'VizTemplate',
-				name: 'Viz Template Name (**)',
+				name: 'GFX Template Name (**)',
 				description: 'The name of the Viz Template',
 				type: ConfigManifestEntryType.STRING,
 				required: true,

--- a/src/tv2_offtube_showstyle/config-manifests.ts
+++ b/src/tv2_offtube_showstyle/config-manifests.ts
@@ -168,6 +168,15 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 				required: false,
 				defaultVal: '',
 				rank: 1
+			},
+			{
+				id: 'VizTemplate',
+				name: 'GFX Template Name',
+				description: 'The name of the design in the HTML package',
+				type: ConfigManifestEntryType.STRING,
+				required: true,
+				defaultVal: '',
+				rank: 2
 			}
 		]
 	}
@@ -207,7 +216,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 		id: 'GFXTemplates',
 		name: 'GFX Templates',
 		description:
-			'This table can contain info in two ways. Things marked (**) are always required. If you want to do the mapping from iNews-code, then all (*)-elements are aslo required. VizTemplate is what the graphic is called in viz. Source layer is the ID of the Sofie Source layer in the UI (i.e. "studio0_graphicsTema"). Layer mapping is the Sofie studio layer mapping (i.e "viz_layer_tema").  iNews command can be something like "KG=", then iNews Name is the thing that follows in iNes i.e. "ident_nyhederne"',
+			'This table can contain info in two ways. Things marked (**) are always required. If you want to do the mapping from iNews-code, then all (*)-elements are also required. GFX Template Name is what the graphic is called in the HTML package. Source layer is the ID of the Sofie Source layer in the UI (i.e. "studio0_graphicsTema"). Layer mapping is the Sofie studio layer mapping (i.e "viz_layer_tema").  iNews command can be something like "KG=", then iNews Name is the thing that follows in iNews i.e. "ident_nyhederne"',
 		type: ConfigManifestEntryType.TABLE,
 		required: false,
 		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })),
@@ -232,8 +241,8 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 			},
 			{
 				id: 'VizTemplate',
-				name: 'Viz Template Name (**)',
-				description: 'The name of the Viz Template',
+				name: 'GFX Template Name (**)',
+				description: 'The name of the Graphic in the HTML package',
 				type: ConfigManifestEntryType.STRING,
 				required: true,
 				defaultVal: '',


### PR DESCRIPTION
(Does not rename the underlying `VizTemplate` property to avoid messing things up at the last minute with migrations, but adds comments)