### PR TITLE
fix: SOF-1404 controlling ATEM's USK above 1

### DIFF
--- a/src/tv2-common/videoSwitchers/Atem.ts
+++ b/src/tv2-common/videoSwitchers/Atem.ts
@@ -259,22 +259,31 @@ export class Atem extends VideoSwitcherBase {
 				}
 		}
 	}
-	private getUpstreamKeyers(keyers: Keyer[]) {
+	private getUpstreamKeyers(keyers: Keyer[]): TSR.TimelineObjAtemME['content']['me']['upstreamKeyers'] {
 		if (!keyers?.length) {
 			return
 		}
-		return keyers.map((keyer) => ({
-			upstreamKeyerId: keyer.config.Number,
-			onAir: keyer.onAir,
-			mixEffectKeyType: 0,
-			flyEnabled: false,
-			fillSource: keyer.config.Fill,
-			cutSource: keyer.config.Key,
-			maskEnabled: false,
-			lumaSettings: {
-				clip: keyer.config.Clip * 10, // input is percents (0-100), atem uses 1-000
-				gain: keyer.config.Gain * 10 // input is percents (0-100), atem uses 1-000
+		const result: TSR.TimelineObjAtemME['content']['me']['upstreamKeyers'] = []
+		for (const keyer of keyers) {
+			result[keyer.config.Number] = {
+				upstreamKeyerId: keyer.config.Number,
+				onAir: keyer.onAir,
+				mixEffectKeyType: 0,
+				flyEnabled: false,
+				fillSource: keyer.config.Fill,
+				cutSource: keyer.config.Key,
+				maskEnabled: false,
+				lumaSettings: {
+					clip: keyer.config.Clip * 10, // input is percents (0-100), atem uses 1-000
+					gain: keyer.config.Gain * 10 // input is percents (0-100), atem uses 1-000
+				}
 			}
-		}))
+		}
+		for (let i = 0; i < keyers.length; ++i) {
+			result[i] = result[i] ?? {
+				upstreamKeyerId: i
+			}
+		}
+		return result
 	}
 }

--- a/src/tv2-common/videoSwitchers/__tests__/Atem.spec.ts
+++ b/src/tv2-common/videoSwitchers/__tests__/Atem.spec.ts
@@ -309,6 +309,116 @@ describe('ATEM', () => {
 				}
 			})
 		})
+
+		test('fills in blank keyers', () => {
+			const atem = setupAtem()
+			const timelineObject = atem.getMixEffectTimelineObject({
+				layer: SwitcherMixEffectLLayer.PROGRAM,
+				content: {
+					keyers: [
+						{
+							onAir: true,
+							config: {
+								Number: 1,
+								Fill: 5,
+								Key: 6,
+								Clip: 125,
+								Gain: 1
+							}
+						}
+					]
+				}
+			})
+			expect(timelineObject).toMatchObject({
+				content: {
+					me: {
+						upstreamKeyers: [
+							{
+								upstreamKeyerId: 0
+							},
+							{
+								upstreamKeyerId: 1,
+								onAir: true,
+								mixEffectKeyType: 0,
+								flyEnabled: false,
+								fillSource: 5,
+								cutSource: 6,
+								maskEnabled: false,
+								lumaSettings: {
+									clip: 1250,
+									gain: 10
+								}
+							}
+						]
+					}
+				}
+			})
+		})
+
+		test('supports more than one keyer and reorders them', () => {
+			const atem = setupAtem()
+			const timelineObject = atem.getMixEffectTimelineObject({
+				layer: SwitcherMixEffectLLayer.PROGRAM,
+				content: {
+					keyers: [
+						{
+							onAir: true,
+							config: {
+								Number: 1,
+								Fill: 5,
+								Key: 6,
+								Clip: 125,
+								Gain: 1
+							}
+						},
+						{
+							onAir: true,
+							config: {
+								Number: 0,
+								Fill: 1,
+								Key: 2,
+								Clip: 125,
+								Gain: 1
+							}
+						}
+					]
+				}
+			})
+			expect(timelineObject).toMatchObject({
+				content: {
+					me: {
+						upstreamKeyers: [
+							{
+								upstreamKeyerId: 0,
+								onAir: true,
+								mixEffectKeyType: 0,
+								flyEnabled: false,
+								fillSource: 1,
+								cutSource: 2,
+								maskEnabled: false,
+								lumaSettings: {
+									clip: 1250,
+									gain: 10
+								}
+							},
+							{
+								upstreamKeyerId: 1,
+								onAir: true,
+								mixEffectKeyType: 0,
+								flyEnabled: false,
+								fillSource: 5,
+								cutSource: 6,
+								maskEnabled: false,
+								lumaSettings: {
+									clip: 1250,
+									gain: 10
+								}
+							}
+						]
+					}
+				}
+			})
+		})
 	})
 
 	describe('Aux', () => {


### PR DESCRIPTION
Fixes how timeline objects controlling Upstream Keyers are generated
(The indexes in the upstreamKeyers array are used by TSR instead of the `upstreamKeyerId`, so we need to fill the array with blank objects when controlling only the higher USKs)