### PR TITLE
fix: SOF-1403 adlibing DVEs before planned ones

### DIFF
--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -727,6 +727,7 @@ async function executeActionSelectDVELayout<
 	if (
 		!nextPart ||
 		!nextDVE ||
+		!nextDVE.dynamicallyInserted ||
 		!meta ||
 		nextPart.segmentId !== (await context.core.getPartInstance('current'))?.segmentId
 	) {

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -788,6 +788,7 @@ async function executeActionSelectDVELayout<
 
 	const newMetaData2: DVEPieceMetaData = {
 		...meta,
+		sources: { ...sources, ...meta.sources },
 		config: userData.config,
 		sisyfosPersistMetaData: {
 			sisyfosLayers: []
@@ -799,6 +800,7 @@ async function executeActionSelectDVELayout<
 		...nextDVE.piece,
 		content: pieceContent.content,
 		metaData: newMetaData2,
+		name: userData.config.DVEName,
 		tags: [
 			GetTagForDVE('', userData.config.DVEName, sources),
 			GetTagForDVENext('', userData.config.DVEName, sources),

--- a/src/tv2-common/content/dve.ts
+++ b/src/tv2-common/content/dve.ts
@@ -30,7 +30,6 @@ import {
 } from 'tv2-common'
 import { ControlClasses, MEDIA_PLAYER_AUTO, SharedGraphicLLayer, SourceType } from 'tv2-constants'
 import * as _ from 'underscore'
-import { AtemSourceIndex } from '../../types/atem'
 import { ActionSelectDVE } from '../actions'
 import {
 	CreateHTMLRendererContent,
@@ -399,7 +398,7 @@ const setBoxSource = (
 
 const setBoxToBlack = (boxConfig: BoxConfig, boxSources: BoxSources) => {
 	setBoxSource(boxConfig, boxSources, {
-		port: AtemSourceIndex.Blk,
+		port: SpecialInput.BLACK,
 		sourceLayerType: SourceLayerType.UNKNOWN
 	})
 }

--- a/src/tv2-common/videoSwitchers/TriCaster.ts
+++ b/src/tv2-common/videoSwitchers/TriCaster.ts
@@ -22,6 +22,7 @@ import { VideoSwitcherBase } from './VideoSwitcher'
 const MAX_REGULAR_INPUT_NUMBER = 1000 // everything >= is assumed a special input
 
 const SPECIAL_INPUT_MAP: Record<SpecialInput, TSR.TriCasterSourceName | TSR.TriCasterMixEffectName> = {
+	[SpecialInput.BLACK]: 'black',
 	[SpecialInput.ME1_PROGRAM]: 'v1',
 	[SpecialInput.ME2_PROGRAM]: 'v2',
 	[SpecialInput.ME3_PROGRAM]: 'v3',
@@ -327,10 +328,14 @@ export class TriCaster extends VideoSwitcherBase {
 		if (typeof input === 'undefined') {
 			return undefined
 		}
+		const specialSourceName = SPECIAL_INPUT_MAP[input]
+		if (specialSourceName) {
+			return specialSourceName
+		}
 		if (input < MAX_REGULAR_INPUT_NUMBER) {
 			return `input${input as number}`
 		}
-		return SPECIAL_INPUT_MAP[input] ?? 'black'
+		return 'black'
 	}
 
 	private getInputNameForMatrix(input: number | SpecialInput): TSR.TriCasterSourceName | TSR.TriCasterMixOutputName {

--- a/src/tv2-common/videoSwitchers/__tests__/TriCaster.spec.ts
+++ b/src/tv2-common/videoSwitchers/__tests__/TriCaster.spec.ts
@@ -599,7 +599,7 @@ describe('TriCaster', () => {
 				content: {
 					boxes: boxes ?? [{ enabled: false }, { enabled: false }, { enabled: false }, { enabled: false }],
 					template: {},
-					artFillSource: 0,
+					artFillSource: 5,
 					artCutSource: 0
 				}
 			}

--- a/src/tv2-common/videoSwitchers/types.ts
+++ b/src/tv2-common/videoSwitchers/types.ts
@@ -10,6 +10,7 @@ export enum SwitcherType {
 
 /** Using Atem values for compatibility */
 export enum SpecialInput {
+	BLACK = AtemSourceIndex.Blk,
 	ME1_PROGRAM = AtemSourceIndex.Prg1,
 	ME2_PROGRAM = AtemSourceIndex.Prg2,
 	ME3_PROGRAM = AtemSourceIndex.Prg3,


### PR DESCRIPTION
Instead of modifying layout of a planned DVE, makes the DVE adlib action queue a new part.
When modifying a dynamically inserted DVE, modifies the piece name, and fills in sources that may have not been defined in the previous layout.
Fixes a minor TriCaster-related bug where `input0` (non-existent in TriCaster) was selected instead of `black`