### PR TITLE
SOF-2010 OVL pilot graphics no longer gets a prerollduration

### DIFF
--- a/src/tv2-common/helpers/graphics/pilot/PilotGraphicGenerator.ts
+++ b/src/tv2-common/helpers/graphics/pilot/PilotGraphicGenerator.ts
@@ -20,6 +20,7 @@ import {
 	GraphicPilot,
 	HtmlPilotGraphicGenerator,
 	IsTargetingFull,
+	IsTargetingOVL,
 	IsTargetingWall,
 	PieceMetaData,
 	ShowStyleContext,
@@ -192,9 +193,15 @@ export abstract class PilotGraphicGenerator extends Graphic {
 	}
 
 	protected getPrerollDuration(): number {
-		return this.config.studio.GraphicsType === 'HTML'
-			? this.config.studio.CasparPrerollDuration
-			: this.config.studio.VizPilotGraphics.PrerollDuration
+		if (this.config.studio.GraphicsType === 'HTML') {
+			return this.config.studio.CasparPrerollDuration
+		}
+
+		if (IsTargetingOVL(this.engine)) {
+			return 0
+		}
+
+		return this.config.studio.VizPilotGraphics.PrerollDuration
 	}
 
 	protected getTv2PieceType(): Tv2PieceType {

--- a/src/tv2_afvd_studio/__tests__/graphics.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/graphics.spec.ts
@@ -191,7 +191,7 @@ describe('Graphics', () => {
 		expect(piece.sourceLayerId).toBe(SourceLayer.PgmPilotOverlay)
 		expect(piece.outputLayerId).toBe(SharedOutputLayer.OVERLAY)
 		expect(piece.enable).toEqual({ start: 2000 })
-		expect(piece.prerollDuration).toBe(context.config.studio.VizPilotGraphics.PrerollDuration)
+		expect(piece.prerollDuration).toBe(0)
 		expect(piece.lifespan).toBe(PieceLifespan.OutOnRundownChange)
 		const content = piece.content!
 		const timeline = content.timelineObjects as TSR.TSRTimelineObj[]


### PR DESCRIPTION
Pilot Overlay graphics was getting a Preroll duration assigned them which allegedly doesn't seem needed. However, this preroll duration does delay the switching of the source in the videomixer which is not good, so the delay have been removed.