### PR TITLE
SOF-1830 Set Selected Servers to Unknown and Remove Output Layer

### DIFF
--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -231,8 +231,7 @@ function getServerSelectionBlueprintPiece(
 		sourceLayerId: layers.SourceLayer.SelectedServer,
 		lifespan: PieceLifespan.WithinPart,
 		metaData: {
-			type: Tv2PieceType.VIDEO_CLIP,
-			outputLayer: Tv2OutputLayer.PROGRAM,
+			type: Tv2PieceType.UNKNOWN,
 			sourceName: contentServerElement.fileName,
 			audioMode:
 				layers.SourceLayer.SelectedServer === SharedSourceLayer.SelectedVoiceOver


### PR DESCRIPTION
This is to fix the bug of multiple pieces being shown for video clips and voice overs. This is because we have a Selected Server for each Server piece. The selected server is not something we use in the GUI and i have therefore changed the metadata to not render it. 