### PR TITLE
SOF-2013 - Add Property for Show Style Variant Change on Segments

### DIFF
--- a/src/tv2-common/getSegment.ts
+++ b/src/tv2-common/getSegment.ts
@@ -97,6 +97,8 @@ interface SegmentMetadata {
 	miniShelfVideoClipFile?: string
 }
 
+const SHOW_STYLE_VARIANT_LOWER_CASE_CUE: string = 'sofie=showstylevariant'
+
 export async function getSegmentBase<ShowStyleConfig extends TV2ShowStyleConfig>(
 	context: SegmentContext<ShowStyleConfig>,
 	ingestSegment: IngestSegment,
@@ -127,7 +129,7 @@ export async function getSegmentBase<ShowStyleConfig extends TV2ShowStyleConfig>
 	}
 
 	segment.definesShowStyleVariant = iNewsStory.cues.some((cue) =>
-		cue ? cue[0].toLowerCase().includes('showstylevariant') : false
+		cue?.some((cueElement) => cueElement.toLowerCase().includes(SHOW_STYLE_VARIANT_LOWER_CASE_CUE))
 	)
 
 	const totalTimeMs = TimeFromINewsField(iNewsStory.fields.totalTime) * 1000


### PR DESCRIPTION
This PR introduces a property on segments that will tell us whether or not a new show style variant is defined by the segment. This is to be used in Sofie Server so we can reingest based on the property.

This is used in the Sofie Server PR: https://github.com/tv2/sofie-server/pull/169