### PR TITLE
SOF-1081 No longer clear MSE shows in baseline

### DIFF
--- a/src/tv2_afvd_studio/getBaseline.ts
+++ b/src/tv2_afvd_studio/getBaseline.ts
@@ -10,7 +10,7 @@ import * as _ from 'underscore'
 import { SharedGraphicLLayer } from '../tv2-constants'
 import { AtemSourceIndex } from '../types/atem'
 import { getStudioConfig } from './helpers/config'
-import { AtemLLayer, GraphicLLayer, SisyfosLLAyer } from './layers'
+import { AtemLLayer, SisyfosLLAyer } from './layers'
 import { sisyfosChannels } from './sisyfosChannels'
 
 function filterMappings(
@@ -167,16 +167,6 @@ export function getBaseline(context: IStudioContext): BlueprintResultBaseline {
 					deviceType: TSR.DeviceType.VIZMSE,
 					type: TSR.TimelineContentTypeVizMSE.CONCEPT,
 					concept: ''
-				}
-			}),
-			literal<TSR.TimelineObjVIZMSECleanupShows>({
-				id: '',
-				enable: { while: '1' },
-				layer: GraphicLLayer.GraphicLLayerCleanup,
-				content: {
-					deviceType: TSR.DeviceType.VIZMSE,
-					type: TSR.TimelineContentTypeVizMSE.CLEANUP_SHOWS,
-					showIds: 'all'
 				}
 			})
 		]


### PR DESCRIPTION
We are going to purge the MSE shows on activation, so there is no longer a need for a timelineObject in the baseline telling TSR to purge the MSE