### PR TITLE
fix: SOF-1127 server audio jump on DVE end

### DIFF
--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -84,7 +84,8 @@ function GetServerTimeline(
 			seek: contentProps.seek,
 			length: contentProps.seek ? contentProps.clipDuration : undefined,
 			inPoint: contentProps.seek ? 0 : undefined,
-			playing: true
+			playing: true,
+			noStarttime: true
 		},
 		metaData: {
 			mediaPlayerSession: contentProps.mediaPlayerSession


### PR DESCRIPTION
`noStarttime` prevents seeking to an undesired timecode when a transition or next part's preroll begins