### PR TITLE
fix: SOF-1201 use a different column for the HTML graphics template name

### DIFF
--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -2144,7 +2144,7 @@ async function executeActionClearGraphics<
 									deviceType: TSR.DeviceType.VIZMSE,
 									type: TSR.TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
 									channelsToSendCommands: userData.sendCommands ? ['OVL1', 'FULL1', 'WALL1'] : undefined,
-									showId: config.selectedGraphicsSetup.OvlShowName
+									showId: config.selectedGraphicsSetup.OvlShowName ?? '' // @todo: improve types at the junction of HTML and Viz
 								}
 							})
 						]

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -52,7 +52,8 @@ export interface TableConfigSchema {
 
 export interface TableConfigGraphicsSetup {
 	Name: string
-	OvlShowName: string
+	HtmlPackageFolder: string
+	OvlShowName?: string
 	FullShowName?: string
 }
 

--- a/src/tv2-common/evaluateCues.ts
+++ b/src/tv2-common/evaluateCues.ts
@@ -458,13 +458,14 @@ export async function EvaluateCuesBase(
 							})
 						}
 					} else if (obj.content.type === TSR.TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS) {
+						const o = obj as TSR.TimelineObjVIZMSEClearAllElements
 						piece.expectedPlayoutItems.push({
 							deviceSubType: TSR.DeviceType.VIZMSE,
 							content: {
 								templateName: 'altud',
 								channel: 'OVL1',
 								templateData: [],
-								showId: config.selectedGraphicsSetup.OvlShowName
+								showId: o.content.showId
 							}
 						})
 					}

--- a/src/tv2-common/helpers/graphics/caspar/__tests__/htmlPilotGraphicGenerator.spec.ts
+++ b/src/tv2-common/helpers/graphics/caspar/__tests__/htmlPilotGraphicGenerator.spec.ts
@@ -98,7 +98,7 @@ describe('HtmlPilotGraphicGenerator', () => {
 			expect(timelineObjects[0].content).toMatchObject(
 				literal<Partial<TSR.TimelineObjCCGTemplate['content']>>({
 					templateType: 'html',
-					name: 'ovl-show-id/index',
+					name: 'html-package-folder/index',
 					data: {
 						display: 'program',
 						slots: {
@@ -168,7 +168,7 @@ describe('HtmlPilotGraphicGenerator', () => {
 			expect(timelineObjects[0].content).toMatchObject(
 				literal<Partial<TSR.TimelineObjCCGTemplate['content']>>({
 					templateType: 'html',
-					name: 'ovl-show-id/index',
+					name: 'html-package-folder/index',
 					data: {
 						display: 'program',
 						slots: {

--- a/src/tv2-common/helpers/graphics/caspar/index.ts
+++ b/src/tv2-common/helpers/graphics/caspar/index.ts
@@ -315,5 +315,5 @@ function getFullPilotBaselineTimelineObject(templateName: string): TSR.TimelineO
 }
 
 export function getHtmlTemplateName(config: TV2BlueprintConfig) {
-	return joinAssetToFolder(config.selectedGraphicsSetup.OvlShowName, 'index')
+	return joinAssetToFolder(config.selectedGraphicsSetup.HtmlPackageFolder, 'index')
 }

--- a/src/tv2-common/helpers/graphics/design/index.ts
+++ b/src/tv2-common/helpers/graphics/design/index.ts
@@ -100,7 +100,7 @@ function designTimeline(config: TV2BlueprintConfig, parsedCue: CueDefinitionGrap
 						type: TSR.TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 						templateName: parsedCue.design,
 						templateData: [],
-						showId: config.selectedGraphicsSetup.OvlShowName
+						showId: config.selectedGraphicsSetup.OvlShowName ?? '' // @todo: improve types at the junction of HTML and Viz
 					}
 				})
 			]

--- a/src/tv2-common/helpers/graphics/viz/index.ts
+++ b/src/tv2-common/helpers/graphics/viz/index.ts
@@ -139,6 +139,10 @@ function findShowName(config: TV2BlueprintConfig, context: IShowStyleUserContext
 			return graphicsSetup.FullShowName
 		case 'TLF':
 		case 'OVL':
+			if (graphicsSetup.OvlShowName === undefined) {
+				context.logWarning("You're using Viz graphics with an incompatible ShowStyle")
+				return ''
+			}
 			return graphicsSetup.OvlShowName
 	}
 }

--- a/src/tv2-common/showstyle/config-manifests.ts
+++ b/src/tv2-common/showstyle/config-manifests.ts
@@ -22,13 +22,13 @@ export const getGraphicsSetupsEntries = (columns: ConfigManifestEntryTable['colu
 				rank: 0
 			},
 			{
-				id: 'OvlShowName',
-				name: 'Overlay Show Name',
-				rank: 1,
+				id: 'HtmlPackageFolder',
+				name: 'HTML Package Folder',
+				rank: 4,
 				required: true,
 				defaultVal: '',
-				hint: '',
-				description: 'Name of the show used for OVL channel',
+				description:
+					'Name of the folder containing the HTML graphics template package, relative to the template-path in CasparCG, e.g. sport-overlay',
 				type: ConfigManifestEntryType.STRING
 			},
 			...columns

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -48,7 +48,8 @@ export const DEFAULT_GRAPHICS_SETUP: GalleryTableConfigGraphicsSetup = {
 	Name: 'SomeProfile',
 	VcpConcept: 'SomeConcept',
 	OvlShowName: OVL_SHOW_NAME,
-	FullShowName: FULL_SHOW_NAME
+	FullShowName: FULL_SHOW_NAME,
+	HtmlPackageFolder: 'html-package-folder'
 }
 
 // in here will be some mock configs that can be referenced paired with ro's for the tests

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -151,7 +151,7 @@ const graphicsSetups = getGraphicsSetupsEntries([
 	{
 		id: 'VcpConcept',
 		name: 'VCP Concept',
-		rank: 0.5,
+		rank: 1,
 		required: true,
 		defaultVal: '',
 		hint: '',
@@ -159,9 +159,19 @@ const graphicsSetups = getGraphicsSetupsEntries([
 		type: ConfigManifestEntryType.STRING
 	},
 	{
+		id: 'OvlShowName',
+		name: 'Overlay Show Name',
+		rank: 2,
+		required: true,
+		defaultVal: '',
+		hint: '',
+		description: 'Name of the show used for OVL channel',
+		type: ConfigManifestEntryType.STRING
+	},
+	{
 		id: 'FullShowName',
 		name: 'Fullscreen Show Name',
-		rank: 2,
+		rank: 3,
 		required: true,
 		defaultVal: '',
 		hint: '',

--- a/src/tv2_afvd_showstyle/helpers/config.ts
+++ b/src/tv2_afvd_showstyle/helpers/config.ts
@@ -10,6 +10,7 @@ import { BlueprintConfig as BlueprintConfigBase } from '../../tv2_afvd_studio/he
 export interface GalleryTableConfigGraphicsSetup extends TableConfigGraphicsSetup {
 	VcpConcept: string
 	FullShowName: string
+	OvlShowName: string
 }
 
 export interface BlueprintConfig extends BlueprintConfigBase {
@@ -30,7 +31,8 @@ export function parseConfig(context: ICommonContext, rawConfig: IBlueprintConfig
 		Name: '',
 		VcpConcept: '',
 		OvlShowName: '',
-		FullShowName: ''
+		FullShowName: '',
+		HtmlPackageFolder: ''
 	})
 	return {
 		showStyle: showstyleConfig,

--- a/src/tv2_offtube_showstyle/helpers/config.ts
+++ b/src/tv2_offtube_showstyle/helpers/config.ts
@@ -43,7 +43,7 @@ export function parseConfig(context: ICommonContext, rawConfig: IBlueprintConfig
 	const showstyleConfig = (rawConfig as unknown) as OfftubeShowStyleConfig
 	const selectedGraphicsSetup = findGraphicsSetup(context, showstyleConfig, {
 		Name: '',
-		OvlShowName: ''
+		HtmlPackageFolder: ''
 	})
 	return {
 		showStyle: showstyleConfig,


### PR DESCRIPTION
Now _HTML Package Folder_ is the common column between Graphics Setups in both Show Styles, used for the HTML template name (for locators in Gallery, and for all the graphics in Qboxes).