### PR TITLE
fix: SOF-1290 disable Server Resume in Qboxes

### DIFF
--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -21,7 +21,6 @@ import {
 	ActionClearGraphics,
 	ActionCommentatorSelectDVE,
 	ActionCommentatorSelectFull,
-	ActionCommentatorSelectServer,
 	ActionCutSourceToBox,
 	ActionCutToCamera,
 	ActionCutToRemote,
@@ -192,6 +191,11 @@ export interface ActionExecutionSettings<
 		alphaAtEnd: number
 	) => WithTimeline<VTContent>
 	pilotGraphicSettings: PilotGeneratorSettings
+	serverActionSettings: ServerActionSettings
+}
+
+interface ServerActionSettings {
+	defaultTriggerMode: ServerSelectMode
 }
 
 export async function executeAction<
@@ -249,9 +253,7 @@ export async function executeAction<
 			case AdlibActionType.COMMENTATOR_SELECT_SERVER:
 				await executeActionCommentatorSelectServer(
 					context,
-					settings,
-					actionId,
-					userData as ActionCommentatorSelectServer
+					settings
 				)
 				break
 			case AdlibActionType.COMMENTATOR_SELECT_FULL:
@@ -451,7 +453,7 @@ async function executeActionSelectServerClip<
 			session: sessionToContinue ?? externalId,
 			adLibPix: userData.adLibPix,
 			lastServerPosition: await getServerPosition(context),
-			actionTriggerMode: triggerMode
+			actionTriggerMode: triggerMode ?? settings.serverActionSettings.defaultTriggerMode
 		},
 		{
 			SourceLayer: {
@@ -1738,9 +1740,7 @@ async function executeActionCommentatorSelectServer<
 	ShowStyleConfig extends TV2BlueprintConfigBase<StudioConfig>
 >(
 	context: ITV2ActionExecutionContext,
-	settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>,
-	_actionId: string,
-	_userData: ActionCommentatorSelectServer
+	settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>
 ) {
 	const data = await findDataStore<ActionSelectServerClip>(context, [
 		settings.SelectedAdlibs.SourceLayer.Server,
@@ -1766,7 +1766,7 @@ async function executeActionCommentatorSelectServer<
 		settings,
 		AdlibActionType.SELECT_SERVER_CLIP,
 		data,
-		ServerSelectMode.RESET,
+		settings.serverActionSettings.defaultTriggerMode,
 		session
 	)
 }

--- a/src/tv2_afvd_showstyle/actions.ts
+++ b/src/tv2_afvd_showstyle/actions.ts
@@ -1,5 +1,5 @@
 import { ActionUserData, IActionExecutionContext } from 'blueprints-integration'
-import { executeAction } from 'tv2-common'
+import { executeAction, ServerSelectMode } from 'tv2-common'
 import { AtemLLayer, CasparLLayer, SisyfosLLAyer } from '../tv2_afvd_studio/layers'
 import { getConfig } from './helpers/config'
 import { AFVD_DVE_GENERATOR_OPTIONS } from './helpers/content/dve'
@@ -64,7 +64,10 @@ export async function executeActionAFVD(
 				SELECTED_ADLIB_LAYERS: [SourceLayer.SelectedServer, SourceLayer.SelectedVoiceOver]
 			},
 			createJingleContent: createJingleContentAFVD,
-			pilotGraphicSettings: pilotGeneratorSettingsAFVD
+			pilotGraphicSettings: pilotGeneratorSettingsAFVD,
+			serverActionSettings: {
+				defaultTriggerMode: ServerSelectMode.RESUME
+			}
 		},
 		actionId,
 		userData,

--- a/src/tv2_offtube_showstyle/actions.ts
+++ b/src/tv2_offtube_showstyle/actions.ts
@@ -1,5 +1,5 @@
 import { ActionUserData, IActionExecutionContext } from 'blueprints-integration'
-import { executeAction } from 'tv2-common'
+import { executeAction, ServerSelectMode } from 'tv2-common'
 import { OfftubeAtemLLayer, OfftubeCasparLLayer, OfftubeSisyfosLLayer } from '../tv2_offtube_studio/layers'
 import { OFFTUBE_DVE_GENERATOR_OPTIONS } from './content/OfftubeDVEContent'
 import { pilotGeneratorSettingsOfftube } from './cues/OfftubeGraphics'
@@ -71,7 +71,10 @@ export async function executeActionOfftube(
 				SELECTED_ADLIB_LAYERS
 			},
 			createJingleContent: createJingleContentOfftube,
-			pilotGraphicSettings: pilotGeneratorSettingsOfftube
+			pilotGraphicSettings: pilotGeneratorSettingsOfftube,
+			serverActionSettings: {
+				defaultTriggerMode: ServerSelectMode.RESET
+			}
 		},
 		actionId,
 		userData


### PR DESCRIPTION
Make `RESET` the default trigger mode for the Server Select action in the Qbox (Offtube) Show Style to prevent servers from stopping in the middle.