### PR TITLE
Sof 1141/last dve doesnt bring back ident

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = env => {
 	// versionIntegration = versionIntegration.replace(/[^\d.]/g, '') || '0.0.0'
 
 	versionTSRTypes = '1.3.0'
-	versionIntegration = '42.0.0'
+	versionIntegration = '46.0.0'
 
 	const entrypoints = env.bundle ? GetEntrypointsForBundle(env.bundle) : BlueprintEntrypoints
 

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -61,6 +61,7 @@ import {
 import {
 	AdlibActionType,
 	CueType,
+	PartType,
 	SharedGraphicLLayer,
 	SharedOutputLayers,
 	SharedSourceLayers,
@@ -1860,7 +1861,8 @@ async function executeActionRecallLastLive<
 		originalOnly: true,
 		excludeCurrentPart: false,
 		pieceMetaDataFilter: {
-			belongsToRemotePart: true
+			partType: PartType.REMOTE,
+			pieceExternalId: lastLive.piece.externalId
 		}
 	})
 

--- a/src/tv2-common/helpers/graphics/InternalGraphic.ts
+++ b/src/tv2-common/helpers/graphics/InternalGraphic.ts
@@ -1,7 +1,7 @@
 import { IBlueprintAdLibPiece, IBlueprintPiece, IShowStyleUserContext, PieceLifespan } from 'blueprints-integration'
 import { Adlib } from 'tv2-common'
 import _ = require('underscore')
-import { AdlibTags, GraphicEngine, PartType, SharedOutputLayers, SharedSourceLayers } from '../../../tv2-constants'
+import { AdlibTags, GraphicEngine, SharedOutputLayers, SharedSourceLayers } from '../../../tv2-constants'
 import { TV2BlueprintConfig } from '../../blueprintConfig'
 import { CueDefinitionGraphic, GraphicInternal, PartDefinition } from '../../inewsConversion'
 import { GraphicPieceMetaData, PieceMetaData } from '../../onTimelineGenerate'
@@ -115,7 +115,8 @@ export class InternalGraphic {
 				sisyfosPersistMetaData: {
 					sisyfosLayers: []
 				},
-				belongsToRemotePart: this.partDefinition?.type === PartType.REMOTE
+				partType: this.partDefinition?.type,
+				pieceExternalId: this.partDefinition?.externalId
 			},
 			content: _.clone(this.content)
 		}

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -13,7 +13,7 @@ import {
 	TSR
 } from 'blueprints-integration'
 import { ActionSelectFullGrafik, ActionSelectJingle, ActionSelectServerClip, CasparPlayerClip } from 'tv2-common'
-import { AbstractLLayer, TallyTags } from 'tv2-constants'
+import { AbstractLLayer, PartType, TallyTags } from 'tv2-constants'
 import * as _ from 'underscore'
 import { SisyfosLLAyer } from '../tv2_afvd_studio/layers'
 import { TV2BlueprintConfigBase, TV2StudioConfigBase } from './blueprintConfig'
@@ -59,7 +59,8 @@ export interface PieceMetaData {
 }
 
 export interface GraphicPieceMetaData extends PieceMetaData {
-	belongsToRemotePart?: boolean
+	partType?: PartType
+	pieceExternalId?: string
 }
 
 export interface JinglePieceMetaData extends PieceMetaData {

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -121,7 +121,8 @@ describe('grafik piece', () => {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
-					belongsToRemotePart: false
+					partType: PartType.Kam,
+					pieceExternalId: dummyPart.externalId
 				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -425,7 +426,8 @@ describe('grafik piece', () => {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
-					belongsToRemotePart: false
+					partType: PartType.Kam,
+					pieceExternalId: dummyPart.externalId
 				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -503,7 +505,8 @@ describe('grafik piece', () => {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
-					belongsToRemotePart: false
+					partType: PartType.Kam,
+					pieceExternalId: dummyPart.externalId
 				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -578,7 +581,8 @@ describe('grafik piece', () => {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
-					belongsToRemotePart: false
+					partType: PartType.Kam,
+					pieceExternalId: dummyPart.externalId
 				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsIdent,
@@ -654,7 +658,8 @@ describe('grafik piece', () => {
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
 					},
-					belongsToRemotePart: false
+					partType: PartType.Kam,
+					pieceExternalId: dummyPart.externalId
 				},
 				outputLayerId: SharedOutputLayers.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsIdent,

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -116,10 +116,11 @@ describe('telefon', () => {
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
 				lifespan: PieceLifespan.WithinPart,
 				metaData: {
-					belongsToRemotePart: false,
 					sisyfosPersistMetaData: {
 						sisyfosLayers: []
-					}
+					},
+					partType: PartType.Kam,
+					pieceExternalId: dummyPart.externalId
 				},
 				content: literal<WithTimeline<GraphicsContent>>({
 					fileName: 'bund',


### PR DESCRIPTION
When recalling last DVE, now also recall the Ident of said DVE.
Fixed a bug where Recall las Live would also recall a Ident if there had been any Live with an Ident on air even though that Ident did not belong to the recalled Live