### PR TITLE
SOF-1539 No longer uses 'while x' for server Parts and Pieces. 

### DIFF
--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -67,12 +67,10 @@ function GetServerTimeline(
 	partProps: ServerPartProps,
 	contentProps: ServerContentProps
 ): TimelineObjectCoreExt[] {
-	const serverEnableClass = `.${GetEnableClassForServer(contentProps.mediaPlayerSession)}`
-
 	const mediaObj: TSR.TimelineObjCCGMedia & TimelineBlueprintExt = {
 		id: '',
 		enable: {
-			while: serverEnableClass
+			start: 0
 		},
 		priority: 1,
 		layer: sourceLayers.Caspar.ClipPending,
@@ -92,17 +90,11 @@ function GetServerTimeline(
 		}
 	}
 
-	const mediaOffObj = JSON.parse(JSON.stringify(mediaObj)) as TSR.TimelineObjCCGMedia & TimelineBlueprintExt
-	mediaOffObj.enable = { while: `!${serverEnableClass}` }
-	mediaOffObj.content.playing = false
-	mediaOffObj.content.noStarttime = true
-
 	const audioEnable = {
-		while: serverEnableClass
+		start: 0
 	}
 	return [
 		mediaObj,
-		mediaOffObj,
 		...GetSisyfosTimelineObjForServer(
 			context.config,
 			partProps.voLevels,

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -226,7 +226,7 @@ function getServerSelectionBlueprintPiece(
 		enable: { start: 0 },
 		outputLayerId: SharedOutputLayer.SEC,
 		sourceLayerId: layers.SourceLayer.SelectedServer,
-		lifespan: PieceLifespan.OutOnSegmentEnd,
+		lifespan: PieceLifespan.WithinPart,
 		metaData: {
 			mediaPlayerSessions: [contentProps.mediaPlayerSession],
 			userData: userDataElement,

--- a/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
@@ -443,7 +443,7 @@ describe('Select Server Action', () => {
 
 		validateNextPartExistsWithDuration(context, SERVER_DURATION_A)
 		validateSourcePiecesExistWithPrerollDuration(activePieces)
-		expect(activePieces.dataStore?.piece.lifespan).toEqual(PieceLifespan.OutOnSegmentEnd)
+		expect(activePieces.dataStore?.piece.lifespan).toEqual(PieceLifespan.WithinPart)
 
 		validateNoWarningsOrErrors(context)
 	})


### PR DESCRIPTION
In order to fit the new way of building the Timeline it has been necessary to change the TimelineEnable of Servers.
Instead of using a "while some class" they now just start at 0. 
Also removed a TimelineObject which was supposed to ensure the Servers wasn't playing when it isn't on Air. Removing it seems to have had zero effect, so hence it is gone.

Funnily enough, this change still works with old Core.