### PR TITLE
SOF-2206/DVE Locators Look Weird Due to Wrong Opacity Value

### DIFF
--- a/src/tv2-common/helpers/graphics/caspar/__tests__/htmlPilotGraphicGenerator.spec.ts
+++ b/src/tv2-common/helpers/graphics/caspar/__tests__/htmlPilotGraphicGenerator.spec.ts
@@ -88,7 +88,7 @@ describe('HtmlPilotGraphicGenerator', () => {
 					},
 					useStopCommand: false,
 					mixer: {
-						opacity: 100
+						opacity: 1
 					}
 				})
 			)
@@ -158,7 +158,7 @@ describe('HtmlPilotGraphicGenerator', () => {
 					},
 					useStopCommand: false,
 					mixer: {
-						opacity: 100
+						opacity: 1
 					}
 				})
 			)

--- a/src/tv2-common/helpers/graphics/caspar/htmlPilotGraphicGenerator.ts
+++ b/src/tv2-common/helpers/graphics/caspar/htmlPilotGraphicGenerator.ts
@@ -78,7 +78,7 @@ export class HtmlPilotGraphicGenerator extends PilotGraphicGenerator {
 						data: templateData,
 						useStopCommand: false,
 						mixer: {
-							opacity: 100
+							opacity: 1
 						}
 					}
 				}),

--- a/src/tv2-common/helpers/graphics/caspar/util.ts
+++ b/src/tv2-common/helpers/graphics/caspar/util.ts
@@ -27,7 +27,7 @@ export function CreateHTMLRendererContent(
 		},
 		useStopCommand: false,
 		mixer: {
-			opacity: 100
+			opacity: 1
 		}
 	}
 }


### PR DESCRIPTION
The opacity value which used to be `100` was passed all the way through to the CasparCG. The theory is that this used to be handled elsewhere before the TSR was updated. Changing it to `1` which is the correct CasparCG value (interval between 0 and 1) fixed the issue we experienced.