### PR TITLE
SOF-2119 Able to set Preview in VideoMixer

### DIFF
--- a/src/tv2-common/videoSwitchers/Atem.ts
+++ b/src/tv2-common/videoSwitchers/Atem.ts
@@ -40,7 +40,7 @@ export class Atem extends VideoSwitcherBase {
 	public getMixEffectTimelineObject(props: MixEffectProps): TSR.TimelineObjAtemME & TimelineBlueprintExt {
 		const { content } = props
 		const me: TSR.TimelineObjAtemME['content']['me'] =
-			content.input && content.transition
+			content.input && content.transition && content.transition !== TransitionStyle.CUT
 				? {
 						input: this.getInputNumber(content.input),
 						transition: this.getTransition(content.transition),

--- a/src/tv2-common/videoSwitchers/VideoSwitcher.ts
+++ b/src/tv2-common/videoSwitchers/VideoSwitcher.ts
@@ -4,6 +4,7 @@ import {
 	AuxProps,
 	DskProps,
 	DveProps,
+	getTimeFromFrames,
 	MixEffectProps,
 	OnAirMixEffectProps,
 	SpecialInput,
@@ -53,6 +54,25 @@ export abstract class VideoSwitcherBase implements VideoSwitcher {
 				layer: this.uniformConfig.switcherLLayers.primaryMixEffect
 			})
 		)
+
+		// In order to set the preview we need to create another TimelineObject after the transition is over that sets program and preview.
+		if (properties.content.transitionDuration) {
+			// We need a slight delay before we tell the VideoMixer to set the next source, else we risk that the VideoMixer sets the next source in program.
+			const previewTimelineObjectDelay: number = 300
+			result.push(
+				this.getMixEffectTimelineObject({
+					...properties,
+					id: primaryId + Math.floor(Math.random() * 10000),
+					layer: this.uniformConfig.switcherLLayers.primaryMixEffect,
+					enable: { start: getTimeFromFrames(properties.content.transitionDuration) + previewTimelineObjectDelay },
+					content: {
+						input: properties.content.input,
+						transition: undefined
+					}
+				})
+			)
+		}
+
 		if (this.uniformConfig.switcherLLayers.primaryMixEffectClone) {
 			result.push(
 				this.getMixEffectTimelineObject({

--- a/src/tv2-common/videoSwitchers/__tests__/Atem.spec.ts
+++ b/src/tv2-common/videoSwitchers/__tests__/Atem.spec.ts
@@ -80,7 +80,7 @@ describe('ATEM', () => {
 			})
 		})
 
-		test('sets input when CUT transition provided', () => {
+		test('sets programInput when CUT transition provided', () => {
 			const atem = createTestee()
 			const timelineObject = atem.getMixEffectTimelineObject({
 				layer: SwitcherMixEffectLLayer.PROGRAM,
@@ -92,8 +92,7 @@ describe('ATEM', () => {
 			expect(timelineObject).toMatchObject({
 				content: {
 					me: {
-						input: 5,
-						transition: TSR.AtemTransitionStyle.CUT
+						programInput: 5
 					}
 				}
 			})

--- a/src/tv2_afvd_showstyle/__tests__/transitions.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/transitions.spec.ts
@@ -125,7 +125,7 @@ function testNotes(context: SegmentUserContextMock) {
 }
 
 describe('Primary Cue Transitions Without Config', () => {
-	it('Cuts by default for KAM', async () => {
+	it('Transition is undefined by default for KAM', async () => {
 		const ingestSegment = _.clone(templateSegment)
 
 		ingestSegment.payload.iNewsStory.body = '\r\n<p><pi>KAM 1</pi><p>'
@@ -138,7 +138,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const piece = getPieceOnLayerFromPart(segment, SourceLayer.PgmCam)
 		const atemCutObj = getATEMMEObj(piece)
 
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds effekt to KAM', async () => {
@@ -156,7 +156,7 @@ describe('Primary Cue Transitions Without Config', () => {
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_2))
 
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds mix to KAM', async () => {
@@ -183,7 +183,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		expect(atemCutObj.content.me.transitionSettings?.mix?.rate).toBe(11)
 	})
 
-	it('Cuts by default for EVS1', async () => {
+	it('Transition is undefined by default for EVS1', async () => {
 		const ingestSegment = _.clone(templateSegment)
 
 		ingestSegment.payload.iNewsStory.body = '\r\n<p><pi>EVS 1</pi><p>'
@@ -196,7 +196,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const piece = getPieceOnLayerFromPart(segment, SourceLayer.PgmLocal)
 		const atemCutObj = getATEMMEObj(piece)
 
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds effekt to EVS1', async () => {
@@ -213,7 +213,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const atemCutObj = getATEMMEObj(piece)
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_1))
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds mix to EVS1', async () => {
@@ -240,7 +240,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		expect(atemCutObj.content.me.transitionSettings?.mix?.rate).toBe(15)
 	})
 
-	it('Cuts by default for EVS1VO', async () => {
+	it('Transition is undefined by default for EVS1VO', async () => {
 		const ingestSegment = _.clone(templateSegment)
 
 		ingestSegment.payload.iNewsStory.body = '\r\n<p><pi>EVS1VO</pi><p>'
@@ -253,7 +253,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const piece = getPieceOnLayerFromPart(segment, SourceLayer.PgmLocal)
 		const atemCutObj = getATEMMEObj(piece)
 
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds effekt to EVS1VO', async () => {
@@ -270,7 +270,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const atemCutObj = getATEMMEObj(piece)
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_1))
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds mix to EVS1VO', async () => {
@@ -297,7 +297,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		expect(atemCutObj.content.me.transitionSettings?.mix?.rate).toBe(25)
 	})
 
-	it('Cuts by default for SERVER', async () => {
+	it('Transition is undefined by default for SERVER', async () => {
 		const ingestSegment = _.clone(templateSegment)
 
 		ingestSegment.payload.iNewsStory.body = '\r\n<p><pi>SERVER</pi><p>'
@@ -310,7 +310,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const piece = getPieceOnLayerFromPart(segment, SourceLayer.PgmServer)
 		const atemCutObj = getATEMMEObj(piece)
 
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds effekt to SERVER', async () => {
@@ -327,7 +327,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const atemCutObj = getATEMMEObj(piece)
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_2))
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds mix to SERVER', async () => {
@@ -354,7 +354,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		expect(atemCutObj.content.me.transitionSettings?.mix?.rate).toBe(20)
 	})
 
-	it('Cuts by default for VO', async () => {
+	it('Transition is undefined by default for VO', async () => {
 		const ingestSegment = _.clone(templateSegment)
 
 		ingestSegment.payload.iNewsStory.body = '\r\n<p><pi>VO</pi><p>'
@@ -367,7 +367,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const piece = getPieceOnLayerFromPart(segment, SourceLayer.PgmVoiceOver)
 		const atemCutObj = getATEMMEObj(piece)
 
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds effekt to VO', async () => {
@@ -384,7 +384,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const atemCutObj = getATEMMEObj(piece)
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_1))
-		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+		expect(atemCutObj.content.me.transition).toBe(undefined)
 	})
 
 	it('Adds mix to VO', async () => {

--- a/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
@@ -409,10 +409,10 @@ function getATEMMEObj(piece: IBlueprintPieceInstance): TSR.TimelineObjAtemME {
 	return atemObj!
 }
 
-function expectATEMToCut(piece: IBlueprintPieceInstance) {
+function expectUndefinedTransition(piece: IBlueprintPieceInstance): void {
 	const atemObj = getATEMMEObj(piece)
 
-	expect(atemObj.content.me.transition).toBe(TSR.AtemTransitionStyle.CUT)
+	expect(atemObj.content.me.transition).toBe(undefined)
 }
 
 function expectATEMToMixOver(piece: IBlueprintPieceInstance, frames: number) {
@@ -956,7 +956,7 @@ describe('Combination Actions', () => {
 
 		validateNextPartExistsWithDuration(context, 0)
 		validateCameraPiece(camPiece)
-		expectATEMToCut(camPiece!)
+		expectUndefinedTransition(camPiece!)
 
 		await executeActionOfftube(context, AdlibActionType.TAKE_WITH_TRANSITION, setMIX20AsTransition)
 
@@ -999,7 +999,7 @@ describe('Combination Actions', () => {
 
 		validateNextPartExistsWithDuration(context, 0)
 		validateCameraPiece(camPiece)
-		expectATEMToCut(camPiece!)
+		expectUndefinedTransition(camPiece!)
 
 		await executeActionOfftube(context, AdlibActionType.TAKE_WITH_TRANSITION, setMIX20AsTransition)
 
@@ -1042,7 +1042,7 @@ describe('Combination Actions', () => {
 
 		validateNextPartExistsWithDuration(context, 0)
 		validateCameraPiece(camPiece)
-		expectATEMToCut(camPiece!)
+		expectUndefinedTransition(camPiece!)
 
 		await executeActionOfftube(context, AdlibActionType.TAKE_WITH_TRANSITION, setMIX20AsTransition)
 
@@ -1085,7 +1085,7 @@ describe('Combination Actions', () => {
 
 		validateNextPartExistsWithDuration(context, 0)
 		validateCameraPiece(camPiece)
-		expectATEMToCut(camPiece!)
+		expectUndefinedTransition(camPiece!)
 
 		await executeActionOfftube(context, AdlibActionType.TAKE_WITH_TRANSITION, setMIX20AsTransition)
 


### PR DESCRIPTION
When creating TimelineObjects for the VideoMixer, if there is a transition, create an extra Timelineobject for when the transition is over to update the value in the Preview in the VideoMixer.

Due to how VideoMixers works, we can't update the Preview while we are doing a transition. If we did, the transition would continue but it would use the updated value. We don't want that, so we have to wait untill the transition is over before updating the Preview. This is what the new TimelineObject does. It starts when the transition is over (plus a slight delay to avoid a race condition) and then updates the Preview.

Note: When we simply receive a CUT transition, we don't create a TimelineObject with transition properties. If we did, then the library `sofie-atem-state` would not update the Preview. This is also why there is a lot of test that used to check for the CUT value, that now checks for undefined. (`sofie-atem-state` will automatically make a CUT transition if it doesn receive any transition properties).

Also note: To update the preview we need to use the `programInput` instead of simply `input`. This is because of the Atem types exposed by TSR. `programInput` will is not the value for the Preview, but `sofie-atem-state` won't update the Preview unless the Program is being updated from `programInput`. The actually value of Preview is, at the time of writing, being set by TSR.
