### PR TITLE
SOF-1636 - Adds content data for graphic template into metadata

### DIFF
--- a/src/tv2-common/helpers/graphics/internal/InternalGraphic.ts
+++ b/src/tv2-common/helpers/graphics/internal/InternalGraphic.ts
@@ -109,7 +109,7 @@ export abstract class InternalGraphic extends Graphic {
 				outputLayer: Tv2OutputLayer.OVERLAY,
 				partType: this.partDefinition?.type,
 				pieceExternalId: this.partDefinition?.externalId,
-				graphicTemplateName: this.templateName
+				graphicsTemplateName: this.templateName
 			}
 		}
 	}

--- a/src/tv2-common/helpers/graphics/internal/InternalGraphic.ts
+++ b/src/tv2-common/helpers/graphics/internal/InternalGraphic.ts
@@ -108,7 +108,8 @@ export abstract class InternalGraphic extends Graphic {
 				type: Tv2PieceType.GRAPHICS,
 				outputLayer: Tv2OutputLayer.OVERLAY,
 				partType: this.partDefinition?.type,
-				pieceExternalId: this.partDefinition?.externalId
+				pieceExternalId: this.partDefinition?.externalId,
+				graphicTemplateName: this.templateName
 			}
 		}
 	}

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -73,7 +73,7 @@ export interface PieceMetaData {
 export interface GraphicPieceMetaData extends PieceMetaData {
 	partType?: PartType
 	pieceExternalId?: string
-	graphicTemplateName?: string
+	graphicsTemplateName?: string
 }
 
 export interface JinglePieceMetaData extends PieceMetaData {

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -73,6 +73,7 @@ export interface PieceMetaData {
 export interface GraphicPieceMetaData extends PieceMetaData {
 	partType?: PartType
 	pieceExternalId?: string
+	graphicTemplateName?: string
 }
 
 export interface JinglePieceMetaData extends PieceMetaData {

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -123,7 +123,8 @@ describe('grafik piece', () => {
 					type: Tv2PieceType.GRAPHICS,
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
-					pieceExternalId: dummyPart.externalId
+					pieceExternalId: dummyPart.externalId,
+					graphicTemplateName: 'bund'
 				},
 				outputLayerId: SharedOutputLayer.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -400,7 +401,8 @@ describe('grafik piece', () => {
 					type: Tv2PieceType.GRAPHICS,
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
-					pieceExternalId: dummyPart.externalId
+					pieceExternalId: dummyPart.externalId,
+					graphicTemplateName: 'bund'
 				},
 				outputLayerId: SharedOutputLayer.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -550,7 +552,8 @@ describe('grafik piece', () => {
 					type: Tv2PieceType.GRAPHICS,
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
-					pieceExternalId: dummyPart.externalId
+					pieceExternalId: dummyPart.externalId,
+					graphicTemplateName: 'direkte'
 				},
 				outputLayerId: SharedOutputLayer.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsIdent,
@@ -619,7 +622,8 @@ describe('grafik piece', () => {
 					type: Tv2PieceType.GRAPHICS,
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
-					pieceExternalId: dummyPart.externalId
+					pieceExternalId: dummyPart.externalId,
+					graphicTemplateName: 'arkiv'
 				},
 				outputLayerId: SharedOutputLayer.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsIdent,

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -124,7 +124,7 @@ describe('grafik piece', () => {
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
 					pieceExternalId: dummyPart.externalId,
-					graphicTemplateName: 'bund'
+					graphicsTemplateName: 'bund'
 				},
 				outputLayerId: SharedOutputLayer.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -402,7 +402,7 @@ describe('grafik piece', () => {
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
 					pieceExternalId: dummyPart.externalId,
-					graphicTemplateName: 'bund'
+					graphicsTemplateName: 'bund'
 				},
 				outputLayerId: SharedOutputLayer.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsLower,
@@ -553,7 +553,7 @@ describe('grafik piece', () => {
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
 					pieceExternalId: dummyPart.externalId,
-					graphicTemplateName: 'direkte'
+					graphicsTemplateName: 'direkte'
 				},
 				outputLayerId: SharedOutputLayer.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsIdent,
@@ -623,7 +623,7 @@ describe('grafik piece', () => {
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
 					pieceExternalId: dummyPart.externalId,
-					graphicTemplateName: 'arkiv'
+					graphicsTemplateName: 'arkiv'
 				},
 				outputLayerId: SharedOutputLayer.OVERLAY,
 				sourceLayerId: SourceLayer.PgmGraphicsIdent,

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -77,7 +77,7 @@ describe('telefon', () => {
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
 					pieceExternalId: dummyPart.externalId,
-					graphicTemplateName: 'bund'
+					graphicsTemplateName: 'bund'
 				},
 				content: literal<WithTimeline<GraphicsContent>>({
 					fileName: 'bund',

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -76,7 +76,8 @@ describe('telefon', () => {
 					type: Tv2PieceType.GRAPHICS,
 					outputLayer: Tv2OutputLayer.OVERLAY,
 					partType: PartType.Kam,
-					pieceExternalId: dummyPart.externalId
+					pieceExternalId: dummyPart.externalId,
+					graphicTemplateName: 'bund'
 				},
 				content: literal<WithTimeline<GraphicsContent>>({
 					fileName: 'bund',


### PR DESCRIPTION
This PR adds the graphic template we receive from iNews into the piece metadata rather than us having to introduce the `content` property in our frontend. This is also to avoid using the confusing behaviour of the `content` properties having multiple purposes such as `fileName` being either a file name for a source or a type of graphic template such as "bundt". 