### PR TITLE
SOF-2499 TriCaster now creates a separate TimelineObject for SplitScreen DSK

### DIFF
--- a/src/tv2-common/videoSwitchers/TriCaster.ts
+++ b/src/tv2-common/videoSwitchers/TriCaster.ts
@@ -229,7 +229,19 @@ export class TriCaster extends VideoSwitcherBase {
 					me: literal<TSR.TriCasterMixEffectInEffectMode & { type: 'EFFECT_MODE' }>({
 						type: 'EFFECT_MODE',
 						transitionEffect: 7,
-						layers: this.generateDveBoxLayers(dveProps.content.boxes),
+						layers: this.generateDveBoxLayers(dveProps.content.boxes)
+					}),
+					temporalPriority: TemporalPriority.DVE
+				}
+			},
+			{
+				...this.getBaseProperties(dveProps, SwitcherDveLLayer.DVE),
+				content: {
+					deviceType: TSR.DeviceType.TRICASTER,
+					type: TSR.TimelineContentTypeTriCaster.ME,
+					me: literal<TSR.TriCasterMixEffectInEffectMode & { type: 'EFFECT_MODE' }>({
+						type: 'EFFECT_MODE',
+						transitionEffect: 7,
 						keyers: this.generateOverlayKeyer(dveProps.content.artFillSource)
 					}),
 					temporalPriority: TemporalPriority.DVE

--- a/src/tv2-common/videoSwitchers/__tests__/TriCaster.spec.ts
+++ b/src/tv2-common/videoSwitchers/__tests__/TriCaster.spec.ts
@@ -585,12 +585,13 @@ describe('TriCaster', () => {
 	})
 
 	describe('getDveTimelineObjects', () => {
-		it('creates one TriCaster DVE timelineObject', () => {
+		it('creates two TriCaster DVE timelineObject', () => {
 			const testee: TriCaster = createTestee()
 			const result: TSR.TSRTimelineObj[] = testee.getDveTimelineObjects(getBasicDveProps())
 
-			expect(result).toHaveLength(1)
+			expect(result).toHaveLength(2)
 			expect(result[0].layer).toBe(prefixLayer(SwitcherDveLLayer.DVE_BOXES))
+			expect(result[1].layer).toBe(prefixLayer(SwitcherDveLLayer.DVE))
 		})
 
 		// TODO: Replace with interface
@@ -625,7 +626,7 @@ describe('TriCaster', () => {
 			} as any as TV2StudioConfigBase)
 			const testee: TriCaster = createTestee({ config: instance(config) })
 			const basicDveProps = getBasicDveProps()
-			const content: TSR.TimelineObjTriCasterME['content'] = testee.getDveTimelineObjects(basicDveProps)[0]
+			const content: TSR.TimelineObjTriCasterME['content'] = testee.getDveTimelineObjects(basicDveProps)[1]
 				.content as TSR.TimelineObjTriCasterME['content']
 			const result: Record<TSR.TriCasterKeyerName, TSR.TriCasterKeyer> = content.me.keyers!
 


### PR DESCRIPTION
For some reason, the TriCaster implementation has combined the TimelineObject for SplitScreen Boxes and SplitScreen DSK into the same TimelineObject. The way Atem does this is to have a separate TimelineObject for each of these.

Alba-server is implemented where SplitScreen Boxes and SplitScreen DSK are two separated TimelineObjects. So when Alba would insert an input into a SplitScreen, the DSK information would disappear, because Alba thought it was in a different TimelineObject. 

This PR moves the SplitScreen DSK information into a separate TimelineObject so the TimelineObject structure matches the same Atem and Alba-server is using.