### PR TITLE
SOF-1824 Add 1/2 audio track to ingested EVS

### DIFF
--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -675,14 +675,15 @@ export function getSourceDefinition(typeStr: string): SourceDefinition | undefin
 		}
 	} else if (EVS_RED_TEXT.test(typeStr)) {
 		const strippedToken = typeStr.match(EVS_RED_TEXT)
-		const id = `EVS ${strippedToken![1].toUpperCase()} 1/2`
-		const vo = strippedToken![2]
+		const name: string = `EVS ${strippedToken![1].toUpperCase()}`
+		const audioTrack: string = '1/2'
+		const vo: string = strippedToken![2]
 		return {
 			sourceType: SourceType.REPLAY,
-			id,
+			id: `${name} ${audioTrack}`,
 			vo: !!vo,
 			raw: strippedToken![0].trim(),
-			name: `${id}${vo ? ' ' + vo : ''}`
+			name: `${name}${vo ? ' ' + vo : ''}`
 		}
 	} else if (/EPSIO/i.test(typeStr)) {
 		return {

--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -675,7 +675,7 @@ export function getSourceDefinition(typeStr: string): SourceDefinition | undefin
 		}
 	} else if (EVS_RED_TEXT.test(typeStr)) {
 		const strippedToken = typeStr.match(EVS_RED_TEXT)
-		const id = `EVS ${strippedToken![1].toUpperCase()}`
+		const id = `EVS ${strippedToken![1].toUpperCase()} 1/2`
 		const vo = strippedToken![2]
 		return {
 			sourceType: SourceType.REPLAY,
@@ -687,7 +687,7 @@ export function getSourceDefinition(typeStr: string): SourceDefinition | undefin
 	} else if (/EPSIO/i.test(typeStr)) {
 		return {
 			sourceType: SourceType.REPLAY,
-			id: 'EPSIO',
+			id: 'EPSIO 1/2',
 			vo: true,
 			raw: typeStr,
 			name: 'EPSIO'

--- a/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
@@ -1515,7 +1515,7 @@ describe('Body parser', () => {
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
 					id: 'EVS 1 1/2',
-					name: 'EVS 1 1/2',
+					name: 'EVS 1',
 					raw: 'EVS 1',
 					vo: false
 				},
@@ -1542,7 +1542,7 @@ describe('Body parser', () => {
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
 					id: 'EVS 1 1/2',
-					name: 'EVS 1 1/2 VOV',
+					name: 'EVS 1 VOV',
 					raw: 'EVS1VOV',
 					vo: true
 				},
@@ -1568,7 +1568,7 @@ describe('Body parser', () => {
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
 					id: 'EVS 1 1/2',
-					name: 'EVS 1 1/2 VO',
+					name: 'EVS 1 VO',
 					raw: 'EVS 1 VO',
 					vo: true
 				},
@@ -1586,7 +1586,7 @@ describe('Body parser', () => {
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
 					id: 'EVS 2 1/2',
-					name: 'EVS 2 1/2 VO',
+					name: 'EVS 2 VO',
 					raw: 'EVS 2VO',
 					vo: true
 				},
@@ -1604,7 +1604,7 @@ describe('Body parser', () => {
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
 					id: 'EVS 3 1/2',
-					name: 'EVS 3 1/2 VO',
+					name: 'EVS 3 VO',
 					raw: 'EVS3VO',
 					vo: true
 				},
@@ -1622,7 +1622,7 @@ describe('Body parser', () => {
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
 					id: 'EVS 4 1/2',
-					name: 'EVS 4 1/2 VO',
+					name: 'EVS 4 VO',
 					raw: 'EVS4 VO',
 					vo: true
 				},
@@ -2564,7 +2564,7 @@ describe('Body parser', () => {
 							routing: {
 								type: CueType.Routing,
 								target: 'WALL',
-								INP1: { sourceType: SourceType.REPLAY, name: 'EVS 1 1/2', id: 'EVS 1 1/2', raw: 'EVS 1', vo: false },
+								INP1: { sourceType: SourceType.REPLAY, name: 'EVS 1', id: 'EVS 1 1/2', raw: 'EVS 1', vo: false },
 								iNewsCommand: ''
 							},
 							graphic: {
@@ -2604,7 +2604,7 @@ describe('Body parser', () => {
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
 					id: 'EVS 1 1/2',
-					name: 'EVS 1 1/2',
+					name: 'EVS 1',
 					raw: 'EVS 1',
 					vo: false
 				},

--- a/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
@@ -1514,8 +1514,8 @@ describe('Body parser', () => {
 				rawType: 'EVS 1',
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
-					id: 'EVS 1',
-					name: 'EVS 1',
+					id: 'EVS 1 1/2',
+					name: 'EVS 1 1/2',
 					raw: 'EVS 1',
 					vo: false
 				},
@@ -1541,8 +1541,8 @@ describe('Body parser', () => {
 				rawType: 'EVS1VOV',
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
-					id: 'EVS 1',
-					name: 'EVS 1 VOV',
+					id: 'EVS 1 1/2',
+					name: 'EVS 1 1/2 VOV',
 					raw: 'EVS1VOV',
 					vo: true
 				},
@@ -1567,8 +1567,8 @@ describe('Body parser', () => {
 				rawType: 'EVS 1 VO',
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
-					id: 'EVS 1',
-					name: 'EVS 1 VO',
+					id: 'EVS 1 1/2',
+					name: 'EVS 1 1/2 VO',
 					raw: 'EVS 1 VO',
 					vo: true
 				},
@@ -1585,8 +1585,8 @@ describe('Body parser', () => {
 				rawType: 'EVS 2VO',
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
-					id: 'EVS 2',
-					name: 'EVS 2 VO',
+					id: 'EVS 2 1/2',
+					name: 'EVS 2 1/2 VO',
 					raw: 'EVS 2VO',
 					vo: true
 				},
@@ -1603,8 +1603,8 @@ describe('Body parser', () => {
 				rawType: 'EVS3VO',
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
-					id: 'EVS 3',
-					name: 'EVS 3 VO',
+					id: 'EVS 3 1/2',
+					name: 'EVS 3 1/2 VO',
 					raw: 'EVS3VO',
 					vo: true
 				},
@@ -1621,8 +1621,8 @@ describe('Body parser', () => {
 				rawType: 'EVS4 VO',
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
-					id: 'EVS 4',
-					name: 'EVS 4 VO',
+					id: 'EVS 4 1/2',
+					name: 'EVS 4 1/2 VO',
 					raw: 'EVS4 VO',
 					vo: true
 				},
@@ -2564,7 +2564,7 @@ describe('Body parser', () => {
 							routing: {
 								type: CueType.Routing,
 								target: 'WALL',
-								INP1: { sourceType: SourceType.REPLAY, name: 'EVS 1', id: 'EVS 1', raw: 'EVS 1', vo: false },
+								INP1: { sourceType: SourceType.REPLAY, name: 'EVS 1 1/2', id: 'EVS 1 1/2', raw: 'EVS 1', vo: false },
 								iNewsCommand: ''
 							},
 							graphic: {
@@ -2603,8 +2603,8 @@ describe('Body parser', () => {
 				rawType: 'EVS 1',
 				sourceDefinition: {
 					sourceType: SourceType.REPLAY,
-					id: 'EVS 1',
-					name: 'EVS 1',
+					id: 'EVS 1 1/2',
+					name: 'EVS 1 1/2',
 					raw: 'EVS 1',
 					vo: false
 				},

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -138,9 +138,9 @@ export const defaultStudioConfig: StudioConfig = {
 	),
 	SourcesReplay: prepareConfig(
 		[
-			{ id: 'EVS 1', switcherSource: 5, sisyfosLayers: ['sisyfos_source_evs_1_audio_1_2'] },
-			{ id: 'EVS 2', switcherSource: 5, sisyfosLayers: ['sisyfos_source_evs_2_audio_1_2'] },
-			{ id: 'EPSIO', switcherSource: 5, sisyfosLayers: ['sisyfos_source_epsio_audio_1_2'] }
+			{ id: 'EVS 1 1/2', switcherSource: 5, sisyfosLayers: ['sisyfos_source_evs_1_audio_1_2'] },
+			{ id: 'EVS 2 1/2', switcherSource: 5, sisyfosLayers: ['sisyfos_source_evs_2_audio_1_2'] },
+			{ id: 'EPSIO 1/2', switcherSource: 5, sisyfosLayers: ['sisyfos_source_epsio_audio_1_2'] }
 		],
 		'SourcesDelayedPlayback',
 		false


### PR DESCRIPTION
After the changes to have an "audio track" on the EVS in https://github.com/tv2/sofie-blueprints-inews/pull/231, the ingested EVS from iNews could no longer find the correct sourceLayer.
This is solved by adding `1/2` to the EVS id.