### PR TITLE
Sof 1202/Gfx Design template migration

### DIFF
--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -231,7 +231,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 		description: '',
 		type: ConfigManifestEntryType.TABLE,
 		required: true,
-		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign === true),
+		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign),
 		columns: [
 			{
 				id: DESIGN_NAME_COLUMN_ID,
@@ -348,7 +348,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 			'This table can contain info in two ways. Things marked (**) are always required. If you want to do the mapping from iNews-code, then all (*)-elements are also required. GFX Template Name is what the graphic is called in viz. Source layer is the ID of the Sofie Source layer in the UI (i.e. "studio0_graphicsTema"). Layer mapping is the Sofie studio layer mapping (i.e "viz_layer_tema").  iNews command can be something like "KG=", then iNews Name is the thing that follows in iNews i.e. "ident_nyhederne"',
 		type: ConfigManifestEntryType.TABLE,
 		required: true,
-		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign === false),
+		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => !template.IsDesign),
 		columns: [
 			{
 				id: 'INewsCode',

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -231,7 +231,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 		description: '',
 		type: ConfigManifestEntryType.TABLE,
 		required: true,
-		defaultVal: [],
+		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign === true),
 		columns: [
 			{
 				id: DESIGN_NAME_COLUMN_ID,
@@ -348,7 +348,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 			'This table can contain info in two ways. Things marked (**) are always required. If you want to do the mapping from iNews-code, then all (*)-elements are also required. GFX Template Name is what the graphic is called in viz. Source layer is the ID of the Sofie Source layer in the UI (i.e. "studio0_graphicsTema"). Layer mapping is the Sofie studio layer mapping (i.e "viz_layer_tema").  iNews command can be something like "KG=", then iNews Name is the thing that follows in iNews i.e. "ident_nyhederne"',
 		type: ConfigManifestEntryType.TABLE,
 		required: true,
-		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })),
+		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign === false),
 		columns: [
 			{
 				id: 'INewsCode',

--- a/src/tv2_offtube_showstyle/config-manifests.ts
+++ b/src/tv2_offtube_showstyle/config-manifests.ts
@@ -149,7 +149,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 		description: '',
 		type: ConfigManifestEntryType.TABLE,
 		required: true,
-		defaultVal: [],
+		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign === true),
 		columns: [
 			{
 				id: 'INewsName',
@@ -219,7 +219,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 			'This table can contain info in two ways. Things marked (**) are always required. If you want to do the mapping from iNews-code, then all (*)-elements are also required. GFX Template Name is what the graphic is called in the HTML package. Source layer is the ID of the Sofie Source layer in the UI (i.e. "studio0_graphicsTema"). Layer mapping is the Sofie studio layer mapping (i.e "viz_layer_tema").  iNews command can be something like "KG=", then iNews Name is the thing that follows in iNews i.e. "ident_nyhederne"',
 		type: ConfigManifestEntryType.TABLE,
 		required: false,
-		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })),
+		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign === false),
 		columns: [
 			{
 				id: 'INewsCode',

--- a/src/tv2_offtube_showstyle/config-manifests.ts
+++ b/src/tv2_offtube_showstyle/config-manifests.ts
@@ -149,7 +149,7 @@ export const gfxDesignTemplates: ConfigManifestEntry[] = [
 		description: '',
 		type: ConfigManifestEntryType.TABLE,
 		required: true,
-		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign === true),
+		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign),
 		columns: [
 			{
 				id: 'INewsName',
@@ -219,7 +219,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 			'This table can contain info in two ways. Things marked (**) are always required. If you want to do the mapping from iNews-code, then all (*)-elements are also required. GFX Template Name is what the graphic is called in the HTML package. Source layer is the ID of the Sofie Source layer in the UI (i.e. "studio0_graphicsTema"). Layer mapping is the Sofie studio layer mapping (i.e "viz_layer_tema").  iNews command can be something like "KG=", then iNews Name is the thing that follows in iNews i.e. "ident_nyhederne"',
 		type: ConfigManifestEntryType.TABLE,
 		required: false,
-		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => template.IsDesign === false),
+		defaultVal: DEFAULT_GRAPHICS.map(val => ({ _id: '', ...val })).filter(template => !template.IsDesign),
 		columns: [
 			{
 				id: 'INewsCode',

--- a/src/tv2_offtube_showstyle/migrations/index.ts
+++ b/src/tv2_offtube_showstyle/migrations/index.ts
@@ -4,6 +4,7 @@ import {
 	changeGfxTemplate,
 	GetDefaultAdLibTriggers,
 	GetDSKSourceLayerNames,
+	mapGfxTemplateToDesignTemplateAndDeleteOriginals,
 	RemoveOldShortcuts,
 	removeSourceLayer,
 	renameSourceLayer,
@@ -265,6 +266,12 @@ export const showStyleMigrations: MigrationStepShowStyle[] = [
 	 * - Remove persistent idents
 	 */
 	removeSourceLayer('1.7.5', 'AFVD', 'studio0_graphicsIdent_persistent'),
+
+	/**
+	 * 1.7.6
+	 * - Map designs from GFXTemplates to GfxDesignTemplates and delete them from GFXTemplates
+	 */
+	mapGfxTemplateToDesignTemplateAndDeleteOriginals('1.7.6', 'QBOX', 'GFXTemplates', 'GfxDesignTemplates'),
 
 	/**
 	 * 1.7.7


### PR DESCRIPTION
The same migration that is used for AFVD was missing for the QBoxes, this has now been added. Furthermore, an issue was discovered with the way that default values are used to populate GFXTemplates, this has been altered so they are rightly divided as GFXTemplates and GfxDesignTemplates.

I, however, do not think this is an ideal way of populating the tables by default, but this should fix the issue for now. 