### PR TITLE
fix: SOF-769 Add missing sourceLayer in kommentator shelf

### DIFF
--- a/shelf-layouts/Kommentator.json
+++ b/shelf-layouts/Kommentator.json
@@ -127,7 +127,8 @@
         "studio0_graphicsIdent",
         "studio0_graphicsIdent_persistent",
         "studio0_graphicsTop",
-        "studio0_graphicsLower"
+        "studio0_graphicsLower",
+        "studio0_pilotOverlay"
       ],
       "tags": [
         "kommentator"


### PR DESCRIPTION
Include sourceLayer for pilot overlay graphics in KG elements in kommentator shelf