### PR TITLE
SOF-1374 Don't recall LIVEs that has been cut directly.

### DIFF
--- a/src/tv2-common/actions/CoreActionExecutionContext.ts
+++ b/src/tv2-common/actions/CoreActionExecutionContext.ts
@@ -198,6 +198,11 @@ export class CoreActionExecutionContext implements ITV2ActionExecutionContext {
 			}
 		}
 
+		piece.metaData = {
+			...piece.metaData,
+			modifiedByAction: true
+		}
+
 		// Regardless of above, let core handle errors
 		return this.core.updatePieceInstance(pieceInstanceId, piece) as Promise<IBlueprintPieceInstance<PieceMetaData>>
 	}

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -1073,7 +1073,7 @@ async function executePiece<
 		if (isServerInCurrentPart && !shouldBeQueued) {
 			await context.core.takeAfterExecuteAction(true)
 		}
-	} else if (currentPiece) {
+	} else if (currentPiece && currentPiece.piece.sourceLayerId !== settings.SourceLayers.Live) {
 		pieceToExecute.externalId = currentPiece.piece.externalId
 		pieceToExecute.enable = currentPiece.piece.enable
 		const currentMetaData = currentPiece.piece.metaData!

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -1039,7 +1039,7 @@ async function executeActionCutToCamera<
 		}
 	}
 
-	await executePiece(context, settings, kamPiece, !userData.cutDirectly, part)
+	await executePiece(context, settings, kamPiece, settings.SourceLayers.Cam, !userData.cutDirectly, part)
 }
 
 async function executePiece<
@@ -1049,6 +1049,7 @@ async function executePiece<
 	context: ActionExecutionContext<ShowStyleConfig>,
 	settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>,
 	pieceToExecute: IBlueprintPiece<PieceMetaData>,
+	sourceLayerToFindCurrentPieceOn: string,
 	shouldBeQueued: boolean,
 	partToQueue: IBlueprintPart
 ) {
@@ -1057,9 +1058,8 @@ async function executePiece<
 		(p) => p.piece.sourceLayerId === settings.SourceLayers.Server || p.piece.sourceLayerId === settings.SourceLayers.VO
 	)
 
-	const layersWithCutDirect: string[] = [settings.SourceLayers.Live, settings.SourceLayers.Cam]
-	const currentPiece: IBlueprintPieceInstance<PieceMetaData> | undefined = currentPieceInstances.find((p) =>
-		layersWithCutDirect.includes(p.piece.sourceLayerId)
+	const currentPiece: IBlueprintPieceInstance<PieceMetaData> | undefined = currentPieceInstances.find(
+		(p) => sourceLayerToFindCurrentPieceOn === p.piece.sourceLayerId
 	)
 
 	if (shouldBeQueued || isServerInCurrentPart) {
@@ -1196,7 +1196,7 @@ async function executeActionCutToRemote<
 		}
 	}
 
-	await executePiece(context, settings, remotePiece, !userData.cutDirectly, part)
+	await executePiece(context, settings, remotePiece, settings.SourceLayers.Live, !userData.cutDirectly, part)
 }
 
 async function executeActionCutSourceToBox<

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -1058,8 +1058,9 @@ async function executePiece<
 	)
 
 	const layersWithCutDirect: string[] = [settings.SourceLayers.Live, settings.SourceLayers.Cam]
-	const currentPiece: IBlueprintPieceInstance<PieceMetaData> | undefined = currentPieceInstances.find((p) =>
-		layersWithCutDirect.includes(p.piece.sourceLayerId)
+	const currentPiece: IBlueprintPieceInstance<PieceMetaData> | undefined = findLastPlayingPieceInstance(
+		currentPieceInstances,
+		layersWithCutDirect
 	)
 
 	if (shouldBeQueued || isServerInCurrentPart) {
@@ -1073,7 +1074,7 @@ async function executePiece<
 		if (isServerInCurrentPart && !shouldBeQueued) {
 			await context.core.takeAfterExecuteAction(true)
 		}
-	} else if (currentPiece && currentPiece.piece.sourceLayerId !== settings.SourceLayers.Live) {
+	} else if (currentPiece && !isPlannedLivePiece(currentPiece, settings.SourceLayers.Live)) {
 		pieceToExecute.externalId = currentPiece.piece.externalId
 		pieceToExecute.enable = currentPiece.piece.enable
 		const currentMetaData = currentPiece.piece.metaData!
@@ -1107,6 +1108,32 @@ async function executePiece<
 		pieceToExecute.enable = { start: 'now' }
 		await context.core.insertPiece('current', pieceToExecute)
 	}
+}
+
+function isPlannedLivePiece(currentPiece: IBlueprintPieceInstance<PieceMetaData>, liveSourceLayerId: string) {
+	return (
+		currentPiece.piece.sourceLayerId === liveSourceLayerId &&
+		!currentPiece.piece.metaData?.modifiedByAction &&
+		!currentPiece?.dynamicallyInserted
+	)
+}
+
+function findLastPlayingPieceInstance(
+	currentPieceInstances: Array<IBlueprintPieceInstance<PieceMetaData>>,
+	sourceLayerIds: string[]
+): IBlueprintPieceInstance<PieceMetaData> | undefined {
+	const playingPiecesOnSelectedLayers = currentPieceInstances.filter(
+		(p) => !p.stoppedPlayback && sourceLayerIds.includes(p.piece.sourceLayerId)
+	)
+	if (playingPiecesOnSelectedLayers.length < 2) {
+		return playingPiecesOnSelectedLayers[0]
+	}
+	return playingPiecesOnSelectedLayers.reduce((prev, current) =>
+		(prev.startedPlayback ?? prev.dynamicallyInserted?.time ?? Infinity) >
+		(current.startedPlayback ?? current.dynamicallyInserted?.time ?? Infinity)
+			? prev
+			: current
+	)
 }
 
 async function stopGraphicPiecesThatShouldEndWithPart(
@@ -1649,7 +1676,10 @@ async function executeActionRecallLastLive<
 ) {
 	const lastLive = await context.core.findLastPieceOnLayer(settings.SourceLayers.Live, {
 		originalOnly: true,
-		excludeCurrentPart: false
+		excludeCurrentPart: false,
+		pieceMetaDataFilter: {
+			modifiedByAction: { $ne: true }
+		}
 	})
 
 	if (!lastLive) {

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -1039,7 +1039,7 @@ async function executeActionCutToCamera<
 		}
 	}
 
-	await executePiece(context, settings, kamPiece, settings.SourceLayers.Cam, !userData.cutDirectly, part)
+	await executePiece(context, settings, kamPiece, !userData.cutDirectly, part)
 }
 
 async function executePiece<
@@ -1049,7 +1049,6 @@ async function executePiece<
 	context: ActionExecutionContext<ShowStyleConfig>,
 	settings: ActionExecutionSettings<StudioConfig, ShowStyleConfig>,
 	pieceToExecute: IBlueprintPiece<PieceMetaData>,
-	sourceLayerToFindCurrentPieceOn: string,
 	shouldBeQueued: boolean,
 	partToQueue: IBlueprintPart
 ) {
@@ -1058,8 +1057,9 @@ async function executePiece<
 		(p) => p.piece.sourceLayerId === settings.SourceLayers.Server || p.piece.sourceLayerId === settings.SourceLayers.VO
 	)
 
-	const currentPiece: IBlueprintPieceInstance<PieceMetaData> | undefined = currentPieceInstances.find(
-		(p) => sourceLayerToFindCurrentPieceOn === p.piece.sourceLayerId
+	const layersWithCutDirect: string[] = [settings.SourceLayers.Live, settings.SourceLayers.Cam]
+	const currentPiece: IBlueprintPieceInstance<PieceMetaData> | undefined = currentPieceInstances.find((p) =>
+		layersWithCutDirect.includes(p.piece.sourceLayerId)
 	)
 
 	if (shouldBeQueued || isServerInCurrentPart) {
@@ -1196,7 +1196,7 @@ async function executeActionCutToRemote<
 		}
 	}
 
-	await executePiece(context, settings, remotePiece, settings.SourceLayers.Live, !userData.cutDirectly, part)
+	await executePiece(context, settings, remotePiece, !userData.cutDirectly, part)
 }
 
 async function executeActionCutSourceToBox<

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,7 +566,7 @@
   integrity sha512-IjHlVaE0IuLp7R8mxIWz5AbnlC8EExtHHWt/F8tbbjSyKYeBahxS0asnbMFnDYMlOZznNrunT4nBy8vwGfTHhg==
   dependencies:
     "@sofie-automation/shared-lib" "npm:@tv2media/shared-lib@46.2.0"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.4.0"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@3.5.0"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 


### PR DESCRIPTION
Cutting directly now creates a new Part instead of just switching the piece in the current part.
Directly cut parts are not able to be recalled as last live.

