### PR TITLE
SOF-1651 Metadata now contains a related mediaId property

### DIFF
--- a/src/tv2-common/helpers/graphics/design/index.ts
+++ b/src/tv2-common/helpers/graphics/design/index.ts
@@ -82,7 +82,7 @@ function createDesignPiece(
 		content: designContent,
 		metaData: {
 			type: Tv2PieceType.GRAPHICS,
-			mediaId: designContent.fileName
+			mediaName: designContent.fileName
 		}
 	}
 }

--- a/src/tv2-common/helpers/graphics/design/index.ts
+++ b/src/tv2-common/helpers/graphics/design/index.ts
@@ -82,7 +82,7 @@ function createDesignPiece(
 		content: designContent,
 		metaData: {
 			type: Tv2PieceType.GRAPHICS,
-			mediaName: designContent.fileName
+			sourceName: designContent.fileName
 		}
 	}
 }

--- a/src/tv2-common/helpers/graphics/design/index.ts
+++ b/src/tv2-common/helpers/graphics/design/index.ts
@@ -68,6 +68,7 @@ function createDesignPiece(
 	cue: CueDefinitionGraphicDesign
 ): IBlueprintPiece<PieceMetaData> {
 	const start = (cue.start ? calculateTime(cue.start) : 0) ?? 0
+	const designContent: WithTimeline<GraphicsContent> = createDesignPieceContent(context, cue)
 	return {
 		externalId: partId,
 		name: cue.design,
@@ -78,9 +79,10 @@ function createDesignPiece(
 		sourceLayerId: SharedSourceLayer.PgmDesign,
 		// @ts-ignore
 		lifespan: cue.isFromField ? 'rundown-change-segment-lookback' : PieceLifespan.OutOnRundownChange,
-		content: createDesignPieceContent(context, cue),
+		content: designContent,
 		metaData: {
-			type: Tv2PieceType.GRAPHICS
+			type: Tv2PieceType.GRAPHICS,
+			mediaId: designContent.fileName
 		}
 	}
 }

--- a/src/tv2-common/helpers/graphics/pilot/PilotGraphicGenerator.ts
+++ b/src/tv2-common/helpers/graphics/pilot/PilotGraphicGenerator.ts
@@ -132,7 +132,7 @@ export abstract class PilotGraphicGenerator extends Graphic {
 			metaData: {
 				type: this.getTv2PieceType(),
 				outputLayer: this.getTv2OutputLayer(),
-				mediaId: graphicsContent.fileName
+				mediaName: graphicsContent.fileName
 			}
 		}
 	}
@@ -167,7 +167,7 @@ export abstract class PilotGraphicGenerator extends Graphic {
 			lifespan: PieceLifespan.OutOnSegmentEnd,
 			metaData: {
 				type: Tv2PieceType.GRAPHICS,
-				mediaId: content.fileName,
+				mediaName: content.fileName,
 				userData: {
 					type: AdlibActionType.SELECT_FULL_GRAFIK,
 					name: this.cue.graphic.name,

--- a/src/tv2-common/helpers/graphics/pilot/PilotGraphicGenerator.ts
+++ b/src/tv2-common/helpers/graphics/pilot/PilotGraphicGenerator.ts
@@ -132,7 +132,7 @@ export abstract class PilotGraphicGenerator extends Graphic {
 			metaData: {
 				type: this.getTv2PieceType(),
 				outputLayer: this.getTv2OutputLayer(),
-				mediaName: graphicsContent.fileName
+				sourceName: graphicsContent.fileName
 			}
 		}
 	}
@@ -167,7 +167,7 @@ export abstract class PilotGraphicGenerator extends Graphic {
 			lifespan: PieceLifespan.OutOnSegmentEnd,
 			metaData: {
 				type: Tv2PieceType.GRAPHICS,
-				mediaName: content.fileName,
+				sourceName: content.fileName,
 				userData: {
 					type: AdlibActionType.SELECT_FULL_GRAFIK,
 					name: this.cue.graphic.name,

--- a/src/tv2-common/helpers/graphics/pilot/PilotGraphicGenerator.ts
+++ b/src/tv2-common/helpers/graphics/pilot/PilotGraphicGenerator.ts
@@ -112,6 +112,7 @@ export abstract class PilotGraphicGenerator extends Graphic {
 	}
 
 	public createPiece(): IBlueprintPiece<PieceMetaData> {
+		const graphicsContent: WithTimeline<GraphicsContent> = this.getContent()
 		return {
 			externalId: this.partId,
 			name: this.getTemplateName(),
@@ -124,13 +125,14 @@ export abstract class PilotGraphicGenerator extends Graphic {
 			sourceLayerId: this.getSourceLayer(),
 			prerollDuration: this.getPrerollDuration(),
 			lifespan: this.getPieceLifespan(),
-			content: this.getContent(),
+			content: graphicsContent,
 			tags: IsTargetingFull(this.engine)
 				? [GetTagForFull(this.segmentExternalId, this.cue.graphic.vcpid), TallyTags.FULL_IS_LIVE]
 				: [],
 			metaData: {
 				type: this.getTv2PieceType(),
-				outputLayer: this.getTv2OutputLayer()
+				outputLayer: this.getTv2OutputLayer(),
+				mediaId: graphicsContent.fileName
 			}
 		}
 	}
@@ -165,6 +167,7 @@ export abstract class PilotGraphicGenerator extends Graphic {
 			lifespan: PieceLifespan.OutOnSegmentEnd,
 			metaData: {
 				type: Tv2PieceType.GRAPHICS,
+				mediaId: content.fileName,
 				userData: {
 					type: AdlibActionType.SELECT_FULL_GRAFIK,
 					name: this.cue.graphic.name,

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -63,6 +63,7 @@ export type TimelineBlueprintExt = TSR.TSRTimelineObjBase & {
 export interface PieceMetaData {
 	type: Tv2PieceType
 	outputLayer?: Tv2OutputLayer
+	mediaId?: string
 	audioMode?: Tv2AudioMode
 	sisyfosPersistMetaData?: SisyfosPersistenceMetaData
 	mediaPlayerSessions?: string[]

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -63,7 +63,7 @@ export type TimelineBlueprintExt = TSR.TSRTimelineObjBase & {
 export interface PieceMetaData {
 	type: Tv2PieceType
 	outputLayer?: Tv2OutputLayer
-	mediaName?: string
+	sourceName?: string
 	audioMode?: Tv2AudioMode
 	sisyfosPersistMetaData?: SisyfosPersistenceMetaData
 	mediaPlayerSessions?: string[]

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -63,7 +63,7 @@ export type TimelineBlueprintExt = TSR.TSRTimelineObjBase & {
 export interface PieceMetaData {
 	type: Tv2PieceType
 	outputLayer?: Tv2OutputLayer
-	mediaId?: string
+	mediaName?: string
 	audioMode?: Tv2AudioMode
 	sisyfosPersistMetaData?: SisyfosPersistenceMetaData
 	mediaPlayerSessions?: string[]

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -233,7 +233,7 @@ function getServerSelectionBlueprintPiece(
 		metaData: {
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
-			mediaId: contentServerElement.fileName,
+			mediaName: contentServerElement.fileName,
 			audioMode:
 				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver
 					? Tv2AudioMode.VOICE_OVER
@@ -272,7 +272,7 @@ function getPgmBlueprintPiece<
 		metaData: {
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
-			mediaId: vtContent.fileName,
+			mediaName: vtContent.fileName,
 			audioMode:
 				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver
 					? Tv2AudioMode.VOICE_OVER

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -280,7 +280,7 @@ function getPgmBlueprintPiece<
 			mediaPlayerSessions: [contentProps.mediaPlayerSession]
 		},
 		content: {
-			...GetVTContentProperties(context.config, contentProps),
+			...vtContent,
 			timelineObjects: CutToServer(context, contentProps.mediaPlayerSession, partDefinition)
 		},
 		tags: [

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -233,6 +233,7 @@ function getServerSelectionBlueprintPiece(
 		metaData: {
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
+			mediaId: contentServerElement.fileName,
 			audioMode:
 				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver
 					? Tv2AudioMode.VOICE_OVER
@@ -260,6 +261,7 @@ function getPgmBlueprintPiece<
 	contentProps: ServerContentProps,
 	layers: ServerPartLayers
 ): IBlueprintPiece<PieceMetaData> {
+	const vtContent = GetVTContentProperties(context.config, contentProps)
 	return {
 		externalId: partDefinition.externalId,
 		name: contentProps.file,
@@ -270,6 +272,7 @@ function getPgmBlueprintPiece<
 		metaData: {
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
+			mediaId: vtContent.fileName,
 			audioMode:
 				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver
 					? Tv2AudioMode.VOICE_OVER

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -233,7 +233,7 @@ function getServerSelectionBlueprintPiece(
 		metaData: {
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
-			mediaName: contentServerElement.fileName,
+			sourceName: contentServerElement.fileName,
 			audioMode:
 				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver
 					? Tv2AudioMode.VOICE_OVER
@@ -272,7 +272,7 @@ function getPgmBlueprintPiece<
 		metaData: {
 			type: Tv2PieceType.VIDEO_CLIP,
 			outputLayer: Tv2OutputLayer.PROGRAM,
-			mediaName: vtContent.fileName,
+			sourceName: vtContent.fileName,
 			audioMode:
 				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver
 					? Tv2AudioMode.VOICE_OVER

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
@@ -62,7 +62,7 @@ export function EvaluateCueBackgroundLoop(
 				}),
 				metaData: {
 					type: Tv2PieceType.UNKNOWN,
-					mediaName: fileName
+					sourceName: fileName
 				}
 			})
 		}
@@ -104,7 +104,7 @@ export function EvaluateCueBackgroundLoop(
 				}),
 				metaData: {
 					type: Tv2PieceType.UNKNOWN,
-					mediaName: parsedCue.backgroundLoop
+					sourceName: parsedCue.backgroundLoop
 				}
 			})
 		}

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
@@ -61,7 +61,8 @@ export function EvaluateCueBackgroundLoop(
 					timelineObjects: dveLoopGenerator.createDveLoopTimelineObject(fileName)
 				}),
 				metaData: {
-					type: Tv2PieceType.UNKNOWN
+					type: Tv2PieceType.UNKNOWN,
+					mediaId: fileName
 				}
 			})
 		}
@@ -102,7 +103,8 @@ export function EvaluateCueBackgroundLoop(
 					timelineObjects: fullLoopTimeline(context.config, parsedCue)
 				}),
 				metaData: {
-					type: Tv2PieceType.UNKNOWN
+					type: Tv2PieceType.UNKNOWN,
+					mediaId: parsedCue.backgroundLoop
 				}
 			})
 		}

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphicBackgroundLoop.ts
@@ -62,7 +62,7 @@ export function EvaluateCueBackgroundLoop(
 				}),
 				metaData: {
 					type: Tv2PieceType.UNKNOWN,
-					mediaId: fileName
+					mediaName: fileName
 				}
 			})
 		}
@@ -104,7 +104,7 @@ export function EvaluateCueBackgroundLoop(
 				}),
 				metaData: {
 					type: Tv2PieceType.UNKNOWN,
-					mediaId: parsedCue.backgroundLoop
+					mediaName: parsedCue.backgroundLoop
 				}
 			})
 		}

--- a/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
@@ -83,7 +83,7 @@ export function EvaluateJingle(
 			metaData: {
 				type: Tv2PieceType.JINGLE,
 				outputLayer: Tv2OutputLayer.JINGLE,
-				mediaId: jingleContent.fileName
+				mediaName: jingleContent.fileName
 			}
 		})
 	}

--- a/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
@@ -1,3 +1,4 @@
+import { VTContent, WithTimeline } from '@sofie-automation/blueprints-integration'
 import { IBlueprintActionManifest, IBlueprintPiece, PieceLifespan } from 'blueprints-integration'
 import {
 	ActionSelectJingle,
@@ -66,6 +67,7 @@ export function EvaluateJingle(
 			}
 		})
 	} else {
+		const jingleContent: WithTimeline<VTContent> = createJingleContentAFVD(context, file, jingle)
 		pieces.push({
 			externalId: `${part.externalId}-JINGLE`,
 			name: effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip,
@@ -77,10 +79,11 @@ export function EvaluateJingle(
 			sourceLayerId: SourceLayer.PgmJingle,
 			prerollDuration: context.config.studio.CasparPrerollDuration + getTimeFromFrames(jingle.StartAlpha),
 			tags: [!effekt ? TallyTags.JINGLE : ''],
-			content: createJingleContentAFVD(context, file, jingle),
+			content: jingleContent,
 			metaData: {
 				type: Tv2PieceType.JINGLE,
-				outputLayer: Tv2OutputLayer.JINGLE
+				outputLayer: Tv2OutputLayer.JINGLE,
+				mediaId: jingleContent.fileName
 			}
 		})
 	}

--- a/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
@@ -83,7 +83,7 @@ export function EvaluateJingle(
 			metaData: {
 				type: Tv2PieceType.JINGLE,
 				outputLayer: Tv2OutputLayer.JINGLE,
-				mediaName: jingleContent.fileName
+				sourceName: jingleContent.fileName
 			}
 		})
 	}

--- a/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
@@ -95,7 +95,7 @@ export function OfftubeEvaluateJingle(
 		metaData: {
 			type: Tv2PieceType.JINGLE,
 			outputLayer: Tv2OutputLayer.JINGLE,
-			mediaId: jingleContent.fileName
+			mediaName: jingleContent.fileName
 		}
 	})
 }

--- a/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
@@ -95,7 +95,7 @@ export function OfftubeEvaluateJingle(
 		metaData: {
 			type: Tv2PieceType.JINGLE,
 			outputLayer: Tv2OutputLayer.JINGLE,
-			mediaName: jingleContent.fileName
+			sourceName: jingleContent.fileName
 		}
 	})
 }

--- a/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
@@ -1,3 +1,4 @@
+import { VTContent, WithTimeline } from '@sofie-automation/blueprints-integration'
 import { IBlueprintActionManifest, IBlueprintPiece, PieceLifespan } from 'blueprints-integration'
 import {
 	ActionSelectJingle,
@@ -73,6 +74,7 @@ export function OfftubeEvaluateJingle(
 		}
 	})
 
+	const jingleContent: WithTimeline<VTContent> = createJingleContentOfftube(context, file, jingle)
 	pieces.push({
 		externalId: `${part.externalId}-JINGLE`,
 		name: effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip,
@@ -83,7 +85,7 @@ export function OfftubeEvaluateJingle(
 		outputLayerId: SharedOutputLayer.JINGLE,
 		sourceLayerId: OfftubeSourceLayer.PgmJingle,
 		prerollDuration: context.config.studio.CasparPrerollDuration + getTimeFromFrames(Number(jingle.StartAlpha)),
-		content: createJingleContentOfftube(context, file, jingle),
+		content: jingleContent,
 		tags: [
 			GetTagForJingle(part.segmentExternalId, parsedCue.clip),
 			GetTagForJingleNext(part.segmentExternalId, parsedCue.clip),
@@ -92,7 +94,8 @@ export function OfftubeEvaluateJingle(
 		],
 		metaData: {
 			type: Tv2PieceType.JINGLE,
-			outputLayer: Tv2OutputLayer.JINGLE
+			outputLayer: Tv2OutputLayer.JINGLE,
+			mediaId: jingleContent.fileName
 		}
 	})
 }


### PR DESCRIPTION
This PR adds a `mediaId` property to the metadata of a piece, it's intended for use in the frontend to help decide the piece availability. 