### PR TITLE
feat: SOF-1386 show Fullscreen gfx on the Clean Feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv2-sofie-blueprints-inews",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "repository": "https://github.com/olzzon/tv2-sofie-blueprints-inews",
   "license": "MIT",
   "private": true,

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -131,6 +131,7 @@ export interface TV2StudioConfigBase {
 	}
 	VizPilotGraphics: {
 		KeepAliveDuration: number
+		CleanFeedPrerollDuration: number
 		PrerollDuration: number
 		OutTransitionDuration: number
 		CutToMediaPlayer: number

--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -148,7 +148,7 @@ export function EnableServer(mediaPlayerSessionId: string) {
 		enable: {
 			start: 0
 		},
-		layer: AbstractLLayer.ServerEnablePending,
+		layer: AbstractLLayer.SERVER_ENABLE_PENDING,
 		content: {
 			deviceType: TSR.DeviceType.ABSTRACT
 		},

--- a/src/tv2-common/cues/lyd.ts
+++ b/src/tv2-common/cues/lyd.ts
@@ -185,7 +185,7 @@ export function CreateLYDBaseline(studio: string): TSR.TSRTimelineObj[] {
 				while: `!.${ControlClasses.LYD_ON_AIR}`
 			},
 			priority: 0,
-			layer: AbstractLLayer.AudioBedBaseline,
+			layer: AbstractLLayer.AUDIO_BED_BASELINE,
 			content: {
 				deviceType: TSR.DeviceType.ABSTRACT
 			}

--- a/src/tv2-common/cues/mixMinus.ts
+++ b/src/tv2-common/cues/mixMinus.ts
@@ -55,7 +55,7 @@ export function getMixMinusTimelineObject(
 		enable: {
 			while: `.${ControlClasses.OVERRIDDEN_ON_MIX_MINUS}`
 		},
-		layer: SwitcherAuxLLayer.AuxVideoMixMinus,
+		layer: SwitcherAuxLLayer.VIDEO_MIX_MINUS,
 		priority,
 		temporalPriority: TemporalPriority.AUX_MIX_MINUS_OVERRIDE
 	})

--- a/src/tv2-common/helpers/abPlayback.ts
+++ b/src/tv2-common/helpers/abPlayback.ts
@@ -313,7 +313,7 @@ function updateObjectsToMediaPlayer<
 				// context.notifyUserWarning(obj)
 			}
 		} else if (obj.content.deviceType === TSR.DeviceType.ABSTRACT) {
-			if (obj.layer === AbstractLLayer.ServerEnablePending) {
+			if (obj.layer === AbstractLLayer.SERVER_ENABLE_PENDING) {
 				obj.layer = AbstractLLayerServerEnable(playerId)
 			}
 		} else {

--- a/src/tv2-common/helpers/dsk.ts
+++ b/src/tv2-common/helpers/dsk.ts
@@ -74,6 +74,23 @@ export function getDskOnAirTimelineObjects(
 						}
 					})
 			  ]
+			: []),
+		...(dskRole === DskRole.FULLGFX && context.uniformConfig.switcherLLayers.fullUskMixEffect
+			? [
+					context.videoSwitcher.getMixEffectTimelineObject({
+						enable: { start: context.config.studio.VizPilotGraphics.CleanFeedPrerollDuration },
+						priority: 1,
+						layer: context.uniformConfig.switcherLLayers.fullUskMixEffect,
+						content: {
+							keyers: [
+								{
+									onAir: true,
+									config: dskConf
+								}
+							]
+						}
+					})
+			  ]
 			: [])
 	]
 }

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -190,7 +190,7 @@ function processServerLookaheads(
 			return true
 		}
 
-		if (obj.layer === AbstractLLayer.ServerEnablePending && obj.isLookahead) {
+		if (obj.layer === AbstractLLayer.SERVER_ENABLE_PENDING && obj.isLookahead) {
 			return false
 		}
 

--- a/src/tv2-common/uniformConfig.ts
+++ b/src/tv2-common/uniformConfig.ts
@@ -15,6 +15,8 @@ export interface UniformConfig {
 		nextAux?: SwitcherAuxLLayer
 		/** Optional layer to show the jingles on an USK */
 		jingleUskMixEffect?: SwitcherMixEffectLLayer
+		/** Optional layer to show Fullscreen graphics on an USK */
+		fullUskMixEffect?: SwitcherMixEffectLLayer
 		/** Optional layer to show the jingles lookahead on */
 		jingleNextMixEffect?: SwitcherMixEffectLLayer
 		/** Optional layer to preview servers on Aux */

--- a/src/tv2-common/videoSwitchers/Atem.ts
+++ b/src/tv2-common/videoSwitchers/Atem.ts
@@ -158,7 +158,7 @@ export class Atem extends VideoSwitcherBase {
 	public getDveTimelineObjects(props: DveProps): TSR.TSRTimelineObj[] {
 		return [
 			literal<TSR.TimelineObjAtemSsrc & TimelineBlueprintExt>({
-				...this.getBaseProperties(props, SwitcherDveLLayer.DveBoxes),
+				...this.getBaseProperties(props, SwitcherDveLLayer.DVE_BOXES),
 				content: {
 					deviceType: TSR.DeviceType.ATEM,
 					type: TSR.TimelineContentTypeAtem.SSRC,
@@ -166,7 +166,7 @@ export class Atem extends VideoSwitcherBase {
 				}
 			}),
 			literal<TSR.TimelineObjAtemSsrcProps>({
-				...this.getBaseProperties(props, SwitcherDveLLayer.Dve),
+				...this.getBaseProperties(props, SwitcherDveLLayer.DVE),
 				content: {
 					deviceType: TSR.DeviceType.ATEM,
 					type: TSR.TimelineContentTypeAtem.SSRCPROPS,

--- a/src/tv2-common/videoSwitchers/TriCaster.ts
+++ b/src/tv2-common/videoSwitchers/TriCaster.ts
@@ -219,7 +219,7 @@ export class TriCaster extends VideoSwitcherBase {
 	public getDveTimelineObjects(dveProps: DveProps): TSR.TimelineObjTriCasterME[] {
 		return [
 			{
-				...this.getBaseProperties(dveProps, SwitcherDveLLayer.DveBoxes),
+				...this.getBaseProperties(dveProps, SwitcherDveLLayer.DVE_BOXES),
 				content: {
 					deviceType: TSR.DeviceType.TRICASTER,
 					type: TSR.TimelineContentTypeTriCaster.ME,

--- a/src/tv2-common/videoSwitchers/TriCaster.ts
+++ b/src/tv2-common/videoSwitchers/TriCaster.ts
@@ -78,6 +78,7 @@ export class TriCaster extends VideoSwitcherBase {
 					...(content.previewInput !== undefined && transition === 'cut'
 						? { previewInput: this.getInputName(content.previewInput) }
 						: {}),
+					// @todo: fix transitionEffect and transitionDuration being set when not needed
 					transitionEffect: transition,
 					transitionDuration: this.getTransitionDuration(content.transition, content.transitionDuration),
 					keyers: content.keyers && this.getKeyers(content.keyers)

--- a/src/tv2-common/videoSwitchers/__tests__/Atem.spec.ts
+++ b/src/tv2-common/videoSwitchers/__tests__/Atem.spec.ts
@@ -19,7 +19,7 @@ function setupAtem(studioConfigOverrides?: Partial<TV2StudioConfigBase>) {
 describe('ATEM', () => {
 	describe('Mix Effect', () => {
 		const DEFAULT_ME: MixEffectProps = {
-			layer: SwitcherMixEffectLLayer.Program,
+			layer: SwitcherMixEffectLLayer.PROGRAM,
 			content: {
 				input: 5
 			}
@@ -64,7 +64,7 @@ describe('ATEM', () => {
 			const atem = setupAtem()
 			const timelineObject = atem.getMixEffectTimelineObject(DEFAULT_ME)
 			expect(timelineObject).toMatchObject({
-				layer: prefixLayer(SwitcherMixEffectLLayer.Program)
+				layer: prefixLayer(SwitcherMixEffectLLayer.PROGRAM)
 			})
 		})
 
@@ -83,7 +83,7 @@ describe('ATEM', () => {
 		test('sets input when CUT transition provided', () => {
 			const atem = setupAtem()
 			const timelineObject = atem.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 5,
 					transition: TransitionStyle.CUT
@@ -102,7 +102,7 @@ describe('ATEM', () => {
 		test('sets previewInput', () => {
 			const atem = setupAtem()
 			const timelineObject = atem.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					previewInput: 5
 				}
@@ -119,7 +119,7 @@ describe('ATEM', () => {
 		test('supports MIX', () => {
 			const atem = setupAtem()
 			const timelineObject = atem.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 5,
 					transition: TransitionStyle.MIX,
@@ -144,7 +144,7 @@ describe('ATEM', () => {
 		test('supports WIPE', () => {
 			const atem = setupAtem()
 			const timelineObject = atem.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 5,
 					transition: TransitionStyle.WIPE,
@@ -176,7 +176,7 @@ describe('ATEM', () => {
 				}
 			})
 			const timelineObject = atem.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 5,
 					transition: TransitionStyle.WIPE_FOR_GFX
@@ -203,7 +203,7 @@ describe('ATEM', () => {
 		test('supports DIP', () => {
 			const atem = setupAtem()
 			const timelineObject = atem.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 5,
 					transition: TransitionStyle.DIP,
@@ -245,7 +245,7 @@ describe('ATEM', () => {
 				}
 			})
 			const timelineObject = atem.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 5,
 					transition: TransitionStyle.DIP,
@@ -271,7 +271,7 @@ describe('ATEM', () => {
 		test('supports keyers', () => {
 			const atem = setupAtem()
 			const timelineObject = atem.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					keyers: [
 						{
@@ -313,7 +313,7 @@ describe('ATEM', () => {
 
 	describe('Aux', () => {
 		const DEFAULT_AUX: AuxProps = {
-			layer: SwitcherAuxLLayer.AuxClean,
+			layer: SwitcherAuxLLayer.CLEAN,
 			content: {
 				input: 5
 			}
@@ -358,7 +358,7 @@ describe('ATEM', () => {
 			const atem = setupAtem()
 			const timelineObject = atem.getAuxTimelineObject(DEFAULT_AUX)
 			expect(timelineObject).toMatchObject({
-				layer: prefixLayer(SwitcherAuxLLayer.AuxClean)
+				layer: prefixLayer(SwitcherAuxLLayer.CLEAN)
 			})
 		})
 

--- a/src/tv2-common/videoSwitchers/__tests__/TriCaster.spec.ts
+++ b/src/tv2-common/videoSwitchers/__tests__/TriCaster.spec.ts
@@ -32,7 +32,7 @@ function createTestee(mocks?: {
 describe('TriCaster', () => {
 	describe('Mix Effect', () => {
 		const DEFAULT_ME: MixEffectProps = {
-			layer: SwitcherMixEffectLLayer.Program,
+			layer: SwitcherMixEffectLLayer.PROGRAM,
 			content: {
 				input: 5
 			}
@@ -77,7 +77,7 @@ describe('TriCaster', () => {
 			const testee: TriCaster = createTestee()
 			const timelineObject = testee.getMixEffectTimelineObject(DEFAULT_ME)
 			expect(timelineObject).toMatchObject({
-				layer: prefixLayer(SwitcherMixEffectLLayer.Program)
+				layer: prefixLayer(SwitcherMixEffectLLayer.PROGRAM)
 			})
 		})
 
@@ -96,7 +96,7 @@ describe('TriCaster', () => {
 		test('sets previewInput', () => {
 			const testee: TriCaster = createTestee()
 			const timelineObject = testee.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					previewInput: 5
 				}
@@ -113,7 +113,7 @@ describe('TriCaster', () => {
 		test('supports MIX', () => {
 			const testee: TriCaster = createTestee()
 			const timelineObject = testee.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 5,
 					transition: TransitionStyle.MIX,
@@ -136,7 +136,7 @@ describe('TriCaster', () => {
 		test('supports WIPE', () => {
 			const testee: TriCaster = createTestee()
 			const timelineObject = testee.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 3,
 					transition: TransitionStyle.WIPE,
@@ -168,7 +168,7 @@ describe('TriCaster', () => {
 			} as any as TV2StudioConfigBase)
 			const testee: TriCaster = createTestee({ config: instance(config) })
 			const timelineObject = testee.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 5,
 					transition: TransitionStyle.WIPE_FOR_GFX
@@ -190,7 +190,7 @@ describe('TriCaster', () => {
 		test('supports DIP', () => {
 			const testee: TriCaster = createTestee()
 			const timelineObject = testee.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					input: 5,
 					transition: TransitionStyle.DIP,
@@ -213,7 +213,7 @@ describe('TriCaster', () => {
 		test('supports keyers', () => {
 			const testee: TriCaster = createTestee()
 			const timelineObject = testee.getMixEffectTimelineObject({
-				layer: SwitcherMixEffectLLayer.Program,
+				layer: SwitcherMixEffectLLayer.PROGRAM,
 				content: {
 					keyers: [
 						{
@@ -248,7 +248,7 @@ describe('TriCaster', () => {
 
 	describe('Aux', () => {
 		const DEFAULT_AUX: AuxProps = {
-			layer: SwitcherAuxLLayer.AuxClean,
+			layer: SwitcherAuxLLayer.CLEAN,
 			content: {
 				input: 5
 			}
@@ -293,7 +293,7 @@ describe('TriCaster', () => {
 			const testee: TriCaster = createTestee()
 			const timelineObject = testee.getAuxTimelineObject(DEFAULT_AUX)
 			expect(timelineObject).toMatchObject({
-				layer: prefixLayer(SwitcherAuxLLayer.AuxClean)
+				layer: prefixLayer(SwitcherAuxLLayer.CLEAN)
 			})
 		})
 
@@ -356,14 +356,14 @@ describe('TriCaster', () => {
 			const context = mock<IStudioContext>()
 			when(context.getStudioMappings).thenReturn(() => {
 				return {
-					[prefixLayer(SwitcherAuxLLayer.AuxClean)]: literal<TSR.MappingTriCaster & BlueprintMapping>({
+					[prefixLayer(SwitcherAuxLLayer.CLEAN)]: literal<TSR.MappingTriCaster & BlueprintMapping>({
 						device: TSR.DeviceType.TRICASTER,
 						deviceId: TRICASTER_DEVICE_ID,
 						lookahead: LookaheadMode.WHEN_CLEAR,
 						mappingType: TSR.MappingTriCasterType.MIX_OUTPUT,
 						name: 'mix5'
 					}),
-					[prefixLayer(SwitcherAuxLLayer.AuxVideoMixMinus)]: literal<TSR.MappingTriCaster & BlueprintMapping>({
+					[prefixLayer(SwitcherAuxLLayer.VIDEO_MIX_MINUS)]: literal<TSR.MappingTriCaster & BlueprintMapping>({
 						device: TSR.DeviceType.TRICASTER,
 						deviceId: TRICASTER_DEVICE_ID,
 						lookahead: LookaheadMode.WHEN_CLEAR,
@@ -375,14 +375,14 @@ describe('TriCaster', () => {
 
 			const uniformConfig = mock<UniformConfig>()
 			when(uniformConfig.specialInputAuxLLayers).thenReturn({
-				[SpecialInput.ME1_PROGRAM]: SwitcherAuxLLayer.AuxProgram,
-				[SpecialInput.ME3_PROGRAM]: SwitcherAuxLLayer.AuxClean
+				[SpecialInput.ME1_PROGRAM]: SwitcherAuxLLayer.PROGRAM,
+				[SpecialInput.ME3_PROGRAM]: SwitcherAuxLLayer.CLEAN
 			})
 
 			const testee = createTestee({ context: instance(context), uniformConfig: instance(uniformConfig) })
 
 			const timelineObject = testee.getAuxTimelineObject({
-				layer: SwitcherAuxLLayer.AuxVideoMixMinus,
+				layer: SwitcherAuxLLayer.VIDEO_MIX_MINUS,
 				content: {
 					input: SpecialInput.ME3_PROGRAM
 				}
@@ -590,7 +590,7 @@ describe('TriCaster', () => {
 			const result: TSR.TSRTimelineObj[] = testee.getDveTimelineObjects(getBasicDveProps())
 
 			expect(result).toHaveLength(1)
-			expect(result[0].layer).toBe(prefixLayer(SwitcherDveLLayer.DveBoxes))
+			expect(result[0].layer).toBe(prefixLayer(SwitcherDveLLayer.DVE_BOXES))
 		})
 
 		// TODO: Replace with interface

--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -192,7 +192,8 @@ export enum AbstractLLayer {
 export enum SwitcherMixEffectLLayer {
 	Program = 'me_program',
 	Clean = 'me_clean',
-	CleanUSKEffect = 'clean_usk_effect',
+	CleanUskFull = 'clean_usk_full',
+	CleanUskEffect = 'clean_usk_effect',
 	Next = 'me_next',
 	NextJingle = 'me_next_jingle'
 }

--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -183,39 +183,39 @@ export enum SharedGraphicLLayer {
 }
 
 export enum AbstractLLayer {
-	ServerEnablePending = 'server_enable_pending',
+	SERVER_ENABLE_PENDING = 'server_enable_pending',
 	/* Exists to give the Ident UI marker a timeline object so that it gets the startedPlayback callback */
-	IdentMarker = 'ident_marker',
-	AudioBedBaseline = 'audio_bed_baseline'
+	IDENT_MARKER = 'ident_marker',
+	AUDIO_BED_BASELINE = 'audio_bed_baseline'
 }
 
 export enum SwitcherMixEffectLLayer {
-	Program = 'me_program',
-	Clean = 'me_clean',
-	CleanUskFull = 'clean_usk_full',
-	CleanUskEffect = 'clean_usk_effect',
-	Next = 'me_next',
-	NextJingle = 'me_next_jingle'
+	PROGRAM = 'me_program',
+	CLEAN = 'me_clean',
+	CLEAN_USK_FULL = 'clean_usk_full',
+	CLEAN_USK_EFFECT = 'clean_usk_effect',
+	NEXT = 'me_next',
+	NEXT_JINGLE = 'me_next_jingle'
 }
 
 export enum SwitcherAuxLLayer {
-	AuxProgram = 'aux_pgm',
-	AuxClean = 'aux_clean',
-	AuxMixEffect3 = 'aux_mix_effect_3', // AUX set by Sofie, but the M/E is uncontrolled by Sofie
-	AuxWall = 'aux_wall',
-	AuxAR = 'aux_ar',
-	AuxVizOvlIn1 = 'aux_viz_ovl_in_1',
-	AuxVenue = 'aux_venue',
-	AuxLookahead = 'aux_lookahead',
-	AuxDve = 'aux_dve',
-	AuxVideoMixMinus = 'aux_video_mix_minus',
-	AuxScreen = 'aux_screen',
-	AuxServerLookahead = 'aux_server_lookahead'
+	PROGRAM = 'aux_pgm',
+	CLEAN = 'aux_clean',
+	MIX_EFFECT_3 = 'aux_mix_effect_3', // AUX set by Sofie, but the M/E is uncontrolled by Sofie
+	WALL = 'aux_wall',
+	AR = 'aux_ar',
+	VIZ_OVL_IN_1 = 'aux_viz_ovl_in_1',
+	VENUE = 'aux_venue',
+	LOOKAHEAD = 'aux_lookahead',
+	DVE = 'aux_dve',
+	VIDEO_MIX_MINUS = 'aux_video_mix_minus',
+	SCREEN = 'aux_screen',
+	SERVER_LOOKAHEAD = 'aux_server_lookahead'
 }
 
 export enum SwitcherDveLLayer {
-	Dve = 'dve',
-	DveBoxes = 'dve_boxes'
+	DVE = 'dve',
+	DVE_BOXES = 'dve_boxes'
 }
 
 export type SwitcherDskLLayer = `dsk_${number}`

--- a/src/tv2_afvd_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/actions.spec.ts
@@ -139,7 +139,7 @@ const kamPieceInstance_Cut: IBlueprintPieceInstance = {
 			timelineObjects: [
 				literal<TSR.TimelineObjAtemME>({
 					id: '',
-					layer: prefixLayer(SwitcherMixEffectLLayer.Program),
+					layer: prefixLayer(SwitcherMixEffectLLayer.PROGRAM),
 					enable: {
 						start: 0
 					},
@@ -175,7 +175,7 @@ const kamPieceInstance_Mix: IBlueprintPieceInstance = {
 			timelineObjects: [
 				literal<TSR.TimelineObjAtemME>({
 					id: '',
-					layer: prefixLayer(SwitcherMixEffectLLayer.Program),
+					layer: prefixLayer(SwitcherMixEffectLLayer.PROGRAM),
 					enable: {
 						start: 0
 					},
@@ -216,7 +216,7 @@ const kamPieceInstance_Effekt: IBlueprintPieceInstance = {
 			timelineObjects: [
 				literal<TSR.TimelineObjAtemME>({
 					id: '',
-					layer: prefixLayer(SwitcherMixEffectLLayer.Program),
+					layer: prefixLayer(SwitcherMixEffectLLayer.PROGRAM),
 					enable: {
 						start: 0
 					},
@@ -273,7 +273,7 @@ const evsPieceInstance_Cut: IBlueprintPieceInstance = {
 			timelineObjects: [
 				literal<TSR.TimelineObjAtemME>({
 					id: '',
-					layer: prefixLayer(SwitcherMixEffectLLayer.Program),
+					layer: prefixLayer(SwitcherMixEffectLLayer.PROGRAM),
 					enable: {
 						start: 0
 					},
@@ -309,7 +309,7 @@ const evsPieceInstance_Mix: IBlueprintPieceInstance = {
 			timelineObjects: [
 				literal<TSR.TimelineObjAtemME>({
 					id: '',
-					layer: prefixLayer(SwitcherMixEffectLLayer.Program),
+					layer: prefixLayer(SwitcherMixEffectLLayer.PROGRAM),
 					enable: {
 						start: 0
 					},
@@ -350,7 +350,7 @@ const evsPieceInstance_Effekt: IBlueprintPieceInstance = {
 			timelineObjects: [
 				literal<TSR.TimelineObjAtemME>({
 					id: '',
-					layer: prefixLayer(SwitcherMixEffectLLayer.Program),
+					layer: prefixLayer(SwitcherMixEffectLLayer.PROGRAM),
 					enable: {
 						start: 0
 					},
@@ -408,7 +408,7 @@ async function getTransitionPiece(
 function getATEMMEObj(piece: IBlueprintPieceInstance): TSR.TimelineObjAtemME {
 	const atemObj = (piece.piece.content.timelineObjects as TSR.TSRTimelineObj[]).find(
 		(obj) =>
-			obj.layer === prefixLayer(SwitcherMixEffectLLayer.Program) &&
+			obj.layer === prefixLayer(SwitcherMixEffectLLayer.PROGRAM) &&
 			obj.content.deviceType === TSR.DeviceType.ATEM &&
 			obj.content.type === TSR.TimelineContentTypeAtem.ME
 	) as TSR.TimelineObjAtemME | undefined

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -135,7 +135,8 @@ export const defaultStudioConfig: StudioConfig = {
 		PrerollDuration: 2000,
 		OutTransitionDuration: 280,
 		CutToMediaPlayer: 1500,
-		FullGraphicBackground: 36
+		FullGraphicBackground: 36,
+		CleanFeedPrerollDuration: 320
 	},
 	HTMLGraphics: {
 		GraphicURL: 'E:/somepath',

--- a/src/tv2_afvd_showstyle/__tests__/transitions.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/transitions.spec.ts
@@ -111,7 +111,7 @@ function getPieceOnLayerFromPart(segment: BlueprintResultSegment, layer: SourceL
 function getATEMMEObj(piece: IBlueprintPiece): TSR.TimelineObjAtemME {
 	const atemMEObj = (piece!.content!.timelineObjects as TSR.TSRTimelineObj[]).find(
 		(obj) =>
-			obj.layer === prefixLayer(SwitcherMixEffectLLayer.Program) &&
+			obj.layer === prefixLayer(SwitcherMixEffectLLayer.PROGRAM) &&
 			obj.content.deviceType === TSR.DeviceType.ATEM &&
 			obj.content.type === TSR.TimelineContentTypeAtem.ME
 	) as TSR.TimelineObjAtemME

--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -209,7 +209,7 @@ class GlobalAdLibPiecesGenerator {
 					this.context.videoSwitcher.getAuxTimelineObject({
 						enable: { while: '1' },
 						priority: 1,
-						layer: SwitcherAuxLLayer.AuxAR,
+						layer: SwitcherAuxLLayer.AR,
 						content: {
 							input: info.port
 						}
@@ -234,7 +234,7 @@ class GlobalAdLibPiecesGenerator {
 					this.context.videoSwitcher.getAuxTimelineObject({
 						enable: { while: '1' },
 						priority: 1,
-						layer: SwitcherAuxLLayer.AuxVizOvlIn1,
+						layer: SwitcherAuxLLayer.VIZ_OVL_IN_1,
 						content: {
 							input: info.port
 						}
@@ -307,7 +307,7 @@ class GlobalAdLibPiecesGenerator {
 					this.context.videoSwitcher.getAuxTimelineObject({
 						enable: { while: '1' },
 						priority: 1,
-						layer: SwitcherAuxLLayer.AuxAR,
+						layer: SwitcherAuxLLayer.AR,
 						content: {
 							input: info.port
 						}
@@ -513,7 +513,7 @@ function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): Bluepri
 
 			context.videoSwitcher.getAuxTimelineObject({
 				enable: { while: '1' },
-				layer: SwitcherAuxLLayer.AuxLookahead,
+				layer: SwitcherAuxLLayer.LOOKAHEAD,
 				content: {
 					input: context.config.studio.SwitcherSource.Default
 				}
@@ -522,7 +522,7 @@ function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): Bluepri
 				? [
 						context.videoSwitcher.getAuxTimelineObject({
 							enable: { while: '1' },
-							layer: SwitcherAuxLLayer.AuxMixEffect3,
+							layer: SwitcherAuxLLayer.MIX_EFFECT_3,
 							content: {
 								input: SpecialInput.ME3_PROGRAM
 							}
@@ -531,7 +531,7 @@ function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): Bluepri
 				: [
 						context.videoSwitcher.getAuxTimelineObject({
 							enable: { while: '1' },
-							layer: SwitcherAuxLLayer.AuxDve,
+							layer: SwitcherAuxLLayer.DVE,
 							content: {
 								input: SpecialInput.DVE
 							}
@@ -539,7 +539,7 @@ function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): Bluepri
 				  ]),
 			context.videoSwitcher.getAuxTimelineObject({
 				enable: { while: '1' },
-				layer: SwitcherAuxLLayer.AuxVideoMixMinus,
+				layer: SwitcherAuxLLayer.VIDEO_MIX_MINUS,
 				content: {
 					input: context.uniformConfig.mixEffects.program.input
 				}

--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -16,6 +16,7 @@ import {
 	createDskBaseline,
 	CreateDSKBaselineAdlibs,
 	CreateLYDBaseline,
+	findDskFullGfx,
 	findDskJingle,
 	getGraphicBaseline,
 	getMixMinusTimelineObject,
@@ -501,7 +502,8 @@ class GlobalAdLibPiecesGenerator {
 }
 
 function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): BlueprintResultBaseline {
-	const jingleDSK = findDskJingle(context.config)
+	const jingleDsk = findDskJingle(context.config)
+	const fullGfxDsk = findDskFullGfx(context.config)
 
 	return {
 		timelineObjects: _.compact([
@@ -573,7 +575,21 @@ function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): Bluepri
 							keyers: [
 								{
 									onAir: false,
-									config: jingleDSK
+									config: jingleDsk
+								}
+							]
+						}
+				  })
+				: undefined,
+			context.uniformConfig.switcherLLayers.fullUskMixEffect
+				? context.videoSwitcher.getMixEffectTimelineObject({
+						enable: { while: '1' },
+						layer: context.uniformConfig.switcherLLayers.fullUskMixEffect,
+						content: {
+							keyers: [
+								{
+									onAir: false,
+									config: fullGfxDsk
 								}
 							]
 						}

--- a/src/tv2_afvd_showstyle/helpers/pieces/routing.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/routing.ts
@@ -46,7 +46,7 @@ export function EvaluateCueRouting(
 			timelineObjects: _.compact<TSR.TSRTimelineObj[]>([
 				context.videoSwitcher.getAuxTimelineObject({
 					priority: 100,
-					layer: SwitcherAuxLLayer.AuxVizOvlIn1,
+					layer: SwitcherAuxLLayer.VIZ_OVL_IN_1,
 					content: {
 						input: sourceInfo.port
 					}

--- a/src/tv2_afvd_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/config-manifest.spec.ts
@@ -72,7 +72,8 @@ const blankStudioConfig: StudioConfig = {
 		PrerollDuration: 1000,
 		OutTransitionDuration: 1000,
 		CutToMediaPlayer: 1000,
-		FullGraphicBackground: 36
+		FullGraphicBackground: 36,
+		CleanFeedPrerollDuration: 320
 	},
 	HTMLGraphics: {
 		GraphicURL: '',

--- a/src/tv2_afvd_studio/__tests__/graphics.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/graphics.spec.ts
@@ -364,7 +364,7 @@ describe('Graphics', () => {
 		) as TSR.TimelineObjAtemAUX | undefined
 		expect(auxObj).toBeTruthy()
 		expect(auxObj?.enable).toEqual({ start: 0 })
-		expect(auxObj?.layer).toBe(prefixLayer(SwitcherAuxLLayer.AuxVizOvlIn1))
+		expect(auxObj?.layer).toBe(prefixLayer(SwitcherAuxLLayer.VIZ_OVL_IN_1))
 		expect(auxObj?.content.aux.input).toBe(1)
 	})
 

--- a/src/tv2_afvd_studio/__tests__/graphics.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/graphics.spec.ts
@@ -128,7 +128,7 @@ describe('Graphics', () => {
 		expect(piece.lifespan).toBe(PieceLifespan.WithinPart)
 		const content = piece.content!
 		const timeline = content.timelineObjects as TSR.TSRTimelineObj[]
-		expect(timeline).toHaveLength(6) // @todo: this depends on unrelated configuration
+		expect(timeline).toHaveLength(7) // @todo: this depends on unrelated configuration
 		const vizObj = timeline.find(
 			(t) =>
 				t.content.deviceType === TSR.DeviceType.VIZMSE && t.content.type === TSR.TimelineContentTypeVizMSE.ELEMENT_PILOT
@@ -300,7 +300,7 @@ describe('Graphics', () => {
 		expect(piece.lifespan).toBe(PieceLifespan.WithinPart)
 		const content = piece.content!
 		const timeline = content.timelineObjects as TSR.TSRTimelineObj[]
-		expect(timeline).toHaveLength(6)
+		expect(timeline).toHaveLength(7)
 		const vizObj = timeline.find(
 			(t) =>
 				t.content.deviceType === TSR.DeviceType.VIZMSE && t.content.type === TSR.TimelineContentTypeVizMSE.ELEMENT_PILOT

--- a/src/tv2_afvd_studio/config-manifests.ts
+++ b/src/tv2_afvd_studio/config-manifests.ts
@@ -525,6 +525,14 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 		defaultVal: 2000
 	},
 	{
+		id: 'VizPilotGraphics.CleanFeedPrerollDuration',
+		name: 'Fullscreen Pilot Preroll Duration for Clean Feed',
+		description: 'ms of preroll before showing Pilot elements on the Clean Feed',
+		type: ConfigManifestEntryType.INT,
+		required: false,
+		defaultVal: 320
+	},
+	{
 		id: 'PreventOverlayWithFull',
 		name: 'Prevent Overlay with Full',
 		description: 'Stop overlay elements from showing when a Full graphic is on-air',

--- a/src/tv2_afvd_studio/getBaseline.ts
+++ b/src/tv2_afvd_studio/getBaseline.ts
@@ -59,7 +59,7 @@ export function getBaseline(coreContext: IStudioContext): BlueprintResultBaselin
 		}
 	}
 
-	const defaultInput =
+	const defaultInput: number =
 		context.config.studio.SwitcherType === SwitcherType.TRICASTER
 			? context.config.studio.SwitcherSource.Default
 			: AtemSourceIndex.MP1

--- a/src/tv2_afvd_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_afvd_studio/migrations/mappings-defaults.ts
@@ -594,7 +594,14 @@ export const MAPPINGS_ATEM = prefixLayers<TSR.MappingAtem & BlueprintMapping>(AT
 		mappingType: TSR.MappingAtemType.MixEffect,
 		index: 3 // 3 = ME4
 	},
-	[SwitcherMixEffectLLayer.CleanUSKEffect]: {
+	[SwitcherMixEffectLLayer.CleanUskFull]: {
+		device: TSR.DeviceType.ATEM,
+		deviceId: ATEM_DEVICE_ID,
+		lookahead: LookaheadMode.NONE,
+		mappingType: TSR.MappingAtemType.MixEffect,
+		index: 3 // 3 = ME4
+	},
+	[SwitcherMixEffectLLayer.CleanUskEffect]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
@@ -689,7 +696,14 @@ export const MAPPINGS_TRICASTER = prefixLayers<TSR.MappingTriCaster & BlueprintM
 		mappingType: TSR.MappingTriCasterType.ME,
 		name: TRICASTER_CLEAN_ME
 	},
-	[SwitcherMixEffectLLayer.CleanUSKEffect]: {
+	[SwitcherMixEffectLLayer.CleanUskFull]: {
+		device: TSR.DeviceType.TRICASTER,
+		deviceId: TRICASTER_DEVICE_ID,
+		lookahead: LookaheadMode.NONE,
+		mappingType: TSR.MappingTriCasterType.ME,
+		name: TRICASTER_CLEAN_ME
+	},
+	[SwitcherMixEffectLLayer.CleanUskEffect]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,

--- a/src/tv2_afvd_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_afvd_studio/migrations/mappings-defaults.ts
@@ -32,7 +32,7 @@ export const MAPPINGS_ABSTRACT: BlueprintMappings = {
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
 	}),
-	[AbstractLLayer.ServerEnablePending]: literal<TSR.MappingAbstract & BlueprintMapping>({
+	[AbstractLLayer.SERVER_ENABLE_PENDING]: literal<TSR.MappingAbstract & BlueprintMapping>({
 		device: TSR.DeviceType.ABSTRACT,
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
@@ -47,12 +47,12 @@ export const MAPPINGS_ABSTRACT: BlueprintMappings = {
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
 	}),
-	[AbstractLLayer.IdentMarker]: literal<TSR.MappingAbstract & BlueprintMapping>({
+	[AbstractLLayer.IDENT_MARKER]: literal<TSR.MappingAbstract & BlueprintMapping>({
 		device: TSR.DeviceType.ABSTRACT,
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
 	}),
-	[AbstractLLayer.AudioBedBaseline]: literal<TSR.MappingAbstract & BlueprintMapping>({
+	[AbstractLLayer.AUDIO_BED_BASELINE]: literal<TSR.MappingAbstract & BlueprintMapping>({
 		device: TSR.DeviceType.ABSTRACT,
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
@@ -580,91 +580,91 @@ export const MAPPINGS_GRAPHICS: BlueprintMappings = {
 }
 
 export const MAPPINGS_ATEM = prefixLayers<TSR.MappingAtem & BlueprintMapping>(ATEM_LAYER_PREFIX, {
-	[SwitcherMixEffectLLayer.Program]: {
+	[SwitcherMixEffectLLayer.PROGRAM]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.MixEffect,
 		index: 0 // 0 = ME1
 	},
-	[SwitcherMixEffectLLayer.Clean]: {
+	[SwitcherMixEffectLLayer.CLEAN]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.MixEffect,
 		index: 3 // 3 = ME4
 	},
-	[SwitcherMixEffectLLayer.CleanUskFull]: {
+	[SwitcherMixEffectLLayer.CLEAN_USK_FULL]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.MixEffect,
 		index: 3 // 3 = ME4
 	},
-	[SwitcherMixEffectLLayer.CleanUskEffect]: {
+	[SwitcherMixEffectLLayer.CLEAN_USK_EFFECT]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.MixEffect,
 		index: 3 // 3 = ME4
 	},
-	[SwitcherAuxLLayer.AuxProgram]: {
+	[SwitcherAuxLLayer.PROGRAM]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 0 // 0 = out 1
 	},
-	[SwitcherAuxLLayer.AuxClean]: {
+	[SwitcherAuxLLayer.CLEAN]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 1 // 1 = out 2
 	},
-	[SwitcherAuxLLayer.AuxAR]: {
+	[SwitcherAuxLLayer.AR]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 3 // 3 = out 4
 	},
-	[SwitcherAuxLLayer.AuxVizOvlIn1]: {
+	[SwitcherAuxLLayer.VIZ_OVL_IN_1]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 4 // 4 = out 5
 	},
-	[SwitcherAuxLLayer.AuxVideoMixMinus]: {
+	[SwitcherAuxLLayer.VIDEO_MIX_MINUS]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 6 // 6 = out 7
 	},
-	[SwitcherAuxLLayer.AuxLookahead]: {
+	[SwitcherAuxLLayer.LOOKAHEAD]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 10 // 10 = out 11
 	},
-	[SwitcherAuxLLayer.AuxDve]: {
+	[SwitcherAuxLLayer.DVE]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 11 // 11 = out 12
 	},
-	[SwitcherDveLLayer.Dve]: {
+	[SwitcherDveLLayer.DVE]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.SuperSourceProperties,
 		index: 0 // 0 = SS
 	},
-	[SwitcherDveLLayer.DveBoxes]: {
+	[SwitcherDveLLayer.DVE_BOXES]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: ATEM_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR, // TODO - verify
@@ -682,98 +682,98 @@ export const MAPPINGS_ATEM = prefixLayers<TSR.MappingAtem & BlueprintMapping>(AT
 })
 
 export const MAPPINGS_TRICASTER = prefixLayers<TSR.MappingTriCaster & BlueprintMapping>(TRICASTER_LAYER_PREFIX, {
-	[SwitcherMixEffectLLayer.Program]: {
+	[SwitcherMixEffectLLayer.PROGRAM]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingTriCasterType.ME,
 		name: TRICASTER_PROGRAM_ME
 	},
-	[SwitcherMixEffectLLayer.Clean]: {
+	[SwitcherMixEffectLLayer.CLEAN]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingTriCasterType.ME,
 		name: TRICASTER_CLEAN_ME
 	},
-	[SwitcherMixEffectLLayer.CleanUskFull]: {
+	[SwitcherMixEffectLLayer.CLEAN_USK_FULL]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingTriCasterType.ME,
 		name: TRICASTER_CLEAN_ME
 	},
-	[SwitcherMixEffectLLayer.CleanUskEffect]: {
+	[SwitcherMixEffectLLayer.CLEAN_USK_EFFECT]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingTriCasterType.ME,
 		name: TRICASTER_CLEAN_ME
 	},
-	[SwitcherAuxLLayer.AuxProgram]: {
+	[SwitcherAuxLLayer.PROGRAM]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingTriCasterType.MIX_OUTPUT,
 		name: 'mix1'
 	},
-	[SwitcherAuxLLayer.AuxClean]: {
+	[SwitcherAuxLLayer.CLEAN]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingTriCasterType.MIX_OUTPUT,
 		name: 'mix2'
 	},
-	[SwitcherAuxLLayer.AuxWall]: {
+	[SwitcherAuxLLayer.WALL]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingTriCasterType.MIX_OUTPUT,
 		name: 'mix3'
 	},
-	[SwitcherAuxLLayer.AuxAR]: {
+	[SwitcherAuxLLayer.AR]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR,
 		mappingType: TSR.MappingTriCasterType.MIX_OUTPUT,
 		name: 'mix4'
 	},
-	[SwitcherAuxLLayer.AuxVizOvlIn1]: {
+	[SwitcherAuxLLayer.VIZ_OVL_IN_1]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR,
 		mappingType: TSR.MappingTriCasterType.MIX_OUTPUT,
 		name: 'mix5'
 	},
-	[SwitcherAuxLLayer.AuxLookahead]: {
+	[SwitcherAuxLLayer.LOOKAHEAD]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR,
 		mappingType: TSR.MappingTriCasterType.MIX_OUTPUT,
 		name: 'mix6'
 	},
-	[SwitcherAuxLLayer.AuxMixEffect3]: {
+	[SwitcherAuxLLayer.MIX_EFFECT_3]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR,
 		mappingType: TSR.MappingTriCasterType.MIX_OUTPUT,
 		name: 'mix7'
 	},
-	[SwitcherAuxLLayer.AuxVideoMixMinus]: {
+	[SwitcherAuxLLayer.VIDEO_MIX_MINUS]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingTriCasterType.MIX_OUTPUT,
 		name: 'mix8'
 	},
-	[SwitcherDveLLayer.Dve]: {
+	[SwitcherDveLLayer.DVE]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingTriCasterType.ME,
 		name: TRICASTER_DVE_ME
 	},
-	[SwitcherDveLLayer.DveBoxes]: {
+	[SwitcherDveLLayer.DVE_BOXES]: {
 		device: TSR.DeviceType.TRICASTER,
 		deviceId: TRICASTER_DEVICE_ID,
 		lookahead: LookaheadMode.WHEN_CLEAR,

--- a/src/tv2_afvd_studio/uniformConfig.ts
+++ b/src/tv2_afvd_studio/uniformConfig.ts
@@ -4,24 +4,24 @@ import { SwitcherAuxLLayer, SwitcherMixEffectLLayer } from 'tv2-constants'
 const MIX_EFFECTS: UniformConfig['mixEffects'] = {
 	program: {
 		input: SpecialInput.ME1_PROGRAM,
-		mixEffectLayer: SwitcherMixEffectLLayer.Program,
-		auxLayer: SwitcherAuxLLayer.AuxProgram
+		mixEffectLayer: SwitcherMixEffectLLayer.PROGRAM,
+		auxLayer: SwitcherAuxLLayer.PROGRAM
 	},
 	clean: {
 		input: SpecialInput.ME4_PROGRAM,
-		mixEffectLayer: SwitcherMixEffectLLayer.Clean,
-		auxLayer: SwitcherAuxLLayer.AuxClean
+		mixEffectLayer: SwitcherMixEffectLLayer.CLEAN,
+		auxLayer: SwitcherAuxLLayer.CLEAN
 	}
 }
 
 export const GALLERY_UNIFORM_CONFIG: UniformConfig = {
 	switcherLLayers: {
-		primaryMixEffect: SwitcherMixEffectLLayer.Program,
-		primaryMixEffectClone: SwitcherMixEffectLLayer.Clean,
-		jingleUskMixEffect: SwitcherMixEffectLLayer.CleanUskEffect,
-		fullUskMixEffect: SwitcherMixEffectLLayer.CleanUskFull,
-		nextAux: SwitcherAuxLLayer.AuxLookahead,
-		mixMinusAux: SwitcherAuxLLayer.AuxVideoMixMinus
+		primaryMixEffect: SwitcherMixEffectLLayer.PROGRAM,
+		primaryMixEffectClone: SwitcherMixEffectLLayer.CLEAN,
+		jingleUskMixEffect: SwitcherMixEffectLLayer.CLEAN_USK_EFFECT,
+		fullUskMixEffect: SwitcherMixEffectLLayer.CLEAN_USK_FULL,
+		nextAux: SwitcherAuxLLayer.LOOKAHEAD,
+		mixMinusAux: SwitcherAuxLLayer.VIDEO_MIX_MINUS
 	},
 	mixEffects: MIX_EFFECTS,
 	specialInputAuxLLayers: {

--- a/src/tv2_afvd_studio/uniformConfig.ts
+++ b/src/tv2_afvd_studio/uniformConfig.ts
@@ -18,7 +18,8 @@ export const GALLERY_UNIFORM_CONFIG: UniformConfig = {
 	switcherLLayers: {
 		primaryMixEffect: SwitcherMixEffectLLayer.Program,
 		primaryMixEffectClone: SwitcherMixEffectLLayer.Clean,
-		jingleUskMixEffect: SwitcherMixEffectLLayer.CleanUSKEffect,
+		jingleUskMixEffect: SwitcherMixEffectLLayer.CleanUskEffect,
+		fullUskMixEffect: SwitcherMixEffectLLayer.CleanUskFull,
 		nextAux: SwitcherAuxLLayer.AuxLookahead,
 		mixMinusAux: SwitcherAuxLLayer.AuxVideoMixMinus
 	},

--- a/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
@@ -93,7 +93,7 @@ const kamPieceInstance: IBlueprintPieceInstance<PieceMetaData> = {
 					enable: {
 						start: 0
 					},
-					layer: prefixLayer(SwitcherMixEffectLLayer.Clean),
+					layer: prefixLayer(SwitcherMixEffectLLayer.CLEAN),
 					content: {
 						deviceType: TSR.DeviceType.ATEM,
 						type: TSR.TimelineContentTypeAtem.ME,
@@ -397,7 +397,7 @@ function validateNextPartExistsWithPreviousPartKeepaliveDuration(
 function getATEMMEObj(piece: IBlueprintPieceInstance): TSR.TimelineObjAtemME {
 	const atemObj = (piece.piece.content.timelineObjects as TSR.TSRTimelineObj[]).find(
 		(obj) =>
-			obj.layer === prefixLayer(SwitcherMixEffectLLayer.Clean) &&
+			obj.layer === prefixLayer(SwitcherMixEffectLLayer.CLEAN) &&
 			obj.content.deviceType === TSR.DeviceType.ATEM &&
 			obj.content.type === TSR.TimelineContentTypeAtem.ME
 	) as TSR.TimelineObjAtemME | undefined

--- a/src/tv2_offtube_showstyle/cues/OfftubePgmClean.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubePgmClean.ts
@@ -43,7 +43,7 @@ export function OfftubeEvaluatePgmClean(
 			timelineObjects: literal<TimelineObjectCoreExt[]>([
 				context.videoSwitcher.getAuxTimelineObject({
 					enable: { while: '1' },
-					layer: SwitcherAuxLLayer.AuxClean,
+					layer: SwitcherAuxLLayer.CLEAN,
 					content: {
 						input: sourceInfo.port
 					}

--- a/src/tv2_offtube_showstyle/getRundown.ts
+++ b/src/tv2_offtube_showstyle/getRundown.ts
@@ -607,7 +607,7 @@ function getBaseline(context: ShowStyleContext<OfftubeBlueprintConfig>): Bluepri
 				: undefined,
 			context.videoSwitcher.getAuxTimelineObject({
 				enable: { while: '1' },
-				layer: SwitcherAuxLLayer.AuxScreen,
+				layer: SwitcherAuxLLayer.SCREEN,
 				content: {
 					input: context.config.studio.SwitcherSource.Loop
 				}

--- a/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
@@ -68,7 +68,8 @@ const blankStudioConfig: OfftubeStudioConfig = {
 		PrerollDuration: 1000,
 		OutTransitionDuration: 1000,
 		CutToMediaPlayer: 1000,
-		FullGraphicBackground: 0
+		FullGraphicBackground: 0,
+		CleanFeedPrerollDuration: 320
 	},
 	HTMLGraphics: {
 		GraphicURL: '',

--- a/src/tv2_offtube_studio/config-manifests.ts
+++ b/src/tv2_offtube_studio/config-manifests.ts
@@ -366,6 +366,14 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 		defaultVal: 2000
 	},
 	{
+		id: 'VizPilotGraphics.CleanFeedPrerollDuration',
+		name: 'Fullscreen Pilot Preroll Duration for Clean Feed',
+		description: 'ms of preroll before showing Pilot elements on the Clean Feed',
+		type: ConfigManifestEntryType.INT,
+		required: false,
+		defaultVal: 320
+	},
+	{
 		id: 'VizPilotGraphics.FullGraphicBackground',
 		name: 'Full frame grafik background source',
 		description: 'Video Switcher source for mos full-frame grafik background source',

--- a/src/tv2_offtube_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_offtube_studio/migrations/mappings-defaults.ts
@@ -18,7 +18,7 @@ const MAPPINGS_ABSTRACT: BlueprintMappings = {
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
 	}),
-	[AbstractLLayer.ServerEnablePending]: literal<TSR.MappingAbstract & BlueprintMapping>({
+	[AbstractLLayer.SERVER_ENABLE_PENDING]: literal<TSR.MappingAbstract & BlueprintMapping>({
 		device: TSR.DeviceType.ABSTRACT,
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
@@ -33,12 +33,12 @@ const MAPPINGS_ABSTRACT: BlueprintMappings = {
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
 	}),
-	[AbstractLLayer.IdentMarker]: literal<TSR.MappingAbstract & BlueprintMapping>({
+	[AbstractLLayer.IDENT_MARKER]: literal<TSR.MappingAbstract & BlueprintMapping>({
 		device: TSR.DeviceType.ABSTRACT,
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
 	}),
-	[AbstractLLayer.AudioBedBaseline]: literal<TSR.MappingAbstract & BlueprintMapping>({
+	[AbstractLLayer.AUDIO_BED_BASELINE]: literal<TSR.MappingAbstract & BlueprintMapping>({
 		device: TSR.DeviceType.ABSTRACT,
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
@@ -447,21 +447,21 @@ const MAPPINGS_GRAPHICS: BlueprintMappings = {
 }
 
 const MAPPINGS_ATEM: Record<string, TSR.MappingAtem & BlueprintMapping> = prefixLayers(ATEM_LAYER_PREFIX, {
-	[SwitcherMixEffectLLayer.Clean]: {
+	[SwitcherMixEffectLLayer.CLEAN]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.MixEffect,
 		index: 1 // 1 = ME2
 	},
-	[SwitcherMixEffectLLayer.Program]: {
+	[SwitcherMixEffectLLayer.PROGRAM]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.MixEffect,
 		index: 0 // 0 = ME1
 	},
-	[SwitcherMixEffectLLayer.Next]: {
+	[SwitcherMixEffectLLayer.NEXT]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
 		lookahead: LookaheadMode.WHEN_CLEAR,
@@ -469,7 +469,7 @@ const MAPPINGS_ATEM: Record<string, TSR.MappingAtem & BlueprintMapping> = prefix
 		index: 0, // 0 = ME1
 		lookaheadDepth: 1
 	},
-	[SwitcherMixEffectLLayer.NextJingle]: {
+	[SwitcherMixEffectLLayer.NEXT_JINGLE]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
 		lookahead: LookaheadMode.PRELOAD,
@@ -477,28 +477,28 @@ const MAPPINGS_ATEM: Record<string, TSR.MappingAtem & BlueprintMapping> = prefix
 		mappingType: TSR.MappingAtemType.MixEffect,
 		index: 0 // 0 = ME1
 	},
-	[SwitcherAuxLLayer.AuxClean]: {
+	[SwitcherAuxLLayer.CLEAN]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 0 // 0 = out 1
 	},
-	[SwitcherAuxLLayer.AuxScreen]: {
+	[SwitcherAuxLLayer.SCREEN]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 1 // 1 = out 2
 	},
-	[SwitcherAuxLLayer.AuxServerLookahead]: {
+	[SwitcherAuxLLayer.SERVER_LOOKAHEAD]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
 		lookahead: LookaheadMode.WHEN_CLEAR,
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 2 // 2 = out 3
 	},
-	[SwitcherDveLLayer.Dve]: {
+	[SwitcherDveLLayer.DVE]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
 		lookahead: LookaheadMode.WHEN_CLEAR,
@@ -506,7 +506,7 @@ const MAPPINGS_ATEM: Record<string, TSR.MappingAtem & BlueprintMapping> = prefix
 		mappingType: TSR.MappingAtemType.SuperSourceProperties,
 		index: 0 // 0 = SS
 	},
-	[SwitcherDveLLayer.DveBoxes]: {
+	[SwitcherDveLLayer.DVE_BOXES]: {
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
 		lookahead: LookaheadMode.WHEN_CLEAR,

--- a/src/tv2_offtube_studio/uniformConfig.ts
+++ b/src/tv2_offtube_studio/uniformConfig.ts
@@ -2,20 +2,20 @@ import { getSpecialLayers, SpecialInput, UniformConfig } from 'tv2-common'
 import { SwitcherAuxLLayer, SwitcherMixEffectLLayer } from 'tv2-constants'
 
 const MIX_EFFECTS: UniformConfig['mixEffects'] = {
-	program: { input: SpecialInput.ME1_PROGRAM, mixEffectLayer: SwitcherMixEffectLLayer.Program },
+	program: { input: SpecialInput.ME1_PROGRAM, mixEffectLayer: SwitcherMixEffectLLayer.PROGRAM },
 	clean: {
 		input: SpecialInput.ME4_PROGRAM,
-		mixEffectLayer: SwitcherMixEffectLLayer.Clean,
-		auxLayer: SwitcherAuxLLayer.AuxClean
+		mixEffectLayer: SwitcherMixEffectLLayer.CLEAN,
+		auxLayer: SwitcherAuxLLayer.CLEAN
 	}
 }
 
 export const QBOX_UNIFORM_CONFIG: UniformConfig = {
 	switcherLLayers: {
-		primaryMixEffect: SwitcherMixEffectLLayer.Clean,
-		nextServerAux: SwitcherAuxLLayer.AuxServerLookahead,
-		nextPreviewMixEffect: SwitcherMixEffectLLayer.Next,
-		jingleNextMixEffect: SwitcherMixEffectLLayer.NextJingle
+		primaryMixEffect: SwitcherMixEffectLLayer.CLEAN,
+		nextServerAux: SwitcherAuxLLayer.SERVER_LOOKAHEAD,
+		nextPreviewMixEffect: SwitcherMixEffectLLayer.NEXT,
+		jingleNextMixEffect: SwitcherMixEffectLLayer.NEXT_JINGLE
 	},
 	mixEffects: MIX_EFFECTS,
 	specialInputAuxLLayers: {


### PR DESCRIPTION
Makes the fullscreen graphics show on the clean feed through a USK. Delay is applied to account for the time that overlays from the previous part need before disappearing.
Note: I'm not very happy about the addition to `getDskOnAirTimelineObjects`, but I also couldn't come up with a good design pattern or just any better, yet simple, way to break that logic down.
(Version bump to cause migrations to create the added layers)