### PR TITLE
refactor: Sofie server related DVE content is renamed to SplitScreen.

### DIFF
--- a/src/tv2-common/content/dve.ts
+++ b/src/tv2-common/content/dve.ts
@@ -105,11 +105,11 @@ export interface DVEPieceMetaData extends PieceMetaData {
 	userData: ActionSelectDVE
 	mediaPlayerSessions?: string[] // TODO: Should probably move to a ServerPieceMetaData
 	serverPlaybackTiming?: Array<{ start?: number; end?: number }>
-	dve?: DvePieceActionMetadata
+	splitScreen?: SplitScreenPieceActionMetadata
 }
 
-// This is used by the "new" Blueprint in order to put sources into a planned DVE.
-export interface DvePieceActionMetadata {
+// This is used by the "new" Blueprint in order to put sources into a planned split screen.
+export interface SplitScreenPieceActionMetadata {
 	boxes: BoxConfig[]
 	audioTimelineObjectsForBoxes: { [inputIndex: number]: TSR.TSRTimelineObj[] }
 }
@@ -132,7 +132,11 @@ export function MakeContentDVEBase<
 	parsedCue: CueDefinitionDVE,
 	dveConfig: DVEConfigInput | undefined,
 	dveGeneratorOptions: DVEOptions
-): { content: WithTimeline<SplitsContent>; valid: boolean; dvePieceActionMetadata?: DvePieceActionMetadata } {
+): {
+	content: WithTimeline<SplitsContent>
+	valid: boolean
+	splitScreenPieceActionMetadata?: SplitScreenPieceActionMetadata
+} {
 	if (!dveConfig) {
 		context.core.notifyUserWarning(`DVE ${parsedCue.template} is not configured`)
 		return {
@@ -169,7 +173,11 @@ export function MakeContentDVE2<
 	sources: DVESources | undefined,
 	dveGeneratorOptions: DVEOptions,
 	mediaPlayerSessionId?: string
-): { content: WithTimeline<SplitsContent>; valid: boolean; dvePieceActionMetadata?: DvePieceActionMetadata } {
+): {
+	content: WithTimeline<SplitsContent>
+	valid: boolean
+	splitScreenPieceActionMetadata?: SplitScreenPieceActionMetadata
+} {
 	let template: DVEConfig
 	try {
 		template = JSON.parse(dveConfig.DVEJSON) as DVEConfig
@@ -304,7 +312,7 @@ export function MakeContentDVE2<
 		}
 	})
 
-	const dvePieceActionMetadata: DvePieceActionMetadata = {
+	const splitScreenPieceActionMetadata: SplitScreenPieceActionMetadata = {
 		boxes,
 		audioTimelineObjectsForBoxes
 	}
@@ -329,7 +337,7 @@ export function MakeContentDVE2<
 	}
 
 	return {
-		dvePieceActionMetadata,
+		splitScreenPieceActionMetadata,
 		valid,
 		content: literal<WithTimeline<SplitsContent>>({
 			boxSourceConfiguration: boxSources,

--- a/src/tv2_afvd_showstyle/helpers/content/dve.ts
+++ b/src/tv2_afvd_showstyle/helpers/content/dve.ts
@@ -3,13 +3,13 @@ import {
 	CueDefinitionDVE,
 	DVEConfigInput,
 	DVEOptions,
-	DvePieceActionMetadata,
 	MakeContentDVEBase,
 	PartDefinition,
-	ShowStyleContext
+	ShowStyleContext,
+	SplitScreenPieceActionMetadata
 } from 'tv2-common'
-import { GalleryBlueprintConfig } from '../../../tv2_afvd_showstyle/helpers/config'
 import { CasparLLayer, SisyfosLLAyer } from '../../../tv2_afvd_studio/layers'
+import { GalleryBlueprintConfig } from '../config'
 
 export const NUMBER_OF_DVE_BOXES = 4
 
@@ -34,6 +34,10 @@ export function MakeContentDVE(
 	partDefinition: PartDefinition,
 	parsedCue: CueDefinitionDVE,
 	dveConfig: DVEConfigInput | undefined
-): { content: WithTimeline<SplitsContent>; valid: boolean; dvePieceActionMetadata?: DvePieceActionMetadata } {
+): {
+	content: WithTimeline<SplitsContent>
+	valid: boolean
+	splitScreenPieceActionMetadata?: SplitScreenPieceActionMetadata
+} {
 	return MakeContentDVEBase(context, partDefinition, parsedCue, dveConfig, AFVD_DVE_GENERATOR_OPTIONS)
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
@@ -90,7 +90,7 @@ export function EvaluateDVE(
 					content: content.content,
 					prerollDuration: Number(context.config.studio.CasparPrerollDuration) || 0,
 					metaData: {
-						dve: content.dvePieceActionMetadata,
+						splitScreen: content.splitScreenPieceActionMetadata,
 						type: Tv2PieceType.SPLIT_SCREEN,
 						outputLayer: Tv2OutputLayer.PROGRAM,
 						mediaPlayerSessions: [partDefinition.segmentExternalId],


### PR DESCRIPTION
Renamed DVE content related to the new Sofie server to split screen.