### PR TITLE
SOF-1781 Add Sisyfos EVS track 3/4

### DIFF
--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -1,4 +1,4 @@
-import { literal, parseMapStr, SwitcherType } from 'tv2-common'
+import { literal, SwitcherType } from 'tv2-common'
 import { defaultDSKConfig, StudioConfig } from '../../tv2_afvd_studio/helpers/config'
 import { GalleryShowStyleConfig, GalleryTableConfigGfxSetup } from '../helpers/config'
 import { DefaultBreakerConfig } from './breakerConfigDefault'
@@ -12,7 +12,7 @@ function getSisyfosLayers(configName: string, id: string): string[] {
 		case 'SourcesFeed':
 			return ['sisyfos_source_live_' + id]
 		case 'SourcesDelayedPlayback':
-			return ['sisyfos_source_' + id.toLowerCase().replace(' ', '_')]
+			return ['sisyfos_source_' + id.toLowerCase().replace(/ /g, '_')]
 	}
 
 	return []
@@ -20,7 +20,7 @@ function getSisyfosLayers(configName: string, id: string): string[] {
 
 // TODO: Broken
 function prepareConfig(
-	conf: string,
+	conf: Array<{ id: string; switcherSource: number; sisyfosLayers?: string[] }>,
 	configName: string,
 	studioMics: boolean,
 	wantsToPersistAudio?: boolean
@@ -31,11 +31,11 @@ function prepareConfig(
 	StudioMics: boolean
 	wantsToPersistAudio: boolean
 }> {
-	return parseMapStr(undefined, conf, true).map((c) => {
+	return conf.map((c) => {
 		return {
 			SourceName: c.id,
-			SwitcherSource: c.val,
-			SisyfosLayers: getSisyfosLayers(configName, c.id),
+			SwitcherSource: c.switcherSource,
+			SisyfosLayers: c.sisyfosLayers ?? getSisyfosLayers(configName, c.id),
 			StudioMics: studioMics,
 			wantsToPersistAudio: wantsToPersistAudio ?? false
 		}
@@ -86,14 +86,65 @@ export const defaultStudioConfig: StudioConfig = {
 	ServerPostrollDuration: 3000,
 	PreventOverlayWithFull: true,
 	SourcesCam: prepareConfig(
-		'1:1,2:2,3:3,4:4,5:5,1S:6,2S:7,3S:8,4S:9,5S:10,X8:13,HVID:14,AR:16,CS1:17,CS2:18,CS3:19,CS4:20,CS5:21,CS 1:17,CS 2:18,CS 3:19,CS 4:20,CS 5:21,SORT:22,11:11,12:12,13:13,14:14,15:15',
+		[
+			{ id: '1', switcherSource: 1 },
+			{ id: '2', switcherSource: 2 },
+			{ id: '3', switcherSource: 3 },
+			{ id: '4', switcherSource: 4 },
+			{ id: '5', switcherSource: 5 },
+			{ id: '1S', switcherSource: 6 },
+			{ id: '2S', switcherSource: 7 },
+			{ id: '3S', switcherSource: 8 },
+			{ id: '4S', switcherSource: 9 },
+			{ id: '5S', switcherSource: 10 }
+		],
 		'SourcesCam',
 		true
 	),
 	// TODO: prepareConfig is legacy code, refactor when refactoring FindSourceInfo
-	SourcesRM: prepareConfig('1:1,2:2,3:3,4:4,5:5,6:6,7:7,8:8,9:9,10:10', 'SourcesRM', false, true),
-	SourcesFeed: prepareConfig('1:1,2:2,3:3,4:4,5:5,6:6,7:7,8:8,9:9,10:10', 'SourcesFeed', false, true),
-	SourcesReplay: prepareConfig('EVS 1:5,EVS 2:5,EPSIO:5', 'SourcesDelayedPlayback', false),
+	SourcesRM: prepareConfig(
+		[
+			{ id: '1', switcherSource: 1 },
+			{ id: '2', switcherSource: 2 },
+			{ id: '3', switcherSource: 3 },
+			{ id: '4', switcherSource: 4 },
+			{ id: '5', switcherSource: 5 },
+			{ id: '6', switcherSource: 6 },
+			{ id: '7', switcherSource: 7 },
+			{ id: '8', switcherSource: 8 },
+			{ id: '9', switcherSource: 9 },
+			{ id: '10', switcherSource: 10 }
+		],
+		'SourcesRM',
+		false,
+		true
+	),
+	SourcesFeed: prepareConfig(
+		[
+			{ id: '1', switcherSource: 1 },
+			{ id: '2', switcherSource: 2 },
+			{ id: '3', switcherSource: 3 },
+			{ id: '4', switcherSource: 4 },
+			{ id: '5', switcherSource: 5 },
+			{ id: '6', switcherSource: 6 },
+			{ id: '7', switcherSource: 7 },
+			{ id: '8', switcherSource: 8 },
+			{ id: '9', switcherSource: 9 },
+			{ id: '10', switcherSource: 10 }
+		],
+		'SourcesFeed',
+		false,
+		true
+	),
+	SourcesReplay: prepareConfig(
+		[
+			{ id: 'EVS 1', switcherSource: 5, sisyfosLayers: ['sisyfos_source_evs_1_audio_1_2'] },
+			{ id: 'EVS 2', switcherSource: 5, sisyfosLayers: ['sisyfos_source_evs_2_audio_1_2'] },
+			{ id: 'EPSIO', switcherSource: 5, sisyfosLayers: ['sisyfos_source_epsio_audio_1_2'] }
+		],
+		'SourcesDelayedPlayback',
+		false
+	),
 	StudioMics: [
 		'sisyfos_source_Host_1_st_a',
 		'sisyfos_source_Host_2_st_a',

--- a/src/tv2_afvd_studio/config-manifests.ts
+++ b/src/tv2_afvd_studio/config-manifests.ts
@@ -199,23 +199,44 @@ export const manifestAFVDSourcesFeed = MakeConfigForSources('Feed', 'Feed', true
 export const manifestAFVDSourcesReplay = MakeConfigForSources('Replay', 'Replay', false, false, [
 	{
 		_id: '',
-		SourceName: '1',
+		SourceName: '1 1/2',
 		SwitcherSource: 22,
-		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEVS_1],
+		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEVS_1_audio_1_2],
 		StudioMics: true
 	},
 	{
 		_id: '',
-		SourceName: '2',
+		SourceName: '2 1/2',
 		SwitcherSource: 23,
-		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEVS_2],
+		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEVS_2_audio_1_2],
 		StudioMics: true
 	},
 	{
 		_id: '',
-		SourceName: 'EPSIO',
+		SourceName: 'EPSIO 1/2',
 		SwitcherSource: 25,
-		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEpsio],
+		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEpsio_audio_1_2],
+		StudioMics: true
+	},
+	{
+		_id: '',
+		SourceName: '1 3/4',
+		SwitcherSource: 30,
+		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEVS_1_audio_3_4],
+		StudioMics: true
+	},
+	{
+		_id: '',
+		SourceName: '2 3/4',
+		SwitcherSource: 31,
+		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEVS_2_audio_3_4],
+		StudioMics: true
+	},
+	{
+		_id: '',
+		SourceName: 'EPSIO 3/4',
+		SwitcherSource: 32,
+		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEpsio_audio_3_4],
 		StudioMics: true
 	}
 ])

--- a/src/tv2_afvd_studio/layers.ts
+++ b/src/tv2_afvd_studio/layers.ts
@@ -62,9 +62,12 @@ enum AFVDSisyfosLLayer {
 	SisyfosSourceServerA = 'sisyfos_source_server_a',
 	SisyfosSourceServerB = 'sisyfos_source_server_b',
 	// SisyfosSourceServerC = 'sisyfos_source_server_c',
-	SisyfosSourceEVS_1 = 'sisyfos_source_evs_1',
-	SisyfosSourceEVS_2 = 'sisyfos_source_evs_2',
-	SisyfosSourceEpsio = 'sisyfos_source_epsio'
+	SisyfosSourceEVS_1_audio_1_2 = 'sisyfos_source_evs_1_audio_1_2',
+	SisyfosSourceEVS_2_audio_1_2 = 'sisyfos_source_evs_2_audio_1_2',
+	SisyfosSourceEpsio_audio_1_2 = 'sisyfos_source_epsio_audio_1_2',
+	SisyfosSourceEVS_1_audio_3_4 = 'sisyfos_source_evs_1_audio_3_4',
+	SisyfosSourceEVS_2_audio_3_4 = 'sisyfos_source_evs_2_audio_3_4',
+	SisyfosSourceEpsio_audio_3_4 = 'sisyfos_source_epsio_audio_3_4'
 }
 
 // tslint:disable-next-line: variable-name

--- a/src/tv2_afvd_studio/migrations/index.ts
+++ b/src/tv2_afvd_studio/migrations/index.ts
@@ -140,8 +140,10 @@ export const studioMigrations: MigrationStepStudio[] = [
 		'sisyfos_source_live_10',
 		'sisyfos_source_server_a',
 		'sisyfos_source_server_b',
-		'sisyfos_source_evs_1',
-		'sisyfos_source_evs_2',
+		'sisyfos_source_evs_1_audio_1_2',
+		'sisyfos_source_evs_2_audio_1_2',
+		'sisyfos_source_evs_1_audio_3_4',
+		'sisyfos_source_evs_2_audio_3_4',
 		'sisyfos_resync'
 	].map((layer) => EnsureSisyfosMappingHasType('1.3.0', layer, TSR.MappingSisyfosType.CHANNEL)),
 	GetMappingDefaultMigrationStepForLayer('1.3.0', SisyfosLLAyer.SisyfosGroupStudioMics),
@@ -190,7 +192,7 @@ export const studioMigrations: MigrationStepStudio[] = [
 	addSourceToSourcesConfig('1.7.4', 'AFVD', 'SourcesReplay', {
 		SourceName: 'EPSIO',
 		SwitcherSource: 25,
-		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEpsio],
+		SisyfosLayers: [SisyfosLLAyer.SisyfosSourceEpsio_audio_1_2],
 		StudioMics: true
 	}),
 

--- a/src/tv2_afvd_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_afvd_studio/migrations/mappings-defaults.ts
@@ -299,19 +299,19 @@ export const MAPPINGS_SISYFOS: BlueprintMappings = {
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
 		setLabelToLayerName: true
 	}),
-	[SisyfosLLAyer.SisyfosSourceEVS_1]: literal<TSR.MappingSisyfos & BlueprintMapping>({
+	[SisyfosLLAyer.SisyfosSourceEVS_1_audio_1_2]: literal<TSR.MappingSisyfos & BlueprintMapping>({
 		device: TSR.DeviceType.SISYFOS,
 		deviceId: 'sisyfos0',
-		layerName: 'EVS 1',
+		layerName: 'EVS 1 3/4',
 		channel: 24,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
 		setLabelToLayerName: true
 	}),
-	[SisyfosLLAyer.SisyfosSourceEVS_2]: literal<TSR.MappingSisyfos & BlueprintMapping>({
+	[SisyfosLLAyer.SisyfosSourceEVS_2_audio_1_2]: literal<TSR.MappingSisyfos & BlueprintMapping>({
 		device: TSR.DeviceType.SISYFOS,
 		deviceId: 'sisyfos0',
-		layerName: 'EVS 2',
+		layerName: 'EVS 2 1/2',
 		channel: 25,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
@@ -344,11 +344,38 @@ export const MAPPINGS_SISYFOS: BlueprintMappings = {
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
 		setLabelToLayerName: true
 	}),
-	[SisyfosLLAyer.SisyfosSourceEpsio]: literal<TSR.MappingSisyfos & BlueprintMapping>({
+	[SisyfosLLAyer.SisyfosSourceEpsio_audio_1_2]: literal<TSR.MappingSisyfos & BlueprintMapping>({
 		device: TSR.DeviceType.SISYFOS,
 		deviceId: 'sisyfos0',
-		layerName: 'EPSIO',
+		layerName: 'EPSIO 1/2',
 		channel: 29,
+		lookahead: LookaheadMode.NONE,
+		mappingType: TSR.MappingSisyfosType.CHANNEL,
+		setLabelToLayerName: true
+	}),
+	[SisyfosLLAyer.SisyfosSourceEVS_1_audio_3_4]: literal<TSR.MappingSisyfos & BlueprintMapping>({
+		device: TSR.DeviceType.SISYFOS,
+		deviceId: 'sisyfos0',
+		layerName: 'EVS 1 3/4',
+		channel: 30,
+		lookahead: LookaheadMode.NONE,
+		mappingType: TSR.MappingSisyfosType.CHANNEL,
+		setLabelToLayerName: true
+	}),
+	[SisyfosLLAyer.SisyfosSourceEVS_2_audio_3_4]: literal<TSR.MappingSisyfos & BlueprintMapping>({
+		device: TSR.DeviceType.SISYFOS,
+		deviceId: 'sisyfos0',
+		layerName: 'EVS 2 3/4',
+		channel: 31,
+		lookahead: LookaheadMode.NONE,
+		mappingType: TSR.MappingSisyfosType.CHANNEL,
+		setLabelToLayerName: true
+	}),
+	[SisyfosLLAyer.SisyfosSourceEpsio_audio_3_4]: literal<TSR.MappingSisyfos & BlueprintMapping>({
+		device: TSR.DeviceType.SISYFOS,
+		deviceId: 'sisyfos0',
+		layerName: 'EPSIO 3/4',
+		channel: 32,
 		lookahead: LookaheadMode.NONE,
 		mappingType: TSR.MappingSisyfosType.CHANNEL,
 		setLabelToLayerName: true

--- a/src/tv2_afvd_studio/migrations/util.ts
+++ b/src/tv2_afvd_studio/migrations/util.ts
@@ -237,10 +237,14 @@ export function GetSisyfosLayersForTableMigrationAFVD(configName: string, val: s
 			}
 			break
 		case 'SourcesDelayedPlayback':
-		case '1':
-			return [SisyfosLLAyer.SisyfosSourceEVS_1]
-		case '2':
-			return [SisyfosLLAyer.SisyfosSourceEVS_2]
+		case '1 1/2':
+			return [SisyfosLLAyer.SisyfosSourceEVS_1_audio_1_2]
+		case '2 1/2':
+			return [SisyfosLLAyer.SisyfosSourceEVS_2_audio_1_2]
+		case '1 3/4':
+			return [SisyfosLLAyer.SisyfosSourceEVS_1_audio_3_4]
+		case '2 3/4':
+			return [SisyfosLLAyer.SisyfosSourceEVS_2_audio_3_4]
 	}
 
 	return []

--- a/src/tv2_afvd_studio/sisyfosChannels.ts
+++ b/src/tv2_afvd_studio/sisyfosChannels.ts
@@ -85,10 +85,16 @@ export const sisyfosChannels: { [key in SisyfosLLAyer]?: SisyfosChannel } = {
 	[SisyfosLLAyer.SisyfosSourceServerB]: {
 		isPgm: 0
 	},
-	[SisyfosLLAyer.SisyfosSourceEVS_1]: {
+	[SisyfosLLAyer.SisyfosSourceEVS_1_audio_1_2]: {
 		isPgm: 0
 	},
-	[SisyfosLLAyer.SisyfosSourceEVS_2]: {
+	[SisyfosLLAyer.SisyfosSourceEVS_2_audio_1_2]: {
+		isPgm: 0
+	},
+	[SisyfosLLAyer.SisyfosSourceEVS_1_audio_3_4]: {
+		isPgm: 0
+	},
+	[SisyfosLLAyer.SisyfosSourceEVS_2_audio_3_4]: {
 		isPgm: 0
 	},
 	[SisyfosLLAyer.SisyfosSourceJingle]: {
@@ -100,7 +106,10 @@ export const sisyfosChannels: { [key in SisyfosLLAyer]?: SisyfosChannel } = {
 	[SisyfosLLAyer.SisyfosSourceTLF]: {
 		isPgm: 0
 	},
-	[SisyfosLLAyer.SisyfosSourceEpsio]: {
+	[SisyfosLLAyer.SisyfosSourceEpsio_audio_1_2]: {
+		isPgm: 0
+	},
+	[SisyfosLLAyer.SisyfosSourceEpsio_audio_3_4]: {
 		isPgm: 0
 	}
 }


### PR DESCRIPTION
This PR contains:
- New Sisyfos EVS layer for track 3/4
- Rename old Sisyfos EVS layer track to include track 1/2
- Slight refactor in the horrible global test setup to make the test for EVS still parse since the Sisyfos layer no longer matched one to one with the EVS name...