### PR TITLE
fix: SOF-1260 small triCaster fixes

### DIFF
--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -51,6 +51,7 @@ import {
 	ServerSelectMode,
 	ShowStyleContext,
 	SisyfosPersistMetaData,
+	TableConfigItemBreaker,
 	TimelineBlueprintExt,
 	TransitionStyle,
 	TV2AdlibAction,
@@ -156,10 +157,7 @@ export interface ActionExecutionSettings<
 	createJingleContent: (
 		context: ShowStyleContext<ShowStyleConfig>,
 		file: string,
-		alphaAtStart: number,
-		loadFirstFrame: boolean,
-		duration: number,
-		alphaAtEnd: number
+		breakerConfig: TableConfigItemBreaker
 	) => WithTimeline<VTContent>
 	serverActionSettings: ServerActionSettings
 }
@@ -940,14 +938,7 @@ async function executeActionSelectJingle<
 
 	const props = GetJinglePartPropertiesFromTableValue(jingle)
 
-	const pieceContent = settings.createJingleContent(
-		context,
-		file,
-		jingle.StartAlpha,
-		jingle.LoadFirstFrame,
-		jingle.Duration,
-		jingle.EndAlpha
-	)
+	const pieceContent = settings.createJingleContent(context, file, jingle)
 
 	const piece: IBlueprintPiece<PieceMetaData> = {
 		externalId: `${externalId}-JINGLE`,
@@ -1041,7 +1032,7 @@ async function executeActionCutToCamera<
 		tags: [GetTagForKam(userData.sourceDefinition)],
 		content: {
 			timelineObjects: [
-				...context.videoSwitcher.getOnAirTimelineObjects({
+				...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 					priority: 1,
 					content: {
 						input: sourceInfoCam.port,
@@ -1172,7 +1163,7 @@ async function executeActionCutToRemote<
 		tags: [GetTagForLive(userData.sourceDefinition)],
 		content: {
 			timelineObjects: _.compact<TSR.TSRTimelineObj[]>([
-				...context.videoSwitcher.getOnAirTimelineObjects({
+				...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 					enable: { while: '1' },
 					priority: 1,
 					content: {

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -9,7 +9,7 @@ import {
 
 export type MediaPlayerConfig = Array<{ id: string; val: string }>
 
-export interface TableConfigItemBreakers {
+export interface TableConfigItemBreaker {
 	BreakerName: string
 	ClipName: string
 	Duration: number
@@ -161,7 +161,7 @@ export interface TV2StudioBlueprintConfigBase<StudioConfig extends TV2StudioConf
 export interface TV2ShowstyleBlueprintConfigBase {
 	DefaultTemplateDuration: number
 	CasparCGLoadingClip: string
-	BreakerConfig: TableConfigItemBreakers[]
+	BreakerConfig: TableConfigItemBreaker[]
 	DVEStyles: DVEConfigInput[]
 	GfxTemplates: TableConfigItemGfxTemplate[]
 	GfxDesignTemplates: TableConfigItemGfxDesignTemplate[]

--- a/src/tv2-common/content/dve.ts
+++ b/src/tv2-common/content/dve.ts
@@ -14,7 +14,7 @@ import {
 	CueDefinitionDVE,
 	DVEConfigInput,
 	DVESources,
-	FindDSKFullGFX,
+	findDskFullGfx,
 	findSourceInfo,
 	getMixMinusTimelineObject,
 	joinAssetToFolder,
@@ -257,7 +257,7 @@ export function MakeContentDVE2<
 					if (mappingFrom.name === 'FULL') {
 						setBoxSource(box, boxSources, {
 							sourceLayerType: SourceLayerType.GRAPHICS,
-							port: FindDSKFullGFX(context.config).Fill
+							port: findDskFullGfx(context.config).Fill
 						})
 						dveTimeline.push(...GetSisyfosTimelineObjForFull(context.config))
 					} else {
@@ -318,7 +318,7 @@ export function MakeContentDVE2<
 						mediaPlayerSession: hasServer ? mediaPlayerSessionId ?? MEDIA_PLAYER_AUTO : undefined
 					}
 				}),
-				...context.videoSwitcher.getOnAirTimelineObjects({
+				...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 					enable: { start: context.config.studio.CasparPrerollDuration },
 					priority: 1,
 					content: {

--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -125,7 +125,7 @@ export function CutToServer(
 ): TimelineBlueprintExt[] {
 	return [
 		EnableServer(mediaPlayerSessionId),
-		...context.videoSwitcher.getOnAirTimelineObjects({
+		...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 			enable: {
 				start: context.config.studio.CasparPrerollDuration
 			},

--- a/src/tv2-common/cues/ekstern.ts
+++ b/src/tv2-common/cues/ekstern.ts
@@ -68,7 +68,7 @@ export function EvaluateEksternBase<
 				studioLabel: '',
 				switcherInput,
 				timelineObjects: literal<TimelineObjectCoreExt[]>([
-					...context.videoSwitcher.getOnAirTimelineObjects({
+					...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						priority: 1,
 						content: {
 							input: switcherInput,
@@ -106,7 +106,7 @@ export function EvaluateEksternBase<
 			studioLabel: '',
 			switcherInput,
 			timelineObjects: literal<TimelineObjectCoreExt[]>([
-				...context.videoSwitcher.getOnAirTimelineObjects({
+				...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 					priority: 1,
 					content: {
 						input: switcherInput,

--- a/src/tv2-common/helpers/dsk.ts
+++ b/src/tv2-common/helpers/dsk.ts
@@ -12,19 +12,19 @@ import { ATEMModel } from '../../types/atem'
 import { TV2BlueprintConfigBase, TV2ShowStyleConfig, TV2StudioConfigBase } from '../blueprintConfig'
 import { TableConfigItemDSK } from '../types'
 
-export function FindDSKFullGFX(config: TV2ShowStyleConfig): TableConfigItemDSK {
-	return FindDSKWithRoles(config, [DskRole.FULLGFX])
+export function findDskFullGfx(config: TV2ShowStyleConfig): TableConfigItemDSK {
+	return findDskWithRoles(config, [DskRole.FULLGFX])
 }
 
-export function FindDSKOverlayGFX(config: TV2ShowStyleConfig): TableConfigItemDSK {
-	return FindDSKWithRoles(config, [DskRole.OVERLAYGFX])
+export function findDskOverlayGfx(config: TV2ShowStyleConfig): TableConfigItemDSK {
+	return findDskWithRoles(config, [DskRole.OVERLAYGFX])
 }
 
-export function FindDSKJingle(config: TV2ShowStyleConfig): TableConfigItemDSK {
-	return FindDSKWithRoles(config, [DskRole.JINGLE])
+export function findDskJingle(config: TV2ShowStyleConfig): TableConfigItemDSK {
+	return findDskWithRoles(config, [DskRole.JINGLE])
 }
 
-function FindDSKWithRoles(config: TV2ShowStyleConfig, roles: DskRole[]): TableConfigItemDSK {
+function findDskWithRoles(config: TV2ShowStyleConfig, roles: DskRole[]): TableConfigItemDSK {
 	return config.dsk.find((dsk) => dsk.Roles?.some((role) => roles.includes(role))) ?? config.dsk[0]
 }
 
@@ -46,7 +46,7 @@ export function getDskOnAirTimelineObjects(
 	dskRole: DskRole,
 	enable?: TSR.TSRTimelineObj['enable']
 ): TSR.TSRTimelineObj[] {
-	const dskConf = FindDSKWithRoles(context.config, [dskRole])
+	const dskConf = findDskWithRoles(context.config, [dskRole])
 	enable = enable ?? { start: 0 }
 	return [
 		context.videoSwitcher.getDskTimelineObject({

--- a/src/tv2-common/helpers/graphics/caspar/htmlPilotGraphicGenerator.ts
+++ b/src/tv2-common/helpers/graphics/caspar/htmlPilotGraphicGenerator.ts
@@ -1,6 +1,6 @@
 import { GraphicsContent, TSR, WithTimeline } from 'blueprints-integration'
 import {
-	FindDSKFullGFX,
+	findDskFullGfx,
 	getDskOnAirTimelineObjects,
 	getHtmlTemplateName,
 	GetSisyfosTimelineObjForFull,
@@ -90,15 +90,15 @@ export class HtmlPilotGraphicGenerator extends PilotGraphicGenerator {
 	}
 
 	protected getFullPilotTimeline(): TSR.TSRTimelineObj[] {
-		const fullDSK = FindDSKFullGFX(this.config)
+		const fullDsk = findDskFullGfx(this.config)
 		return [
-			...this.context.videoSwitcher.getOnAirTimelineObjects({
+			...this.context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 				enable: {
 					start: Number(this.config.studio.CasparPrerollDuration)
 				},
 				priority: 1,
 				content: {
-					input: fullDSK.Fill,
+					input: fullDsk.Fill,
 					transition: TransitionStyle.WIPE_FOR_GFX,
 					transitionDuration: 20
 				}

--- a/src/tv2-common/helpers/graphics/viz/VizPilotGraphicGenerator.ts
+++ b/src/tv2-common/helpers/graphics/viz/VizPilotGraphicGenerator.ts
@@ -80,7 +80,7 @@ export class VizPilotGraphicGenerator extends PilotGraphicGenerator {
 
 	private getFullPilotTimeline(): TSR.TSRTimelineObj[] {
 		return [
-			...this.context.videoSwitcher.getOnAirTimelineObjects({
+			...this.context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 				enable: {
 					start: this.config.studio.VizPilotGraphics.CutToMediaPlayer
 				},

--- a/src/tv2-common/helpers/graphics/viz/VizPilotGraphicGenerator.ts
+++ b/src/tv2-common/helpers/graphics/viz/VizPilotGraphicGenerator.ts
@@ -1,7 +1,6 @@
 import { GraphicsContent, TSR, WithTimeline } from 'blueprints-integration'
 import {
 	assertUnreachable,
-	FindDSKFullGFX,
 	getDskOnAirTimelineObjects,
 	GetSisyfosTimelineObjForFull,
 	IsTargetingFull,
@@ -79,9 +78,8 @@ export class VizPilotGraphicGenerator extends PilotGraphicGenerator {
 		}
 	}
 
-	private getFullPilotTimeline() {
-		const fullDSK = FindDSKFullGFX(this.config)
-		const timelineObjects = [
+	private getFullPilotTimeline(): TSR.TSRTimelineObj[] {
+		return [
 			...this.context.videoSwitcher.getOnAirTimelineObjects({
 				enable: {
 					start: this.config.studio.VizPilotGraphics.CutToMediaPlayer
@@ -96,20 +94,5 @@ export class VizPilotGraphicGenerator extends PilotGraphicGenerator {
 			...getDskOnAirTimelineObjects(this.context, DskRole.FULLGFX),
 			...GetSisyfosTimelineObjForFull(this.config)
 		]
-		if (this.context.uniformConfig.mixEffects.program.auxLayer) {
-			timelineObjects.push(
-				this.context.videoSwitcher.getAuxTimelineObject({
-					enable: {
-						start: this.config.studio.VizPilotGraphics.CutToMediaPlayer
-					},
-					priority: 1,
-					layer: this.context.uniformConfig.mixEffects.program.auxLayer,
-					content: {
-						input: fullDSK.Fill
-					}
-				})
-			)
-		}
-		return timelineObjects
 	}
 }

--- a/src/tv2-common/helpers/rundownAdLibActions.ts
+++ b/src/tv2-common/helpers/rundownAdLibActions.ts
@@ -12,17 +12,15 @@ import {
 	TV2StudioConfigBase
 } from 'tv2-common'
 import { AdlibActionType, AdlibTags, SharedOutputLayer, SharedSourceLayer } from 'tv2-constants'
-import { TV2ShowStyleConfig } from '../blueprintConfig'
-import { CreateJingleExpectedMedia } from '../content'
+import { TableConfigItemBreaker, TV2ShowStyleConfig } from '../blueprintConfig'
+import { createJingleExpectedMedia } from '../content'
 import { t } from './translation'
 
 interface TransitionValues {
 	rank: number
 	label: string
 	jingle: string
-	alphaAtStart?: number
-	duration?: number
-	alphaAtEnd?: number
+	breakerConfig?: TableConfigItemBreaker
 }
 
 export function GetTransitionAdLibActions<
@@ -58,13 +56,8 @@ function createActionsForTransition(
 	const transitionValues: TransitionValues = {
 		rank,
 		label: transition,
-		jingle: jingleConfig?.ClipName ?? transition
-	}
-
-	if (jingleConfig) {
-		transitionValues.alphaAtStart = jingleConfig.StartAlpha
-		transitionValues.duration = jingleConfig.Duration
-		transitionValues.alphaAtEnd = jingleConfig.EndAlpha
+		jingle: jingleConfig?.ClipName ?? transition,
+		breakerConfig: jingleConfig
 	}
 
 	const variant: ActionTakeWithTransitionVariant = ParseTransitionString(transition)
@@ -154,15 +147,10 @@ function makeTransitionAction(
 			content:
 				/^MIX ?\d+$/i.test(transitionValues.label) ||
 				/^CUT$/i.test(transitionValues.label) ||
-				/^DIP ?\d+$/i.test(transitionValues.label)
+				/^DIP ?\d+$/i.test(transitionValues.label) ||
+				!transitionValues.breakerConfig
 					? {}
-					: CreateJingleExpectedMedia(
-							config,
-							transitionValues.jingle,
-							transitionValues.alphaAtStart ?? 0,
-							transitionValues.duration ?? 0,
-							transitionValues.alphaAtEnd ?? 0
-					  )
+					: createJingleExpectedMedia(config, transitionValues.jingle, transitionValues.breakerConfig)
 		}
 	}
 }

--- a/src/tv2-common/jinglePartProperties.ts
+++ b/src/tv2-common/jinglePartProperties.ts
@@ -1,6 +1,6 @@
 import { IBlueprintPart } from 'blueprints-integration'
 import { CueType } from 'tv2-constants'
-import { TableConfigItemBreakers } from './blueprintConfig'
+import { TableConfigItemBreaker } from './blueprintConfig'
 import { getTimeFromFrames } from './frameTime'
 import { CueDefinitionJingle, PartDefinition } from './inewsConversion'
 import { ShowStyleContext } from './showstyle'
@@ -27,10 +27,10 @@ export function GetJinglePartProperties(
 }
 
 export function GetJinglePartPropertiesFromTableValue(
-	realBreaker: TableConfigItemBreakers
+	realBreaker: TableConfigItemBreaker
 ): Pick<IBlueprintPart, 'autoNext' | 'expectedDuration' | 'autoNextOverlap' | 'disableNextInTransition'> {
-	const expectedDuration = Math.max(0, getTimeFromFrames(Number(realBreaker.Duration) - Number(realBreaker.StartAlpha)))
-	const autoNextOverlap = Math.min(expectedDuration, getTimeFromFrames(Number(realBreaker.EndAlpha)))
+	const expectedDuration = Math.max(0, getTimeFromFrames(realBreaker.Duration - realBreaker.StartAlpha))
+	const autoNextOverlap = Math.min(expectedDuration, getTimeFromFrames(realBreaker.EndAlpha))
 	return {
 		expectedDuration,
 		autoNextOverlap,

--- a/src/tv2-common/parts/effekt.ts
+++ b/src/tv2-common/parts/effekt.ts
@@ -11,6 +11,8 @@ import {
 import {
 	ActionTakeWithTransitionVariantDip,
 	ActionTakeWithTransitionVariantMix,
+	findDskJingle,
+	getBreakerMixEffectCutEnable,
 	getDskOnAirTimelineObjects,
 	GetTagForTransition,
 	getTimeFromFrames,
@@ -108,6 +110,8 @@ export function CreateEffektForPartInner<
 
 	const fileName = joinAssetToFolder(context.config.studio.JingleFolder, file)
 
+	const jingleDsk = findDskJingle(context.config)
+
 	pieces.push({
 		externalId,
 		name: label,
@@ -144,6 +148,14 @@ export function CreateEffektForPartInner<
 						deviceType: TSR.DeviceType.CASPARCG,
 						type: TSR.TimelineContentTypeCasparCg.MEDIA,
 						file: fileName
+					}
+				}),
+				...context.videoSwitcher.getOnAirTimelineObjects({
+					enable: getBreakerMixEffectCutEnable(effektConfig, context.config.studio.CasparPrerollDuration),
+					priority: 1,
+					content: {
+						input: jingleDsk.Fill,
+						transition: TransitionStyle.CUT
 					}
 				}),
 				...getDskOnAirTimelineObjects(context, DskRole.JINGLE, {

--- a/src/tv2-common/pieces/telemetric.ts
+++ b/src/tv2-common/pieces/telemetric.ts
@@ -28,7 +28,7 @@ export function createTelemetricsPieceForRobotCamera(
 
 function createTelemetricsTimelineObject(preset: number): TSR.TimelineObjTelemetrics {
 	return literal<TSR.TimelineObjTelemetrics>({
-		id: `telemetrics_preset_${preset}_${Math.random() * 1000}`,
+		id: `telemetrics_preset_${preset}_${Math.floor(Math.random() * 1000)}`,
 		enable: {
 			start: 0
 		},

--- a/src/tv2-common/videoSwitchers/TriCaster.ts
+++ b/src/tv2-common/videoSwitchers/TriCaster.ts
@@ -254,7 +254,7 @@ export class TriCaster extends VideoSwitcherBase {
 
 	private generateInvisibleBoxLayer(): TSR.TriCasterLayer {
 		return {
-			input: 'Black',
+			input: 'black',
 			positioningAndCropEnabled: true,
 			position: {
 				x: -3.555,

--- a/src/tv2-common/videoSwitchers/VideoSwitcher.ts
+++ b/src/tv2-common/videoSwitchers/VideoSwitcher.ts
@@ -42,6 +42,7 @@ export abstract class VideoSwitcherBase implements VideoSwitcher {
 		this.core = core
 		this.uniformConfig = uniformConfig
 	}
+
 	public getOnAirTimelineObjects(properties: OnAirMixEffectProps): TSR.TSRTimelineObj[] {
 		const result: TSR.TSRTimelineObj[] = []
 		const primaryId = properties.id ?? this.core.getHashId(this.uniformConfig.switcherLLayers.primaryMixEffect, true)
@@ -61,6 +62,12 @@ export abstract class VideoSwitcherBase implements VideoSwitcher {
 				})
 			)
 		}
+		return result
+	}
+
+	public getOnAirTimelineObjectsWithLookahead(properties: OnAirMixEffectProps): TSR.TSRTimelineObj[] {
+		const result: TSR.TSRTimelineObj[] = this.getOnAirTimelineObjects(properties)
+		const primaryId = result[0].id
 		if (this.uniformConfig.switcherLLayers.nextPreviewMixEffect && properties.content.input) {
 			result.push(
 				this.getMixEffectTimelineObject({
@@ -84,6 +91,7 @@ export abstract class VideoSwitcherBase implements VideoSwitcher {
 		}
 		return result
 	}
+
 	public abstract updateAuxInput(
 		timelineObject: TimelineObjectCoreExt<unknown, unknown>,
 		input: number | SpecialInput

--- a/src/tv2-common/videoSwitchers/__tests__/TriCaster.spec.ts
+++ b/src/tv2-common/videoSwitchers/__tests__/TriCaster.spec.ts
@@ -653,7 +653,7 @@ describe('TriCaster', () => {
 
 		function invisibleBox(): TSR.TriCasterLayer {
 			return {
-				input: 'Black',
+				input: 'black',
 				positioningAndCropEnabled: true,
 				position: {
 					x: -3.555,

--- a/src/tv2-common/videoSwitchers/types.ts
+++ b/src/tv2-common/videoSwitchers/types.ts
@@ -109,7 +109,18 @@ export interface DveProps extends TimelineObjectProps {
 export interface VideoSwitcher {
 	isMixEffect(timelineObject: TimelineObjectCoreExt): boolean
 	getMixEffectTimelineObject(properties: MixEffectProps): TSR.TSRTimelineObj
+
+	/**
+	 * Returns timeline objects that cut (or transition) to a given input on Program and Clean M/Es
+	 * @param properties OnAirMixEffectProps
+	 */
 	getOnAirTimelineObjects(properties: OnAirMixEffectProps): TSR.TSRTimelineObj[]
+	/**
+	 * Returns timeline objects that cut (or transition) to a given input on Program and Clean M/Es
+	 * and objects letting lookahead logic show given input as Next
+	 * @param properties OnAirMixEffectProps
+	 */
+	getOnAirTimelineObjectsWithLookahead(properties: OnAirMixEffectProps): TSR.TSRTimelineObj[]
 	isVideoSwitcherTimelineObject(timelineObject: TimelineObjectCoreExt): boolean
 	updateTransition(
 		timelineObject: TimelineObjectCoreExt,

--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -116,7 +116,7 @@ export enum ControlClasses {
 	SERVER_ON_AIR = 'server_on_air',
 	LYD_ON_AIR = 'lyd_on_air',
 	OVERRIDDEN_ON_MIX_MINUS = 'overridden_on_mix_minus',
-	ABSTRACT_LOOKAHEAD = 'abstract_lookahead',
+	ABSTRACT_LOOKAHEAD = 'abstract_lookahead'
 }
 
 export function GetEnableClassForServer(mediaPlayerSessionId: string) {

--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -117,7 +117,6 @@ export enum ControlClasses {
 	LYD_ON_AIR = 'lyd_on_air',
 	OVERRIDDEN_ON_MIX_MINUS = 'overridden_on_mix_minus',
 	ABSTRACT_LOOKAHEAD = 'abstract_lookahead',
-	PLACEHOLDER = 'placeholder'
 }
 
 export function GetEnableClassForServer(mediaPlayerSessionId: string) {

--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -16,7 +16,7 @@ import {
 	createDskBaseline,
 	CreateDSKBaselineAdlibs,
 	CreateLYDBaseline,
-	FindDSKJingle,
+	findDskJingle,
 	getGraphicBaseline,
 	getMixMinusTimelineObject,
 	GetSisyfosTimelineObjForRemote,
@@ -179,7 +179,7 @@ class GlobalAdLibPiecesGenerator {
 			content: {
 				ignoreMediaObjectStatus: true,
 				timelineObjects: [
-					...this.context.videoSwitcher.getOnAirTimelineObjects({
+					...this.context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						enable: { while: '1' },
 						priority: 1,
 						content: {
@@ -265,7 +265,7 @@ class GlobalAdLibPiecesGenerator {
 			tags: [AdlibTags.ADLIB_QUEUE_NEXT],
 			content: {
 				timelineObjects: [
-					...this.context.videoSwitcher.getOnAirTimelineObjects({
+					...this.context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						enable: { while: '1' },
 						priority: 1,
 						content: {
@@ -501,7 +501,7 @@ class GlobalAdLibPiecesGenerator {
 }
 
 function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): BlueprintResultBaseline {
-	const jingleDSK = FindDSKJingle(context.config)
+	const jingleDSK = findDskJingle(context.config)
 
 	return {
 		timelineObjects: _.compact([

--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -41,6 +41,7 @@ import {
 	SwitcherAuxLLayer
 } from 'tv2-constants'
 import * as _ from 'underscore'
+import { getMixEffectBaseline } from '../tv2_afvd_studio/getBaseline'
 import { CasparLLayer, SisyfosLLAyer } from '../tv2_afvd_studio/layers'
 import { SisyfosChannel, sisyfosChannels } from '../tv2_afvd_studio/sisyfosChannels'
 import { GALLERY_UNIFORM_CONFIG } from '../tv2_afvd_studio/uniformConfig'
@@ -506,7 +507,7 @@ function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): Bluepri
 		timelineObjects: _.compact([
 			...getGraphicBaseline(context.config),
 			// Default timeline
-			...getMixEffectBaseline(context),
+			...getMixEffectBaseline(context, context.config.studio.SwitcherSource.Default),
 
 			context.videoSwitcher.getAuxTimelineObject({
 				enable: { while: '1' },
@@ -767,28 +768,4 @@ function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): Bluepri
 			})
 		])
 	}
-}
-
-function getMixEffectBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): TSR.TSRTimelineObj[] {
-	return Object.values(context.uniformConfig.mixEffects).flatMap((mixEffect) =>
-		_.compact([
-			context.videoSwitcher.getMixEffectTimelineObject({
-				enable: { while: '1' },
-				layer: mixEffect.mixEffectLayer,
-				content: {
-					input: context.config.studio.SwitcherSource.Default,
-					transition: TransitionStyle.CUT
-				}
-			}),
-			mixEffect.auxLayer
-				? context.videoSwitcher.getAuxTimelineObject({
-						enable: { while: '1' },
-						layer: mixEffect.auxLayer,
-						content: {
-							input: mixEffect.input
-						}
-				  })
-				: undefined
-		])
-	)
 }

--- a/src/tv2_afvd_showstyle/getSegment.ts
+++ b/src/tv2_afvd_showstyle/getSegment.ts
@@ -81,7 +81,7 @@ export function CreatePartContinuity(
 					studioLabel: '',
 					switcherInput: context.config.studio.SwitcherSource.Continuity,
 					timelineObjects: [
-						...context.videoSwitcher.getOnAirTimelineObjects({
+						...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 							priority: 1,
 							content: {
 								input: context.config.studio.SwitcherSource.Continuity,

--- a/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
@@ -9,7 +9,8 @@ import {
 	getTimeFromFrames,
 	PartDefinition,
 	ShowStyleContext,
-	t
+	t,
+	TableConfigItemBreaker
 } from 'tv2-common'
 import { AdlibActionType, AdlibTags, SharedOutputLayer, TallyTags } from 'tv2-constants'
 import { SourceLayer } from '../../../tv2_afvd_showstyle/layers'
@@ -55,14 +56,7 @@ export function EvaluateJingle(
 				sourceLayerId: SourceLayer.PgmJingle,
 				outputLayerId: SharedOutputLayer.JINGLE,
 				content: {
-					...createJingleContentAFVD(
-						context,
-						file,
-						jingle.StartAlpha,
-						jingle.LoadFirstFrame,
-						jingle.Duration,
-						jingle.EndAlpha
-					)
+					...createJingleContentAFVD(context, file, jingle)
 				},
 				tags: [AdlibTags.ADLIB_FLOW_PRODUCER],
 				currentPieceTags: [GetTagForJingle(part.segmentExternalId, parsedCue.clip)],
@@ -79,16 +73,9 @@ export function EvaluateJingle(
 			lifespan: PieceLifespan.WithinPart,
 			outputLayerId: SharedOutputLayer.JINGLE,
 			sourceLayerId: SourceLayer.PgmJingle,
-			prerollDuration: context.config.studio.CasparPrerollDuration + getTimeFromFrames(Number(jingle.StartAlpha)),
+			prerollDuration: context.config.studio.CasparPrerollDuration + getTimeFromFrames(jingle.StartAlpha),
 			tags: [!effekt ? TallyTags.JINGLE : ''],
-			content: createJingleContentAFVD(
-				context,
-				file,
-				jingle.StartAlpha,
-				jingle.LoadFirstFrame,
-				jingle.Duration,
-				jingle.EndAlpha
-			)
+			content: createJingleContentAFVD(context, file, jingle)
 		})
 	}
 }
@@ -96,12 +83,9 @@ export function EvaluateJingle(
 export function createJingleContentAFVD(
 	context: ShowStyleContext<GalleryBlueprintConfig>,
 	file: string,
-	alphaAtStart: number,
-	loadFirstFrame: boolean,
-	duration: number,
-	alphaAtEnd: number
+	breakerConfig: TableConfigItemBreaker
 ) {
-	return CreateJingleContentBase(context, file, alphaAtStart, loadFirstFrame, duration, alphaAtEnd, {
+	return CreateJingleContentBase(context, file, breakerConfig, {
 		Caspar: {
 			PlayerJingle: CasparLLayer.CasparPlayerJingle
 		},

--- a/src/tv2_afvd_showstyle/parts/evs.ts
+++ b/src/tv2_afvd_showstyle/parts/evs.ts
@@ -109,7 +109,7 @@ function makeContentEVS(
 		switcherInput,
 		ignoreMediaObjectStatus: true,
 		timelineObjects: literal<TimelineObjectCoreExt[]>([
-			...context.videoSwitcher.getOnAirTimelineObjects({
+			...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 				priority: 1,
 				content: {
 					input: switcherInput,

--- a/src/tv2_afvd_showstyle/parts/kam.ts
+++ b/src/tv2_afvd_showstyle/parts/kam.ts
@@ -12,7 +12,7 @@ import {
 	AddScript,
 	CreatePartInvalid,
 	CreatePartKamBase,
-	FindDSKJingle,
+	findDskJingle,
 	findSourceInfo,
 	GetSisyfosTimelineObjForCamera,
 	literal,
@@ -43,7 +43,7 @@ export async function CreatePartKam(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
-	const jingleDSK = FindDSKJingle(context.config)
+	const jingleDsk = findDskJingle(context.config)
 
 	if (/\bcs *\d*/i.test(partDefinition.sourceDefinition.id)) {
 		pieces.push({
@@ -63,10 +63,10 @@ export async function CreatePartKam(
 				fileName: '',
 				path: '',
 				timelineObjects: [
-					...context.videoSwitcher.getOnAirTimelineObjects({
+					...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						priority: 1,
 						content: {
-							input: jingleDSK.Fill,
+							input: jingleDsk.Fill,
 							transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
 							transitionDuration: partDefinition.transition?.duration
 						}
@@ -102,7 +102,7 @@ export async function CreatePartKam(
 				studioLabel: '',
 				switcherInput,
 				timelineObjects: [
-					...context.videoSwitcher.getOnAirTimelineObjects({
+					...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						priority: 1,
 						content: {
 							input: switcherInput,

--- a/src/tv2_afvd_studio/__tests__/graphics.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/graphics.spec.ts
@@ -128,7 +128,7 @@ describe('Graphics', () => {
 		expect(piece.lifespan).toBe(PieceLifespan.WithinPart)
 		const content = piece.content!
 		const timeline = content.timelineObjects as TSR.TSRTimelineObj[]
-		expect(timeline).toHaveLength(7) // @todo: this depends on unrelated configuration
+		expect(timeline).toHaveLength(6) // @todo: this depends on unrelated configuration
 		const vizObj = timeline.find(
 			(t) =>
 				t.content.deviceType === TSR.DeviceType.VIZMSE && t.content.type === TSR.TimelineContentTypeVizMSE.ELEMENT_PILOT
@@ -300,7 +300,7 @@ describe('Graphics', () => {
 		expect(piece.lifespan).toBe(PieceLifespan.WithinPart)
 		const content = piece.content!
 		const timeline = content.timelineObjects as TSR.TSRTimelineObj[]
-		expect(timeline).toHaveLength(7)
+		expect(timeline).toHaveLength(6)
 		const vizObj = timeline.find(
 			(t) =>
 				t.content.deviceType === TSR.DeviceType.VIZMSE && t.content.type === TSR.TimelineContentTypeVizMSE.ELEMENT_PILOT

--- a/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
@@ -11,7 +11,8 @@ import {
 	PartDefinition,
 	PieceMetaData,
 	SegmentContext,
-	t
+	t,
+	TableConfigItemBreaker
 } from 'tv2-common'
 import { AdlibActionType, AdlibTags, SharedOutputLayer, TallyTags } from 'tv2-constants'
 import { OfftubeCasparLLayer, OfftubeSisyfosLLayer } from '../../tv2_offtube_studio/layers'
@@ -62,14 +63,7 @@ export function OfftubeEvaluateJingle(
 			sourceLayerId: OfftubeSourceLayer.PgmJingle,
 			outputLayerId: OfftubeOutputLayers.JINGLE,
 			content: {
-				...createJingleContentOfftube(
-					context,
-					file,
-					jingle.StartAlpha,
-					jingle.LoadFirstFrame,
-					jingle.Duration,
-					jingle.EndAlpha
-				)
+				...createJingleContentOfftube(context, file, jingle)
 			},
 			tags: [AdlibTags.OFFTUBE_100pc_SERVER, AdlibTags.ADLIB_KOMMENTATOR],
 			currentPieceTags: [GetTagForJingle(part.segmentExternalId, parsedCue.clip)],
@@ -92,14 +86,7 @@ export function OfftubeEvaluateJingle(
 			}
 		},
 		prerollDuration: context.config.studio.CasparPrerollDuration + getTimeFromFrames(Number(jingle.StartAlpha)),
-		content: createJingleContentOfftube(
-			context,
-			file,
-			jingle.StartAlpha,
-			jingle.LoadFirstFrame,
-			jingle.Duration,
-			jingle.EndAlpha
-		),
+		content: createJingleContentOfftube(context, file, jingle),
 		tags: [
 			GetTagForJingle(part.segmentExternalId, parsedCue.clip),
 			GetTagForJingleNext(part.segmentExternalId, parsedCue.clip),
@@ -112,12 +99,9 @@ export function OfftubeEvaluateJingle(
 export function createJingleContentOfftube(
 	context: SegmentContext<OfftubeBlueprintConfig>,
 	file: string,
-	alphaAtStart: number,
-	loadFirstFrame: boolean,
-	duration: number,
-	alphaAtEnd: number
+	breakerConfig: TableConfigItemBreaker
 ) {
-	return CreateJingleContentBase(context, file, alphaAtStart, loadFirstFrame, duration, alphaAtEnd, {
+	return CreateJingleContentBase(context, file, breakerConfig, {
 		Caspar: {
 			PlayerJingle: OfftubeCasparLLayer.CasparPlayerJingle,
 			PlayerJinglePreload: OfftubeCasparLLayer.CasparPlayerJinglePreload

--- a/src/tv2_offtube_showstyle/getSegment.ts
+++ b/src/tv2_offtube_showstyle/getSegment.ts
@@ -71,7 +71,7 @@ function CreatePartContinuity(
 					studioLabel: '',
 					switcherInput: context.config.studio.SwitcherSource.Continuity,
 					timelineObjects: [
-						...context.videoSwitcher.getOnAirTimelineObjects({
+						...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 							priority: 1,
 							content: {
 								input: context.config.studio.SwitcherSource.Continuity,

--- a/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
@@ -12,7 +12,7 @@ import {
 	AddScript,
 	CreatePartInvalid,
 	CreatePartKamBase,
-	FindDSKJingle,
+	findDskJingle,
 	findSourceInfo,
 	GetSisyfosTimelineObjForCamera,
 	GetTagForKam,
@@ -43,7 +43,7 @@ export async function OfftubeCreatePartKam(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
-	const jingleDSK = FindDSKJingle(context.config)
+	const jingleDsk = findDskJingle(context.config)
 
 	if (/\bcs *\d*/i.test(partDefinition.sourceDefinition.id)) {
 		pieces.push({
@@ -58,10 +58,10 @@ export async function OfftubeCreatePartKam(
 				ignoreMediaObjectStatus: true,
 				fileName: '',
 				path: '',
-				timelineObjects: context.videoSwitcher.getOnAirTimelineObjects({
+				timelineObjects: context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 					priority: 1,
 					content: {
-						input: jingleDSK.Fill,
+						input: jingleDsk.Fill,
 						transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
 						transitionDuration: partDefinition.transition?.duration
 					}
@@ -95,7 +95,7 @@ export async function OfftubeCreatePartKam(
 				studioLabel: '',
 				switcherInput,
 				timelineObjects: [
-					...context.videoSwitcher.getOnAirTimelineObjects({
+					...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						priority: 1,
 						content: {
 							input: switcherInput,


### PR DESCRIPTION
- uses lowercase input names for consistency
- does not cut to full gfx on Pgm aux
- shows Default source on Pgm in studio baseline

- makes jingles cut to jingle fill source when fully opaque (between start-alpha ends and end-alpha starts)

- prevents dot from appearing in timeline object id