### PR TITLE
SOF-964 Able to find SelectedGfxSetup using GfxDefaults

### DIFF
--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -44,7 +44,7 @@ export interface TableConfigItemGfxShowMapping {
 }
 
 export interface TableConfigItemGfxDefaults {
-	GfxSetup: string
+	DefaultSetupName: { value: string; label: string }
 	DefaultSchema: string
 	DefaultDesign: string
 }

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -60,6 +60,7 @@ export interface TableConfigGfxSchema {
 }
 
 export interface TableConfigGfxSetup {
+	_id: string
 	Name: string
 	HtmlPackageFolder: string
 	OvlShowName?: string

--- a/src/tv2-common/helpers/config.ts
+++ b/src/tv2-common/helpers/config.ts
@@ -19,7 +19,7 @@ export function findGfxSetup<ShowStyleConfig extends TV2ShowstyleBlueprintConfig
 ): ShowStyleConfig['GfxSetups'][0] {
 	const defaultSetupName = config.GfxDefaults[0].DefaultSetupName
 	const foundTableConfigGfxSetup: TableConfigGfxSetup | undefined = config.GfxSetups.find(
-		(tableConfigGfxSetup) => tableConfigGfxSetup.Name === defaultSetupName?.label
+		(tableConfigGfxSetup) => tableConfigGfxSetup._id === defaultSetupName?.value
 	)
 	if (!foundTableConfigGfxSetup) {
 		context.logWarning(`No GFX setup found for profile: ${JSON.stringify(defaultSetupName)}`)

--- a/src/tv2-common/helpers/config.ts
+++ b/src/tv2-common/helpers/config.ts
@@ -22,7 +22,7 @@ export function findGfxSetup<ShowStyleConfig extends TV2ShowstyleBlueprintConfig
 		(tableConfigGfxSetup) => tableConfigGfxSetup.Name === defaultSetupName?.label
 	)
 	if (!foundTableConfigGfxSetup) {
-		context.logWarning(`No GFX setup found for profile: ${defaultSetupName}`)
+		context.logWarning(`No GFX setup found for profile: ${JSON.stringify(defaultSetupName)}`)
 		return fallbackGfxSetup
 	}
 	return foundTableConfigGfxSetup

--- a/src/tv2-common/helpers/config.ts
+++ b/src/tv2-common/helpers/config.ts
@@ -17,11 +17,12 @@ export function findGfxSetup<ShowStyleConfig extends TV2ShowstyleBlueprintConfig
 	config: ShowStyleConfig,
 	fallbackGfxSetup: ShowStyleConfig['GfxSetups'][0]
 ): ShowStyleConfig['GfxSetups'][0] {
+	const defaultSetupName = config.GfxDefaults[0].DefaultSetupName
 	const foundTableConfigGfxSetup: TableConfigGfxSetup | undefined = config.GfxSetups.find(
-		(tableConfigGfxSetup) => tableConfigGfxSetup.Name === config.GfxDefaults[0].GfxSetup
+		(tableConfigGfxSetup) => tableConfigGfxSetup.Name === defaultSetupName?.label
 	)
 	if (!foundTableConfigGfxSetup) {
-		context.logWarning(`No GFX setup found for profile: ${config.GfxDefaults[0].GfxSetup}`)
+		context.logWarning(`No GFX setup found for profile: ${defaultSetupName}`)
 		return fallbackGfxSetup
 	}
 	return foundTableConfigGfxSetup

--- a/src/tv2-common/showstyle/config-manifests.ts
+++ b/src/tv2-common/showstyle/config-manifests.ts
@@ -1,5 +1,4 @@
 import { ConfigManifestEntry, ConfigManifestEntryTable, ConfigManifestEntryType } from 'blueprints-integration'
-import { TableConfigItemGfxDefaults } from '../blueprintConfig'
 
 export enum ShowStyleConfigId {
 	GRAPHICS_SETUPS_TABLE_ID = 'GfxSetups',
@@ -48,21 +47,19 @@ export const getGfxSetupsEntries = (columns: ConfigManifestEntryTable['columns']
 	}
 ]
 
-export const GFX_DEFAULT_VALUES: TableConfigItemGfxDefaults[] = [
-	{
-		GfxSetup: '',
-		DefaultSchema: '',
-		DefaultDesign: ''
-	}
-]
+const GFX_DEFAULT_VALUES = {
+	DefaultSetupName: '',
+	DefaultSchema: '',
+	DefaultDesign: ''
+}
 
-export const getGfxDefaults: ConfigManifestEntry = {
+export const getGfxDefaults: ConfigManifestEntryTable = {
 	id: ShowStyleConfigId.GFX_DEFAULTS_TABLE_ID,
 	name: 'GFX Defaults',
 	description: 'The default values available for the GFX setup',
 	type: ConfigManifestEntryType.TABLE,
 	required: false,
-	defaultVal: GFX_DEFAULT_VALUES.map((gfxDefaultValue) => ({ _id: '', ...gfxDefaultValue })),
+	defaultVal: [{ _id: '', ...GFX_DEFAULT_VALUES }],
 	disableRowManipulation: true,
 	columns: [
 		{

--- a/src/tv2_afvd_showstyle/__tests__/config-manifest.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/config-manifest.spec.ts
@@ -17,7 +17,13 @@ const blankShowStyleConfig: GalleryShowStyleConfig = {
 	GfxSetups: [],
 	GfxSchemaTemplates: [],
 	GfxShowMapping: [],
-	GfxDefaults: [{ GfxSetup: '', DefaultSchema: '', DefaultDesign: '' }]
+	GfxDefaults: [
+		{
+			DefaultSetupName: { value: '', label: '' },
+			DefaultDesign: '',
+			DefaultSchema: ''
+		}
+	]
 }
 
 describe('Config Manifest', () => {

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -274,5 +274,11 @@ export const defaultShowStyleConfig: GalleryShowStyleConfig = {
 	ShowstyleTransition: 'CUT',
 	GfxSchemaTemplates: [],
 	GfxShowMapping: [],
-	GfxDefaults: [{ GfxSetup: 'SomeProfile', DefaultDesign: '', DefaultSchema: '' }]
+	GfxDefaults: [
+		{
+			DefaultSetupName: { value: '', label: 'SomeProfile' },
+			DefaultDesign: '',
+			DefaultSchema: ''
+		}
+	]
 }

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -45,6 +45,7 @@ function prepareConfig(
 export const OVL_SHOW_NAME = 'ovl-show-id'
 export const FULL_SHOW_NAME = 'full-show-id'
 export const DEFAULT_GFX_SETUP: GalleryTableConfigGfxSetup = {
+	_id: 'SomeId',
 	Name: 'SomeProfile',
 	VcpConcept: 'SomeConcept',
 	OvlShowName: OVL_SHOW_NAME,
@@ -276,7 +277,7 @@ export const defaultShowStyleConfig: GalleryShowStyleConfig = {
 	GfxShowMapping: [],
 	GfxDefaults: [
 		{
-			DefaultSetupName: { value: '', label: 'SomeProfile' },
+			DefaultSetupName: { value: 'SomeId', label: 'SomeProfile' },
 			DefaultDesign: '',
 			DefaultSchema: ''
 		}

--- a/src/tv2_afvd_showstyle/helpers/config.ts
+++ b/src/tv2_afvd_showstyle/helpers/config.ts
@@ -29,6 +29,7 @@ export interface GalleryShowStyleConfig extends TV2ShowstyleBlueprintConfigBase 
 export function preprocessConfig(context: ICommonContext, rawConfig: IBlueprintConfig): any {
 	const showstyleConfig = rawConfig as unknown as GalleryShowStyleConfig
 	const selectedGfxSetup = findGfxSetup(context, showstyleConfig, {
+		_id: '',
 		Name: '',
 		VcpConcept: '',
 		OvlShowName: '',

--- a/src/tv2_offtube_showstyle/helpers/config.ts
+++ b/src/tv2_offtube_showstyle/helpers/config.ts
@@ -42,6 +42,7 @@ export interface OfftubeShowStyleConfig extends TV2ShowstyleBlueprintConfigBase 
 export function preprocessConfig(context: ICommonContext, rawConfig: IBlueprintConfig): any {
 	const showstyleConfig = rawConfig as unknown as OfftubeShowStyleConfig
 	const selectedGfxSetup = findGfxSetup(context, showstyleConfig, {
+		_id: '',
 		Name: '',
 		HtmlPackageFolder: ''
 	})


### PR DESCRIPTION
Now uses DefaultSetupName in TableConfigItemGfxDefaults instead of GfxSetup since these were two different names for the same field.
Changed the type to match actually stored in the database.

