### PR TITLE
feat/ Add VO Metadata on Video Clips and Replays

### DIFF
--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -22,6 +22,7 @@ import {
 } from 'tv2-common'
 import { AbstractLLayer, PartType, SharedSisyfosLLayer, TallyTags } from 'tv2-constants'
 import * as _ from 'underscore'
+import {Tv2AudioMode} from "../tv2-constants/tv2-audio.mode";
 import { Tv2OutputLayer } from '../tv2-constants/tv2-output-layer'
 import { Tv2PieceType } from '../tv2-constants/tv2-piece-type'
 import { TV2BlueprintConfigBase, TV2StudioConfigBase } from './blueprintConfig'
@@ -62,6 +63,7 @@ export type TimelineBlueprintExt = TSR.TSRTimelineObjBase & {
 export interface PieceMetaData {
 	type: Tv2PieceType
 	outputLayer?: Tv2OutputLayer
+	audioMode?: Tv2AudioMode
 	sisyfosPersistMetaData?: SisyfosPersistenceMetaData
 	mediaPlayerSessions?: string[]
 	modifiedByAction?: boolean

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -22,7 +22,7 @@ import {
 } from 'tv2-common'
 import { AbstractLLayer, PartType, SharedSisyfosLLayer, TallyTags } from 'tv2-constants'
 import * as _ from 'underscore'
-import {Tv2AudioMode} from "../tv2-constants/tv2-audio.mode";
+import { Tv2AudioMode } from '../tv2-constants/tv2-audio.mode'
 import { Tv2OutputLayer } from '../tv2-constants/tv2-output-layer'
 import { Tv2PieceType } from '../tv2-constants/tv2-piece-type'
 import { TV2BlueprintConfigBase, TV2StudioConfigBase } from './blueprintConfig'

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -234,7 +234,9 @@ function getServerSelectionBlueprintPiece(
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
 			audioMode:
-				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver ? Tv2AudioMode.VOICE_OVER : undefined,
+				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver
+					? Tv2AudioMode.VOICE_OVER
+					: Tv2AudioMode.FULL,
 			mediaPlayerSessions: [contentProps.mediaPlayerSession],
 			userData: userDataElement,
 			sisyfosPersistMetaData: {
@@ -269,7 +271,9 @@ function getPgmBlueprintPiece<
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
 			audioMode:
-				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver ? Tv2AudioMode.VOICE_OVER : undefined,
+				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver
+					? Tv2AudioMode.VOICE_OVER
+					: Tv2AudioMode.FULL,
 			mediaPlayerSessions: [contentProps.mediaPlayerSession]
 		},
 		content: {

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -16,17 +16,17 @@ import {
 	ServerPieceMetaData,
 	ShowStyleContext
 } from 'tv2-common'
-import {AdlibActionType, PartType, SharedOutputLayer, SharedSourceLayer, TallyTags} from 'tv2-constants'
-import {Tv2AudioMode} from "../../tv2-constants/tv2-audio.mode";
-import {Tv2OutputLayer} from '../../tv2-constants/tv2-output-layer'
-import {Tv2PieceType} from '../../tv2-constants/tv2-piece-type'
-import {ActionSelectServerClip} from '../actions'
-import {TV2BlueprintConfigBase, TV2StudioConfigBase} from '../blueprintConfig'
-import {getSourceDuration, GetVTContentProperties} from '../content'
-import {getServerSeek, ServerPosition, ServerSelectMode} from '../helpers'
-import {PartDefinition} from '../inewsConversion'
-import {SanitizeString} from '../util'
-import {CreatePartInvalid} from './invalid'
+import { AdlibActionType, PartType, SharedOutputLayer, SharedSourceLayer, TallyTags } from 'tv2-constants'
+import { Tv2AudioMode } from '../../tv2-constants/tv2-audio.mode'
+import { Tv2OutputLayer } from '../../tv2-constants/tv2-output-layer'
+import { Tv2PieceType } from '../../tv2-constants/tv2-piece-type'
+import { ActionSelectServerClip } from '../actions'
+import { TV2BlueprintConfigBase, TV2StudioConfigBase } from '../blueprintConfig'
+import { getSourceDuration, GetVTContentProperties } from '../content'
+import { getServerSeek, ServerPosition, ServerSelectMode } from '../helpers'
+import { PartDefinition } from '../inewsConversion'
+import { SanitizeString } from '../util'
+import { CreatePartInvalid } from './invalid'
 
 export interface ServerPartProps {
 	voLayer: boolean

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -16,16 +16,17 @@ import {
 	ServerPieceMetaData,
 	ShowStyleContext
 } from 'tv2-common'
-import { AdlibActionType, PartType, SharedOutputLayer, TallyTags } from 'tv2-constants'
-import { Tv2OutputLayer } from '../../tv2-constants/tv2-output-layer'
-import { Tv2PieceType } from '../../tv2-constants/tv2-piece-type'
-import { ActionSelectServerClip } from '../actions'
-import { TV2BlueprintConfigBase, TV2StudioConfigBase } from '../blueprintConfig'
-import { getSourceDuration, GetVTContentProperties } from '../content'
-import { getServerSeek, ServerPosition, ServerSelectMode } from '../helpers'
-import { PartDefinition } from '../inewsConversion'
-import { SanitizeString } from '../util'
-import { CreatePartInvalid } from './invalid'
+import {AdlibActionType, PartType, SharedOutputLayer, SharedSourceLayer, TallyTags} from 'tv2-constants'
+import {Tv2AudioMode} from "../../tv2-constants/tv2-audio.mode";
+import {Tv2OutputLayer} from '../../tv2-constants/tv2-output-layer'
+import {Tv2PieceType} from '../../tv2-constants/tv2-piece-type'
+import {ActionSelectServerClip} from '../actions'
+import {TV2BlueprintConfigBase, TV2StudioConfigBase} from '../blueprintConfig'
+import {getSourceDuration, GetVTContentProperties} from '../content'
+import {getServerSeek, ServerPosition, ServerSelectMode} from '../helpers'
+import {PartDefinition} from '../inewsConversion'
+import {SanitizeString} from '../util'
+import {CreatePartInvalid} from './invalid'
 
 export interface ServerPartProps {
 	voLayer: boolean
@@ -232,6 +233,8 @@ function getServerSelectionBlueprintPiece(
 		metaData: {
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
+			audioMode:
+				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver ? Tv2AudioMode.VOICE_OVER : undefined,
 			mediaPlayerSessions: [contentProps.mediaPlayerSession],
 			userData: userDataElement,
 			sisyfosPersistMetaData: {
@@ -265,6 +268,8 @@ function getPgmBlueprintPiece<
 		metaData: {
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
+			audioMode:
+				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver ? Tv2AudioMode.VOICE_OVER : undefined,
 			mediaPlayerSessions: [contentProps.mediaPlayerSession]
 		},
 		content: {

--- a/src/tv2-constants/tv2-audio.mode.ts
+++ b/src/tv2-constants/tv2-audio.mode.ts
@@ -1,0 +1,4 @@
+export enum Tv2AudioMode {
+	FULL = 'FULL',
+	VOICE_OVER = 'VOICE_OVER'
+}

--- a/src/tv2_afvd_showstyle/parts/evs.ts
+++ b/src/tv2_afvd_showstyle/parts/evs.ts
@@ -69,7 +69,7 @@ export async function CreatePartEVS(
 		metaData: {
 			type: Tv2PieceType.REPLAY,
 			outputLayer: Tv2OutputLayer.PROGRAM,
-			audioMode: partDefinition.sourceDefinition.vo ? Tv2AudioMode.VOICE_OVER : undefined,
+			audioMode: partDefinition.sourceDefinition.vo ? Tv2AudioMode.VOICE_OVER : Tv2AudioMode.FULL,
 			sisyfosPersistMetaData: {
 				sisyfosLayers: []
 			}

--- a/src/tv2_afvd_showstyle/parts/evs.ts
+++ b/src/tv2_afvd_showstyle/parts/evs.ts
@@ -23,6 +23,7 @@ import {
 	TransitionStyle
 } from 'tv2-common'
 import { SharedOutputLayer } from 'tv2-constants'
+import { Tv2AudioMode } from '../../tv2-constants/tv2-audio.mode'
 import { Tv2OutputLayer } from '../../tv2-constants/tv2-output-layer'
 import { Tv2PieceType } from '../../tv2-constants/tv2-piece-type'
 import { GalleryBlueprintConfig } from '../helpers/config'
@@ -68,6 +69,7 @@ export async function CreatePartEVS(
 		metaData: {
 			type: Tv2PieceType.REPLAY,
 			outputLayer: Tv2OutputLayer.PROGRAM,
+			audioMode: partDefinition.sourceDefinition.vo ? Tv2AudioMode.VOICE_OVER : undefined,
 			sisyfosPersistMetaData: {
 				sisyfosLayers: []
 			}


### PR DESCRIPTION
This PR introduces metadata for video clips and replays that can be used to reflect whether they have voice over. This is under a pieces metadata as `audioMode`. 