### PR TITLE
feat: SOF-1065 use showName(s) instead of showId(s)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "@sofie-automation/blueprints-integration": "npm:@tv2media/blueprints-integration@46.0.2",
+    "@sofie-automation/blueprints-integration": "npm:@tv2media/blueprints-integration@46.0.4",
     "underscore": "^1.12.1"
   },
   "resolutions": {

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -2146,7 +2146,7 @@ async function executeActionClearGraphics<
 									deviceType: TSR.DeviceType.VIZMSE,
 									type: TSR.TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
 									channelsToSendCommands: userData.sendCommands ? ['OVL1', 'FULL1', 'WALL1'] : undefined,
-									showId: config.selectedGraphicsSetup.OvlShowName ?? '' // @todo: improve types at the junction of HTML and Viz
+									showName: config.selectedGraphicsSetup.OvlShowName ?? '' // @todo: improve types at the junction of HTML and Viz
 								}
 							})
 						]

--- a/src/tv2-common/evaluateCues.ts
+++ b/src/tv2-common/evaluateCues.ts
@@ -442,7 +442,7 @@ export async function EvaluateCuesBase(
 									templateName: (obj as TSR.TimelineObjVIZMSEElementInternal).content.templateName,
 									templateData: (obj as TSR.TimelineObjVIZMSEElementInternal).content.templateData,
 									channel: o.content.channelName,
-									showId: o.content.showId
+									showName: o.content.showName
 								}
 							})
 						}
@@ -465,7 +465,7 @@ export async function EvaluateCuesBase(
 								templateName: 'altud',
 								channel: 'OVL1',
 								templateData: [],
-								showId: o.content.showId
+								showName: o.content.showName
 							}
 						})
 					}

--- a/src/tv2-common/helpers/graphics/design/index.ts
+++ b/src/tv2-common/helpers/graphics/design/index.ts
@@ -100,7 +100,7 @@ function designTimeline(config: TV2BlueprintConfig, parsedCue: CueDefinitionGrap
 						type: TSR.TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 						templateName: parsedCue.design,
 						templateData: [],
-						showId: config.selectedGraphicsSetup.OvlShowName ?? '' // @todo: improve types at the junction of HTML and Viz
+						showName: config.selectedGraphicsSetup.OvlShowName ?? '' // @todo: improve types at the junction of HTML and Viz
 					}
 				})
 			]

--- a/src/tv2-common/helpers/graphics/viz/index.ts
+++ b/src/tv2-common/helpers/graphics/viz/index.ts
@@ -109,7 +109,7 @@ export function GetInternalGraphicContentVIZ(
 					templateName: mappedTemplate,
 					templateData: parsedCue.graphic.textFields,
 					channelName: engine === 'WALL' ? 'WALL1' : 'OVL1', // TODO: TranslateEngine
-					showId: findShowName(config, context, engine)
+					showName: findShowName(config, context, engine)
 				}
 			}),
 			// Assume DSK is off by default (config table)

--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -459,7 +459,7 @@ function getGlobalAdLibPiecesAFVD(context: IStudioUserContext, config: Blueprint
 						type: TSR.TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 						templateName: 'BG_LOADER_SC',
 						templateData: [],
-						showId: config.selectedGraphicsSetup.OvlShowName
+						showName: config.selectedGraphicsSetup.OvlShowName
 					}
 				})
 			)

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -165,7 +165,7 @@ describe('grafik piece', () => {
 								templateName: 'bund',
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj
@@ -238,7 +238,7 @@ describe('grafik piece', () => {
 								templateName: 'bund',
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj
@@ -278,7 +278,7 @@ describe('grafik piece', () => {
 								templateName: 'bund',
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj
@@ -353,7 +353,7 @@ describe('grafik piece', () => {
 								templateName: 'bund',
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj
@@ -393,7 +393,7 @@ describe('grafik piece', () => {
 								templateName: 'bund',
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj
@@ -470,7 +470,7 @@ describe('grafik piece', () => {
 								templateName: 'bund',
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj
@@ -649,7 +649,7 @@ describe('grafik piece', () => {
 								templateName: 'direkte',
 								templateData: ['KØBENHAVN'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj
@@ -726,7 +726,7 @@ describe('grafik piece', () => {
 								templateName: 'arkiv',
 								templateData: ['unnamed org'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj
@@ -799,7 +799,7 @@ describe('grafik piece', () => {
 								templateName: 'tlftoptlive',
 								templateData: ['Line 1', 'Line 2'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj
@@ -838,7 +838,7 @@ describe('grafik piece', () => {
 								templateName: 'tlftoptlive',
 								templateData: ['Line 1', 'Line 2'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						dskEnableObj

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -140,7 +140,7 @@ describe('telefon', () => {
 								templateName: 'bund',
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1',
-								showId: OVL_SHOW_NAME
+								showName: OVL_SHOW_NAME
 							}
 						}),
 						literal<TSR.TimelineObjAtemDSK>({

--- a/src/tv2_afvd_showstyle/helpers/pieces/clearGrafiks.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/clearGrafiks.ts
@@ -69,7 +69,7 @@ export function EvaluateClearGrafiks(
 							content: {
 								deviceType: TSR.DeviceType.VIZMSE,
 								type: TSR.TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
-								showId: config.selectedGraphicsSetup.OvlShowName
+								showName: config.selectedGraphicsSetup.OvlShowName
 							}
 						})
 				  ]

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
@@ -130,7 +130,7 @@ function fullLoopTimeline(config: TV2BlueprintConfig, parsedCue: CueDefinitionBa
 				type: TSR.TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 				templateName: parsedCue.backgroundLoop,
 				templateData: [],
-				showId: config.selectedGraphicsSetup.FullShowName
+				showName: config.selectedGraphicsSetup.FullShowName
 			}
 		})
 	]

--- a/src/tv2_afvd_showstyle/helpers/pieces/showLifecycle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/showLifecycle.ts
@@ -7,8 +7,8 @@ import { SourceLayer } from '../../layers'
 export function CreateShowLifecyclePieces(
 	config: TV2BlueprintConfig,
 	part: BlueprintResultPart,
-	initializeShowIds: string[],
-	cleanupShowIds: string[]
+	initializeShowNames: string[],
+	cleanupShowNames: string[]
 ) {
 	if (config.studio.GraphicsType === 'VIZ') {
 		part.pieces.push({
@@ -29,7 +29,7 @@ export function CreateShowLifecyclePieces(
 						content: {
 							deviceType: TSR.DeviceType.VIZMSE,
 							type: TSR.TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
-							showIds: initializeShowIds
+							showNames: initializeShowNames
 						}
 					}),
 					literal<TSR.TimelineObjVIZMSECleanupShows>({
@@ -41,7 +41,7 @@ export function CreateShowLifecyclePieces(
 						content: {
 							deviceType: TSR.DeviceType.VIZMSE,
 							type: TSR.TimelineContentTypeVizMSE.CLEANUP_SHOWS,
-							showIds: cleanupShowIds
+							showNames: cleanupShowNames
 						}
 					})
 				]

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,13 +560,13 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sofie-automation/blueprints-integration@npm:@tv2media/blueprints-integration@46.0.2":
-  version "46.0.1"
-  resolved "https://registry.yarnpkg.com/@tv2media/blueprints-integration/-/blueprints-integration-46.0.1.tgz#e344f31e3fcc48d582914ebc33378a626cebd0e6"
-  integrity sha512-y0ITMUH0JrDligG9X+mWsvVnnGYmZJTrx5iE2XVsHiQ1xQTeBrqDyoxOag2lpbUIF8HI7mXCQkGfk7AYvQLopQ==
+"@sofie-automation/blueprints-integration@npm:@tv2media/blueprints-integration@46.0.4":
+  version "46.0.4"
+  resolved "https://registry.yarnpkg.com/@tv2media/blueprints-integration/-/blueprints-integration-46.0.4.tgz#70907f5d6be3d6c45eaa2432fffd59103625a2c7"
+  integrity sha512-BTrnMzV5ijCgdHyZl9XpXadz6GN8ts7AeY202oQGGxS4wntV31vX4u0QG0ooZWGm9K44GpTTO2jnmtFznxnOrA==
   dependencies:
     "@sofie-automation/shared-lib" "npm:@tv2media/shared-lib@46.0.0"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@2.2.3"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.0.3"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -5956,10 +5956,10 @@ through@2, "through@>=2.2.7 <3":
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-2.2.3.tgz#4b40293b564d1c774e98dab193e719ba0cf3854c"
-  integrity sha512-Dj+hXIYrl6OCozBfK5ZkRQkyXPwmZKjRY+wwLw04+sJdnCqTT2W+42ZvH+pVu3MKd/GFGeF9N+7aWa02ITaDRg==
+"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-3.0.3.tgz#cb22a1dee460403c2a306e666003a1d57af7f8d2"
+  integrity sha512-PqqV2EFCfhQyphngRFh0K7UcO+pptB5e6vk73uT+gz0S+j/aV2uAtOKA3PPeEc7W37ov4KCsP10T4KVTntNkAw==
   dependencies:
     tslib "^2.3.1"
 


### PR DESCRIPTION
Note: Not a draft, but the tests won't pass on this branch until updating the TSR types, which I'll do after merging https://github.com/tv2/tv-automation-state-timeline-resolver/pull/41

Uses new TSR types where the `showId`/`showIds` is replaced by the human-readable `showName`/`showNames`, and resolved in the TSR using the MSE's directory. 
No migrations because the property names were already changed, but manual config change is needed in the Graphics Setups table after deployment.