### PR TITLE
SOF-1374 Live cuts directly

### DIFF
--- a/src/tv2-common/actions/actionTypes.ts
+++ b/src/tv2-common/actions/actionTypes.ts
@@ -54,7 +54,7 @@ export interface ActionCallRobotPreset extends ActionBase {
 
 export interface ActionCutToCamera extends ActionBase {
 	type: AdlibActionType.CUT_TO_CAMERA
-	queue: boolean
+	cutDirectly: boolean
 	sourceDefinition: SourceDefinitionKam
 }
 

--- a/src/tv2-common/actions/actionTypes.ts
+++ b/src/tv2-common/actions/actionTypes.ts
@@ -60,6 +60,7 @@ export interface ActionCutToCamera extends ActionBase {
 
 export interface ActionCutToRemote extends ActionBase {
 	type: AdlibActionType.CUT_TO_REMOTE
+	cutDirectly: boolean
 	sourceDefinition: SourceDefinitionRemote
 }
 

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -1059,7 +1059,7 @@ async function executePiece<
 	partToQueue: IBlueprintPart
 ) {
 	const currentPieceInstances = await context.core.getPieceInstances('current')
-	const serverInCurrentPart = currentPieceInstances.some(
+	const isServerInCurrentPart = currentPieceInstances.some(
 		(p) => p.piece.sourceLayerId === settings.SourceLayers.Server || p.piece.sourceLayerId === settings.SourceLayers.VO
 	)
 
@@ -1068,7 +1068,7 @@ async function executePiece<
 		layersWithCutDirect.includes(p.piece.sourceLayerId)
 	)
 
-	if (shouldBeQueued || serverInCurrentPart) {
+	if (shouldBeQueued || isServerInCurrentPart) {
 		await context.core.queuePart(partToQueue, [
 			pieceToExecute,
 			...(settings.SelectedAdlibs
@@ -1076,7 +1076,7 @@ async function executePiece<
 				: [])
 		])
 
-		if (serverInCurrentPart && !shouldBeQueued) {
+		if (isServerInCurrentPart && !shouldBeQueued) {
 			await context.core.takeAfterExecuteAction(true)
 		}
 	} else if (currentPiece) {

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -1045,7 +1045,7 @@ async function executeActionCutToCamera<
 		}
 	}
 
-	await executePiece(context, settings, kamPiece, userData.queue, part)
+	await executePiece(context, settings, kamPiece, !userData.cutDirectly, part)
 }
 
 async function executePiece<

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -1167,7 +1167,8 @@ async function executeActionCutToRemote<
 			? {
 					sisyfosLayers: sourceInfo.sisyfosLayers ?? [],
 					wantsToPersistAudio: sourceInfo.wantsToPersistAudio,
-					acceptPersistAudio: sourceInfo.acceptPersistAudio
+					acceptPersistAudio: sourceInfo.acceptPersistAudio,
+					isPieceInjectedInPart: userData.cutDirectly
 			  }
 			: { sisyfosLayers: [] }
 

--- a/src/tv2_afvd_showstyle/GlobalAdlibActionsGenerator.ts
+++ b/src/tv2_afvd_showstyle/GlobalAdlibActionsGenerator.ts
@@ -39,13 +39,8 @@ export class GlobalAdlibActionsGenerator {
 		this.config.sources.cameras
 			.slice(0, 5) // the first x cameras to create INP1/2/3 cam-adlibs from
 			.forEach((camera) => {
-				blueprintActions.push(this.makeCutCameraAction(camera, false, globalRank++))
-			})
-
-		this.config.sources.cameras
-			.slice(0, 5) // the first x cameras to create preview cam-adlibs from
-			.forEach((camera) => {
-				blueprintActions.push(this.makeCutCameraAction(camera, true, globalRank++))
+				blueprintActions.push(this.makeCutDirectlyCameraAction(camera, globalRank++))
+				blueprintActions.push(this.makeQueueAsNextCameraAction(camera, globalRank++))
 			})
 
 		this.config.sources.cameras
@@ -93,11 +88,23 @@ export class GlobalAdlibActionsGenerator {
 		return blueprintActions
 	}
 
-	private makeCutCameraAction(info: SourceInfo, queue: boolean, rank: number): IBlueprintActionManifest {
-		const sourceDefinition = SourceInfoToSourceDefinition(info) as SourceDefinitionKam
+	private makeCutDirectlyCameraAction(cameraSourceInfo: SourceInfo, rank: number): IBlueprintActionManifest {
+		return this.makeCutCameraAction(cameraSourceInfo, true, rank)
+	}
+
+	private makeQueueAsNextCameraAction(cameraSourceInfo: SourceInfo, rank: number): IBlueprintActionManifest {
+		return this.makeCutCameraAction(cameraSourceInfo, false, rank)
+	}
+
+	private makeCutCameraAction(
+		cameraSourceInfo: SourceInfo,
+		cutDirectly: boolean,
+		rank: number
+	): IBlueprintActionManifest {
+		const sourceDefinition = SourceInfoToSourceDefinition(cameraSourceInfo) as SourceDefinitionKam
 		const userData: ActionCutToCamera = {
 			type: AdlibActionType.CUT_TO_CAMERA,
-			queue,
+			cutDirectly,
 			sourceDefinition
 		}
 		return {
@@ -111,7 +118,7 @@ export class GlobalAdlibActionsGenerator {
 				sourceLayerId: SourceLayer.PgmCam,
 				outputLayerId: SharedOutputLayer.PGM,
 				content: {},
-				tags: queue ? [AdlibTags.ADLIB_QUEUE_NEXT] : [AdlibTags.ADLIB_CUT_DIRECT]
+				tags: cutDirectly ? [AdlibTags.ADLIB_CUT_DIRECT] : [AdlibTags.ADLIB_QUEUE_NEXT]
 			}
 		}
 	}

--- a/src/tv2_afvd_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/actions.spec.ts
@@ -822,7 +822,7 @@ describe('Camera shortcuts on server', () => {
 			AdlibActionType.CUT_TO_CAMERA,
 			literal<ActionCutToCamera>({
 				type: AdlibActionType.CUT_TO_CAMERA,
-				queue: false,
+				cutDirectly: true,
 				sourceDefinition: SOURCE_DEFINITION_KAM_1
 			})
 		)
@@ -865,7 +865,7 @@ describe('Camera shortcuts on server', () => {
 			AdlibActionType.CUT_TO_CAMERA,
 			literal<ActionCutToCamera>({
 				type: AdlibActionType.CUT_TO_CAMERA,
-				queue: true,
+				cutDirectly: false,
 				sourceDefinition: SOURCE_DEFINITION_KAM_1
 			})
 		)
@@ -910,7 +910,7 @@ describe('Camera shortcuts on VO', () => {
 			AdlibActionType.CUT_TO_CAMERA,
 			literal<ActionCutToCamera>({
 				type: AdlibActionType.CUT_TO_CAMERA,
-				queue: false,
+				cutDirectly: true,
 				sourceDefinition: SOURCE_DEFINITION_KAM_1
 			})
 		)
@@ -953,7 +953,7 @@ describe('Camera shortcuts on VO', () => {
 			AdlibActionType.CUT_TO_CAMERA,
 			literal<ActionCutToCamera>({
 				type: AdlibActionType.CUT_TO_CAMERA,
-				queue: true,
+				cutDirectly: false,
 				sourceDefinition: SOURCE_DEFINITION_KAM_1
 			})
 		)

--- a/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
@@ -234,7 +234,7 @@ const commentatorSelectDVE = literal<ActionCommentatorSelectDVE>({
 const selectCameraAction = literal<ActionCutToCamera>({
 	type: AdlibActionType.CUT_TO_CAMERA,
 	sourceDefinition: SOURCE_DEFINITION_KAM_1,
-	queue: true
+	cutDirectly: false
 })
 
 const selectLiveAction = literal<ActionCutToRemote>({

--- a/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
@@ -239,6 +239,7 @@ const selectCameraAction = literal<ActionCutToCamera>({
 
 const selectLiveAction = literal<ActionCutToRemote>({
 	type: AdlibActionType.CUT_TO_REMOTE,
+	cutDirectly: false,
 	sourceDefinition: SOURCE_DEFINITION_LIVE_2
 })
 

--- a/src/tv2_offtube_showstyle/getRundown.ts
+++ b/src/tv2_offtube_showstyle/getRundown.ts
@@ -263,6 +263,7 @@ function getGlobalAdlibActionsOfftube(
 		const sourceDefinition = SourceInfoToSourceDefinition(sourceInfo) as SourceDefinitionRemote
 		const userData: ActionCutToRemote = {
 			type: AdlibActionType.CUT_TO_REMOTE,
+			cutDirectly: false,
 			sourceDefinition
 		}
 		blueprintActions.push({

--- a/src/tv2_offtube_showstyle/getRundown.ts
+++ b/src/tv2_offtube_showstyle/getRundown.ts
@@ -234,14 +234,26 @@ function getGlobalAdlibActionsOfftube(
 
 	let globalRank = 2000
 
-	function makeCutCameraActions(info: SourceInfo, queue: boolean, rank: number) {
-		const sourceDefinition = SourceInfoToSourceDefinition(info) as SourceDefinitionKam
+	function makeCutDirectlyCameraAction(cameraSourceInfo: SourceInfo, rank: number): IBlueprintActionManifest {
+		return makeCutCameraAction(cameraSourceInfo, true, rank)
+	}
+
+	function makeQueueAsNextCameraAction(cameraSourceInfo: SourceInfo, rank: number): IBlueprintActionManifest {
+		return makeCutCameraAction(cameraSourceInfo, false, rank)
+	}
+
+	function makeCutCameraAction(
+		cameraSourceInfo: SourceInfo,
+		cutDirectly: boolean,
+		rank: number
+	): IBlueprintActionManifest {
+		const sourceDefinition = SourceInfoToSourceDefinition(cameraSourceInfo) as SourceDefinitionKam
 		const userData: ActionCutToCamera = {
 			type: AdlibActionType.CUT_TO_CAMERA,
-			queue,
+			cutDirectly,
 			sourceDefinition
 		}
-		blueprintActions.push({
+		return {
 			externalId: generateExternalId(context, userData),
 			actionId: AdlibActionType.CUT_TO_CAMERA,
 			userData,
@@ -252,11 +264,11 @@ function getGlobalAdlibActionsOfftube(
 				sourceLayerId: OfftubeSourceLayer.PgmCam,
 				outputLayerId: SharedOutputLayer.PGM,
 				content: {},
-				tags: queue ? [AdlibTags.OFFTUBE_SET_CAM_NEXT, AdlibTags.ADLIB_QUEUE_NEXT] : [AdlibTags.ADLIB_CUT_DIRECT],
+				tags: cutDirectly ? [AdlibTags.ADLIB_CUT_DIRECT] : [AdlibTags.OFFTUBE_SET_CAM_NEXT, AdlibTags.ADLIB_QUEUE_NEXT],
 				currentPieceTags: [GetTagForKam(sourceDefinition)],
 				nextPieceTags: [GetTagForKam(sourceDefinition)]
 			}
-		})
+		}
 	}
 
 	function makeRemoteAction(sourceInfo: SourceInfo, rank: number) {
@@ -483,14 +495,9 @@ function getGlobalAdlibActionsOfftube(
 
 	config.sources.cameras
 		.slice(0, 5) // the first x cameras to create INP1/2/3 cam-adlibs from
-		.forEach((o) => {
-			makeCutCameraActions(o, false, globalRank++)
-		})
-
-	config.sources.cameras
-		.slice(0, 5) // the first x cameras to create preview cam-adlibs from
-		.forEach((o) => {
-			makeCutCameraActions(o, true, globalRank++)
+		.forEach((cameraSourceInfo) => {
+			blueprintActions.push(makeCutDirectlyCameraAction(cameraSourceInfo, globalRank++))
+			blueprintActions.push(makeQueueAsNextCameraAction(cameraSourceInfo, globalRank++))
 		})
 
 	config.sources.cameras


### PR DESCRIPTION
Able to create ActionTriggers for Live that cuts directly to program.

This is basically extracting the code from `executeActionCutToCamera` that determines when and how to cut directly and make `executeActionCutToRemote` use the extracted code.

Naming suggestions for `executePiece` is much appreciated. If you want me to refactor `executePiece` further, let me know (currently just extracted it and changed some variable names)