### PR TITLE
SOF-2291: Use studio microphones for all voice overs

### DIFF
--- a/src/tv2-common/helpers/sisyfos.ts
+++ b/src/tv2-common/helpers/sisyfos.ts
@@ -113,7 +113,7 @@ function GetSisyfosTimelineObjForSource(
 			})
 		)
 	})
-	if (sourceInfo.useStudioMics && (!enableStudioMicsOnlyForVo || vo)) {
+	if (vo || (sourceInfo.useStudioMics && !enableStudioMicsOnlyForVo)) {
 		result.push(getStudioMicsTimelineObj(config, timelineEnable))
 	}
 	return result

--- a/src/tv2-common/helpers/sisyfos.ts
+++ b/src/tv2-common/helpers/sisyfos.ts
@@ -22,7 +22,7 @@ export function GetSisyfosTimelineObjForRemote(
 }
 
 export function GetSisyfosTimelineObjForReplay(config: TV2ShowStyleConfig, sourceInfo: SourceInfo, vo: boolean) {
-	return GetSisyfosTimelineObjForSource(config, sourceInfo, vo, true)
+	return GetSisyfosTimelineObjForSource(config, sourceInfo, vo, false)
 }
 
 export function GetSisyfosTimelineObjForServer(


### PR DESCRIPTION
The PR makes it so that all voice overs make use of studio microphones, and enable replay 100% audio content to use studio microphones. The latter, requires that `Use Studio Microphones` are disabled in _Replay Mappings_ under settings to get the default behavior.