### PR TITLE
SOF-2203: Uses part index in segment to assign action rank.

### DIFF
--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -107,6 +107,8 @@ const STOPPABLE_GRAPHICS_LAYERS = [
 	SharedSourceLayer.PgmGraphicsTLF
 ]
 
+const EXECUTE_ACTION_PART_INDEX: number = 0
+
 export interface ActionExecutionSettings<BlueprintConfig extends TV2ShowStyleConfig = TV2ShowStyleConfig> {
 	EvaluateCues: (
 		context: ShowStyleContext<BlueprintConfig>,
@@ -117,6 +119,7 @@ export interface ActionExecutionSettings<BlueprintConfig extends TV2ShowStyleCon
 		mediaSubscriptions: HackPartMediaObjectSubscription[],
 		cues: CueDefinition[],
 		partDefinition: PartDefinition,
+		partIndex: number,
 		options: EvaluateCuesOptions
 	) => void
 	DVEGeneratorOptions: DVEOptions
@@ -471,10 +474,21 @@ async function executeActionSelectServerClip<
 		})
 	}
 
-	settings.EvaluateCues(context, basePart.part.part, grafikPieces, [], [], [], partDefinition.cues, partDefinition, {
-		excludeAdlibs: true,
-		selectedCueTypes: [CueType.Graphic]
-	})
+	settings.EvaluateCues(
+		context,
+		basePart.part.part,
+		grafikPieces,
+		[],
+		[],
+		[],
+		partDefinition.cues,
+		partDefinition,
+		EXECUTE_ACTION_PART_INDEX,
+		{
+			excludeAdlibs: true,
+			selectedCueTypes: [CueType.Graphic]
+		}
+	)
 
 	if (basePart.invalid || !activeServerPiece || !serverDataStore) {
 		context.core.notifyUserWarning(`Could not start server clip`)

--- a/src/tv2_afvd_showstyle/helpers/pieces/evaluateCues.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/evaluateCues.ts
@@ -37,6 +37,7 @@ export async function EvaluateCues(
 	mediaSubscriptions: HackPartMediaObjectSubscription[],
 	cues: CueDefinition[],
 	partDefinition: PartDefinition,
+	partIndex: number,
 	options: EvaluateCuesOptions
 ) {
 	await EvaluateCuesBase(
@@ -65,6 +66,7 @@ export async function EvaluateCues(
 		mediaSubscriptions,
 		cues,
 		partDefinition,
-		options
+		options,
+		partIndex
 	)
 }

--- a/src/tv2_afvd_showstyle/parts/evs.ts
+++ b/src/tv2_afvd_showstyle/parts/evs.ts
@@ -34,6 +34,7 @@ import { CreateEffektForpart } from './effekt'
 export async function CreatePartEVS(
 	context: SegmentContext<GalleryBlueprintConfig>,
 	partDefinition: PartDefinitionEVS,
+	partIndex: number,
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(context.config, partDefinition, totalWords, false)
@@ -88,6 +89,7 @@ export async function CreatePartEVS(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{}
 	)
 	AddScript(partDefinition, pieces, partTime, SourceLayer.PgmScript)

--- a/src/tv2_afvd_showstyle/parts/grafik.ts
+++ b/src/tv2_afvd_showstyle/parts/grafik.ts
@@ -22,6 +22,7 @@ import { SourceLayer } from '../layers'
 export async function CreatePartGrafik(
 	context: ShowStyleContext<GalleryBlueprintConfig>,
 	partDefinition: PartDefinition,
+	partIndex: number,
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(context.config, partDefinition, totalWords, false)
@@ -51,6 +52,7 @@ export async function CreatePartGrafik(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{
 			isGrafikPart: true
 		}

--- a/src/tv2_afvd_showstyle/parts/intro.ts
+++ b/src/tv2_afvd_showstyle/parts/intro.ts
@@ -23,6 +23,7 @@ import { SourceLayer } from '../layers'
 export async function CreatePartIntro(
 	context: ShowStyleContext<GalleryBlueprintConfig>,
 	partDefinition: PartDefinition,
+	partIndex: number,
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(context.config, partDefinition, totalWords, false)
@@ -80,6 +81,7 @@ export async function CreatePartIntro(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{}
 	)
 	AddScript(partDefinition, pieces, partTime, SourceLayer.PgmScript)

--- a/src/tv2_afvd_showstyle/parts/kam.ts
+++ b/src/tv2_afvd_showstyle/parts/kam.ts
@@ -34,6 +34,7 @@ import { CreateEffektForpart } from './effekt'
 export async function CreatePartKam(
 	context: SegmentContext<GalleryBlueprintConfig>,
 	partDefinition: PartDefinitionKam,
+	partIndex: number,
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partKamBase = CreatePartKamBase(context, partDefinition, totalWords)
@@ -131,6 +132,7 @@ export async function CreatePartKam(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{}
 	)
 	AddScript(partDefinition, pieces, partTime, SourceLayer.PgmScript)

--- a/src/tv2_afvd_showstyle/parts/live.ts
+++ b/src/tv2_afvd_showstyle/parts/live.ts
@@ -7,7 +7,7 @@ import {
 } from 'blueprints-integration'
 import { AddScript, CueDefinition, Part, PartDefinition, PartTime, SegmentContext } from 'tv2-common'
 import { CueType } from 'tv2-constants'
-import { GalleryBlueprintConfig } from '../../tv2_afvd_showstyle/helpers/config'
+import { GalleryBlueprintConfig } from '../helpers/config'
 import { EvaluateCues } from '../helpers/pieces/evaluateCues'
 import { SourceLayer } from '../layers'
 import { CreateEffektForpart } from './effekt'
@@ -15,6 +15,7 @@ import { CreateEffektForpart } from './effekt'
 export async function CreatePartLive(
 	context: SegmentContext<GalleryBlueprintConfig>,
 	partDefinition: PartDefinition,
+	partIndex: number,
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(context.config, partDefinition, totalWords, false)
@@ -41,6 +42,7 @@ export async function CreatePartLive(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{}
 	)
 	AddScript(partDefinition, pieces, partTime, SourceLayer.PgmScript)

--- a/src/tv2_afvd_showstyle/parts/server.ts
+++ b/src/tv2_afvd_showstyle/parts/server.ts
@@ -9,6 +9,7 @@ import { CreateEffektForpart } from './effekt'
 export async function CreatePartServer(
 	context: SegmentContext<GalleryBlueprintConfig>,
 	partDefinition: PartDefinition,
+	partIndex: number,
 	partProps: ServerPartProps
 ): Promise<BlueprintResultPart> {
 	const basePartProps = await CreatePartServerBase(context, partDefinition, partProps, {
@@ -50,6 +51,7 @@ export async function CreatePartServer(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{}
 	)
 

--- a/src/tv2_afvd_showstyle/parts/teknik.ts
+++ b/src/tv2_afvd_showstyle/parts/teknik.ts
@@ -13,6 +13,7 @@ import { SourceLayer } from '../layers'
 export async function CreatePartTeknik(
 	context: SegmentContext<GalleryBlueprintConfig>,
 	partDefinition: PartDefinition,
+	partIndex: number,
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(context.config, partDefinition, totalWords, false)
@@ -36,6 +37,7 @@ export async function CreatePartTeknik(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{}
 	)
 	AddScript(partDefinition, pieces, partTime, SourceLayer.PgmScript)

--- a/src/tv2_afvd_showstyle/parts/unknown.ts
+++ b/src/tv2_afvd_showstyle/parts/unknown.ts
@@ -23,6 +23,7 @@ import { CreateEffektForpart } from './effekt'
 export async function CreatePartUnknown(
 	context: ShowStyleContext<GalleryBlueprintConfig>,
 	partDefinition: PartDefinition,
+	partIndex: number,
 	totalWords: number,
 	asAdlibs?: boolean
 ) {
@@ -41,8 +42,11 @@ export async function CreatePartUnknown(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
-	part = { ...part, ...CreateEffektForpart(context, partDefinition, pieces) }
-	part = { ...part, ...GetJinglePartProperties(context, partDefinition) }
+	part = {
+		...part,
+		...CreateEffektForpart(context, partDefinition, pieces),
+		...GetJinglePartProperties(context, partDefinition)
+	}
 
 	if (
 		partDefinition.cues.some((cue) => cue.type === CueType.Graphic && GraphicIsPilot(cue) && cue.target === 'FULL') &&
@@ -60,6 +64,7 @@ export async function CreatePartUnknown(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{
 			adlib: asAdlibs
 		}

--- a/src/tv2_afvd_studio/__tests__/graphics.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/graphics.spec.ts
@@ -47,7 +47,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartGrafik(context, partDefintion, 0)
+		const result = await CreatePartGrafik(context, partDefintion, 0, 0)
 
 		expect((context.core as SegmentUserContextMock).getNotes().map((msg) => msg.message)).toEqual([
 			`No graphic found after GRAFIK cue`
@@ -84,7 +84,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		CreatePartGrafik(context, partDefinition, 0)
+		CreatePartGrafik(context, partDefinition, 0, 0)
 
 		expect((context.core as SegmentUserContextMock).getNotes().map((msg) => msg.message)).toEqual([
 			`Graphic found without target engine`
@@ -121,7 +121,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartGrafik(context, partDefinition, 0)
+		const result = await CreatePartGrafik(context, partDefinition, 0, 0)
 		expect(result.pieces).toHaveLength(2)
 		const piece = result.pieces[0]
 		expect(piece.sourceLayerId).toBe(SourceLayer.PgmPilot)
@@ -185,7 +185,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartGrafik(context, partDefinition, 0)
+		const result = await CreatePartGrafik(context, partDefinition, 0, 0)
 		expect(result.pieces).toHaveLength(1)
 		const piece = result.pieces[0]
 		expect(piece.sourceLayerId).toBe(SourceLayer.PgmPilotOverlay)
@@ -242,7 +242,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartGrafik(context, partDefinition, 0)
+		const result = await CreatePartGrafik(context, partDefinition, 0, 0)
 		expect(result.pieces).toHaveLength(1)
 		const piece = result.pieces[0]
 		expect(piece.sourceLayerId).toBe(SourceLayer.WallGraphics)
@@ -296,7 +296,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartGrafik(context, partDefinition, 0)
+		const result = await CreatePartGrafik(context, partDefinition, 0, 0)
 		expect(result.pieces).toHaveLength(2)
 		const piece = result.pieces[0]
 		expect(piece.sourceLayerId).toBe(SourceLayer.PgmGraphicsTLF)
@@ -366,7 +366,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartGrafik(context, partDefinition, 0)
+		const result = await CreatePartGrafik(context, partDefinition, 0, 0)
 		expect(result.pieces).toHaveLength(3)
 		const auxPiece = result.pieces.find((p) => p.outputLayerId === SharedOutputLayer.AUX)!
 		expect(auxPiece.enable).toEqual({ start: 0 })
@@ -405,7 +405,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartUnknown(context, partDefinition, 0)
+		const result = await CreatePartUnknown(context, partDefinition, 0, 0)
 		expect(result.pieces).toHaveLength(1)
 		const piece = result.pieces[0]
 		expect(piece).toBeTruthy()
@@ -440,7 +440,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartUnknown(context, partDefinition, 0)
+		const result = await CreatePartUnknown(context, partDefinition, 0, 0)
 		expect(result.pieces).toHaveLength(1)
 		const piece = result.pieces[0]
 		expect(piece.lifespan).toBe('rundown-change-segment-lookback')
@@ -471,7 +471,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartUnknown(context, partDefinition, 0)
+		const result = await CreatePartUnknown(context, partDefinition, 0, 0)
 		expect(result.pieces).toHaveLength(1)
 		const piece = result.pieces[0]
 		expect(piece).toBeTruthy()
@@ -522,7 +522,7 @@ describe('Graphics', () => {
 			segmentRank: 0
 		})
 
-		const result = await CreatePartUnknown(context, partDefinition, 0)
+		const result = await CreatePartUnknown(context, partDefinition, 0, 0)
 		expect(result.pieces).toHaveLength(1)
 		const piece = result.pieces[0]
 		expect(piece).toBeTruthy()

--- a/src/tv2_offtube_showstyle/helpers/EvaluateCues.ts
+++ b/src/tv2_offtube_showstyle/helpers/EvaluateCues.ts
@@ -33,6 +33,7 @@ export async function OfftubeEvaluateCues(
 	mediaSubscriptions: HackPartMediaObjectSubscription[],
 	cues: CueDefinition[],
 	partDefinition: PartDefinition,
+	partIndex: number,
 	options: EvaluateCuesOptions
 ) {
 	await EvaluateCuesBase(
@@ -57,6 +58,7 @@ export async function OfftubeEvaluateCues(
 		mediaSubscriptions,
 		cues,
 		partDefinition,
-		options
+		options,
+		partIndex
 	)
 }

--- a/src/tv2_offtube_showstyle/parts/OfftubeDVE.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeDVE.ts
@@ -14,6 +14,7 @@ import { OfftubeSourceLayer } from '../layers'
 export async function OfftubeCreatePartDVE(
 	context: SegmentContext<OfftubeBlueprintConfig>,
 	partDefinition: PartDefinitionDVE,
+	partIndex: number,
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partTime = PartTime(context.config, partDefinition, totalWords, false)
@@ -38,6 +39,7 @@ export async function OfftubeCreatePartDVE(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{
 			adlib: true
 		}

--- a/src/tv2_offtube_showstyle/parts/OfftubeGrafik.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeGrafik.ts
@@ -13,6 +13,7 @@ import { OfftubeSourceLayer } from '../layers'
 export async function OfftubeCreatePartGrafik(
 	context: SegmentContext<OfftubeBlueprintConfig>,
 	partDefinition: PartDefinition,
+	partIndex: number,
 	totalWords: number,
 	asAdlibs?: boolean
 ) {
@@ -42,6 +43,7 @@ export async function OfftubeCreatePartGrafik(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{
 			adlib: asAdlibs
 		}

--- a/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
@@ -33,6 +33,7 @@ import { CreateEffektForpart } from './OfftubeEffekt'
 export async function OfftubeCreatePartKam(
 	context: SegmentContext<OfftubeBlueprintConfig>,
 	partDefinition: PartDefinitionKam,
+	partIndex: number,
 	totalWords: number
 ): Promise<BlueprintResultPart> {
 	const partKamBase = CreatePartKamBase(context, partDefinition, totalWords)
@@ -128,6 +129,7 @@ export async function OfftubeCreatePartKam(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{}
 	)
 

--- a/src/tv2_offtube_showstyle/parts/OfftubeServer.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeServer.ts
@@ -16,6 +16,7 @@ import { CreateEffektForpart } from './OfftubeEffekt'
 export async function OfftubeCreatePartServer(
 	context: SegmentContext<OfftubeBlueprintConfig>,
 	partDefinition: PartDefinition,
+	partIndex: number,
 	partProps: ServerPartProps
 ): Promise<BlueprintResultPart> {
 	const basePartProps = await CreatePartServerBase(context, partDefinition, partProps, {
@@ -78,6 +79,7 @@ export async function OfftubeCreatePartServer(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{}
 	)
 

--- a/src/tv2_offtube_showstyle/parts/OfftubeUnknown.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeUnknown.ts
@@ -22,6 +22,7 @@ import { OfftubeSourceLayer } from '../layers'
 export async function CreatePartUnknown(
 	context: SegmentContext<OfftubeBlueprintConfig>,
 	partDefinition: PartDefinition,
+	partIndex: number,
 	totalWords: number,
 	asAdlibs?: boolean
 ) {
@@ -58,6 +59,7 @@ export async function CreatePartUnknown(
 		mediaSubscriptions,
 		partDefinition.cues,
 		partDefinition,
+		partIndex,
 		{
 			adlib: asAdlibs
 		}


### PR DESCRIPTION
Previously, action ranks were calculated by segment rank and cue index in part. This caused actions generated from segments, with multiple parts to not have the right order and get mixed if more than one action is generated per part.