### PR TITLE
SOF-2454 Assign ME types to TriCaster ME content

### DIFF
--- a/src/tv2-common/videoSwitchers/TriCaster.ts
+++ b/src/tv2-common/videoSwitchers/TriCaster.ts
@@ -74,7 +74,8 @@ export class TriCaster extends VideoSwitcherBase {
 			content: {
 				deviceType: TSR.DeviceType.TRICASTER,
 				type: TSR.TimelineContentTypeTriCaster.ME,
-				me: {
+				me: literal<TSR.TriCasterMixEffect & { type: 'PROGRAM' }>({
+					type: 'PROGRAM',
 					programInput: this.getInputName(content.input),
 					...(content.previewInput !== undefined && transition === 'cut'
 						? { previewInput: this.getInputName(content.previewInput) }
@@ -83,7 +84,7 @@ export class TriCaster extends VideoSwitcherBase {
 					transitionEffect: transition,
 					transitionDuration: this.getTransitionDuration(content.transition, content.transitionDuration),
 					keyers: content.keyers && this.getKeyers(content.keyers)
-				}
+				})
 			}
 		}
 		return result
@@ -134,14 +135,15 @@ export class TriCaster extends VideoSwitcherBase {
 			content: {
 				deviceType: TSR.DeviceType.TRICASTER,
 				type: TSR.TimelineContentTypeTriCaster.ME,
-				me: {
+				me: literal<TSR.TriCasterMixEffect & { type: 'DOWNSTREAM_KEYER' }>({
+					type: 'DOWNSTREAM_KEYER',
 					keyers: {
 						[`dsk${props.content.config.Number + 1}`]: {
 							onAir: props.content.onAir,
 							input: this.getInputName(props.content.config.Fill)
 						}
 					}
-				}
+				})
 			}
 		}
 	}
@@ -224,7 +226,8 @@ export class TriCaster extends VideoSwitcherBase {
 				content: {
 					deviceType: TSR.DeviceType.TRICASTER,
 					type: TSR.TimelineContentTypeTriCaster.ME,
-					me: literal<TSR.TriCasterMixEffectInEffectMode>({
+					me: literal<TSR.TriCasterMixEffectInEffectMode & { type: 'EFFECT_MODE' }>({
+						type: 'EFFECT_MODE',
 						transitionEffect: 7,
 						layers: this.generateDveBoxLayers(dveProps.content.boxes),
 						keyers: this.generateOverlayKeyer(dveProps.content.artFillSource)


### PR DESCRIPTION
In Alba we have introduced `TriCasterMixEffectContentType` on the ME content of TriCaster TimelineObject.
This is not something that Blueprints have supported and hence TimelineObjects generated from Bluerprints don't have this value.

So when Alba makes a check for it, like on line 308 in the snippet below, it will always return undefined.
![image](https://github.com/user-attachments/assets/9872888b-0810-439c-8cc3-356271d7d726)

So any flows in Alba that needs these values won't work.

This PR introduce these values in Blueprints for TriCaster ME TimelineObjects.

Note that to add this attribute the `&` syntax has been used. This is because Blueprints fetches the types from BlueprintIntegration and we would have to publish a new version of BlueprintIntegration if we wanted to include them there. Since this is Alba only, and we want to get rid of Blueprints, we are simply using this syntax for now.

The "magic strings" are defined in AlbaServer as `TriCasterMixEffectContentType`.
![image](https://github.com/user-attachments/assets/eb5d2130-42b6-4ac3-a3f6-52c669dbf95e)

