### PR TITLE
SOF-769 - fix: adds Kommentator tag to created Adlibs Pieces.

### DIFF
--- a/src/tv2-common/helpers/graphics/pilot/index.ts
+++ b/src/tv2-common/helpers/graphics/pilot/index.ts
@@ -153,7 +153,7 @@ export abstract class PilotGraphicGenerator {
 
 	public createAdlibPiece(rank?: number): IBlueprintAdLibPiece {
 		const pilotPiece = this.createPiece()
-		pilotPiece.tags = [...(pilotPiece.tags ?? []), AdlibTags.ADLIB_FLOW_PRODUCER]
+		pilotPiece.tags = [...(pilotPiece.tags ?? []), AdlibTags.ADLIB_FLOW_PRODUCER, AdlibTags.ADLIB_KOMMENTATOR]
 		return {
 			...pilotPiece,
 			_rank: rank ?? 0


### PR DESCRIPTION
Forgot the SOF tag in the commit.