### PR TITLE
SOF-1889 Use full name for Lives

### DIFF
--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -701,7 +701,7 @@ export function getSourceDefinition(typeStr: string): SourceDefinition | undefin
 		return {
 			sourceType: SourceType.REMOTE,
 			remoteType: variant,
-			id,
+			id: `${variant} ${id}`, // The 'id' field needs to match the 'Name' field of the SourceMappingConfiguration.
 			raw: strippedTypeStr,
 			name: `${variant} ${id}`
 		}

--- a/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/body-parser.spec.ts
@@ -93,7 +93,7 @@ const unparsedGrafik3 = ['kg bund 3']
 const SOURCE_DEFINITION_LIVE_1: SourceDefinitionRemote = {
 	sourceType: SourceType.REMOTE,
 	remoteType: RemoteType.LIVE,
-	id: '1',
+	id: 'LIVE 1',
 	name: 'LIVE 1',
 	raw: 'LIVE 1'
 }
@@ -108,7 +108,7 @@ const unparsedEkstern1 = ['EKSTERN=LIVE 1']
 const SOURCE_DEFINITION_LIVE_2: SourceDefinitionRemote = {
 	sourceType: SourceType.REMOTE,
 	remoteType: RemoteType.LIVE,
-	id: '2',
+	id: 'LIVE 2',
 	name: 'LIVE 2',
 	raw: 'LIVE 2'
 }

--- a/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
@@ -50,14 +50,14 @@ const SOURCE_DEFINITION_KAM_2: SourceDefinitionKam = {
 const SOURCE_DEFINITION_LIVE_1: SourceDefinitionRemote = {
 	sourceType: SourceType.REMOTE,
 	remoteType: RemoteType.LIVE,
-	id: '1',
+	id: 'LIVE 1',
 	name: 'LIVE 1',
 	raw: 'LIVE 1'
 }
 const SOURCE_DEFINITION_LIVE_2: SourceDefinitionRemote = {
 	sourceType: SourceType.REMOTE,
 	remoteType: RemoteType.LIVE,
-	id: '2',
+	id: 'LIVE 2',
 	name: 'LIVE 2',
 	raw: 'LIVE 2'
 }

--- a/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/blueprint.spec.ts
@@ -908,7 +908,7 @@ describe('AFVD Blueprint', () => {
 			studioConfig: {
 				SourcesRM: [
 					{
-						SourceName: '1',
+						SourceName: 'LIVE 1',
 						SwitcherSource: 10,
 						SisyfosLayers: [],
 						StudioMics: true,
@@ -932,7 +932,7 @@ describe('AFVD Blueprint', () => {
 			studioConfig: {
 				SourcesRM: [
 					{
-						SourceName: '1',
+						SourceName: 'LIVE 1',
 						SwitcherSource: 10,
 						SisyfosLayers: [],
 						StudioMics: false,

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -10,7 +10,7 @@ function getSisyfosLayers(configName: string, id: string): string[] {
 			return []
 		case 'SourcesRM':
 		case 'SourcesFeed':
-			return ['sisyfos_source_live_' + id]
+			return ['sisyfos_source_live_' + id.match(/\d+/)]
 		case 'SourcesDelayedPlayback':
 			return ['sisyfos_source_' + id.toLowerCase().replace(/ /g, '_')]
 	}
@@ -104,16 +104,16 @@ export const defaultStudioConfig: StudioConfig = {
 	// TODO: prepareConfig is legacy code, refactor when refactoring FindSourceInfo
 	SourcesRM: prepareConfig(
 		[
-			{ id: '1', switcherSource: 1 },
-			{ id: '2', switcherSource: 2 },
-			{ id: '3', switcherSource: 3 },
-			{ id: '4', switcherSource: 4 },
-			{ id: '5', switcherSource: 5 },
-			{ id: '6', switcherSource: 6 },
-			{ id: '7', switcherSource: 7 },
-			{ id: '8', switcherSource: 8 },
-			{ id: '9', switcherSource: 9 },
-			{ id: '10', switcherSource: 10 }
+			{ id: 'LIVE 1', switcherSource: 1 },
+			{ id: 'LIVE 2', switcherSource: 2 },
+			{ id: 'LIVE 3', switcherSource: 3 },
+			{ id: 'LIVE 4', switcherSource: 4 },
+			{ id: 'LIVE 5', switcherSource: 5 },
+			{ id: 'LIVE 6', switcherSource: 6 },
+			{ id: 'LIVE 7', switcherSource: 7 },
+			{ id: 'LIVE 8', switcherSource: 8 },
+			{ id: 'LIVE 9', switcherSource: 9 },
+			{ id: 'LIVE 10', switcherSource: 10 }
 		],
 		'SourcesRM',
 		false,
@@ -121,16 +121,16 @@ export const defaultStudioConfig: StudioConfig = {
 	),
 	SourcesFeed: prepareConfig(
 		[
-			{ id: '1', switcherSource: 1 },
-			{ id: '2', switcherSource: 2 },
-			{ id: '3', switcherSource: 3 },
-			{ id: '4', switcherSource: 4 },
-			{ id: '5', switcherSource: 5 },
-			{ id: '6', switcherSource: 6 },
-			{ id: '7', switcherSource: 7 },
-			{ id: '8', switcherSource: 8 },
-			{ id: '9', switcherSource: 9 },
-			{ id: '10', switcherSource: 10 }
+			{ id: 'FEED 1', switcherSource: 1 },
+			{ id: 'FEED 2', switcherSource: 2 },
+			{ id: 'FEED 3', switcherSource: 3 },
+			{ id: 'FEED 4', switcherSource: 4 },
+			{ id: 'FEED 5', switcherSource: 5 },
+			{ id: 'FEED 6', switcherSource: 6 },
+			{ id: 'FEED 7', switcherSource: 7 },
+			{ id: 'FEED 8', switcherSource: 8 },
+			{ id: 'FEED 9', switcherSource: 9 },
+			{ id: 'FEED 10', switcherSource: 10 }
 		],
 		'SourcesFeed',
 		false,

--- a/src/tv2_afvd_studio/__tests__/graphics.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/graphics.spec.ts
@@ -334,7 +334,13 @@ describe('Graphics', () => {
 				routing: {
 					type: CueType.Routing,
 					target: 'TLF',
-					INP1: { sourceType: SourceType.REMOTE, id: '1', name: 'LIVE 1', raw: 'LIVE 1', remoteType: RemoteType.LIVE },
+					INP1: {
+						sourceType: SourceType.REMOTE,
+						id: 'LIVE 1',
+						name: 'LIVE 1',
+						raw: 'LIVE 1',
+						remoteType: RemoteType.LIVE
+					},
 					iNewsCommand: ''
 				},
 				graphic: {

--- a/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
@@ -57,7 +57,7 @@ const SOURCE_DEFINITION_KAM_1: SourceDefinitionKam = {
 const SOURCE_DEFINITION_LIVE_2: SourceDefinitionRemote = {
 	sourceType: SourceType.REMOTE,
 	remoteType: RemoteType.LIVE,
-	id: '1',
+	id: 'LIVE 1',
 	name: 'LIVE 1',
 	raw: 'Live 1'
 }


### PR DESCRIPTION
When parsing Remotes we now use both the 'LIVE' and 'number' part of the cue

Note: This change requires that the `Live mapping` studio blueprint configuration table has the name of the entries to be `LIVE X` instead of just `X`. For Live 1 it would look lik `LIVE 1`.