### PR TITLE
SOF-1823 Set proper default values for Server lookahead

### DIFF
--- a/src/tv2_afvd_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_afvd_studio/migrations/mappings-defaults.ts
@@ -395,8 +395,8 @@ export const MAPPINGS_CASPAR: BlueprintMappings = {
 		device: TSR.DeviceType.ABSTRACT,
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.PRELOAD,
-		lookaheadDepth: 1,
-		lookaheadMaxSearchDistance: -1
+		lookaheadDepth: 2,
+		lookaheadMaxSearchDistance: 10
 	}),
 	[CasparPlayerClip(1)]: literal<TSR.MappingCasparCG & BlueprintMapping>({
 		device: TSR.DeviceType.CASPARCG,

--- a/src/tv2_offtube_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_offtube_studio/migrations/mappings-defaults.ts
@@ -218,7 +218,7 @@ const MAPPINGS_CASPAR: BlueprintMappings = {
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.PRELOAD,
 		lookaheadDepth: 1,
-		lookaheadMaxSearchDistance: 1
+		lookaheadMaxSearchDistance: 5
 	}),
 	[CasparPlayerClip(1)]: literal<TSR.MappingCasparCG & BlueprintMapping>({
 		device: TSR.DeviceType.CASPARCG,


### PR DESCRIPTION
The default values for the layer mapping `casparcg_player_clip_pending` was pointing at values that would "deactivate" the lookahead functionality by saying the max search distance should be -1. 

This means that everytime we would run migrations, the layer mapping would change to an unusable value.

This PR changes the default values to be the values we actually want for lookahead, so a future migration won't ruin it.