### PR TITLE
SOF-2527 Allow freetext in FEEDS and LIVES cues

### DIFF
--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -695,6 +695,7 @@ export function getSourceDefinition(typeStr: string): SourceDefinition | undefin
 			name: `KAM ${id}`
 		}
 	} else if (REMOTE_CUE.test(typeStr)) {
+		// NOTE: This if-clause is deprecated!
 		const remoteNumber = typeStr.match(REMOTE_CUE)
 		const variant = remoteNumber![1].toUpperCase() as RemoteType
 		const id = remoteNumber![2]

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -491,14 +491,13 @@ function parseRemoteAndFeedCue(cue: string): CueDefinitionEkstern | undefined {
 		return
 	}
 
-	const leftSideOfCue: string = stripTransitionProperties(source[1])
-
+	const rightSideOfCue: string = source[1]
 	const sourceDefinition: SourceDefinitionRemote = {
-		id: leftSideOfCue,
+		id: rightSideOfCue,
 		sourceType: SourceType.REMOTE,
 		remoteType: RemoteType.LIVE, // This is just hardcoded to LIVE. It was primarily used to see whether to look at the LIVES or FEEDS table. We now just look at both.
-		name: leftSideOfCue,
-		raw: leftSideOfCue
+		name: rightSideOfCue,
+		raw: rightSideOfCue
 	}
 
 	const transitionProperties = getTransitionProperties(cue)

--- a/src/tv2-common/sources.ts
+++ b/src/tv2-common/sources.ts
@@ -101,7 +101,7 @@ export function findSourceInfo(sources: SourceMapping, sourceDefinition: SourceD
 			arrayToSearchIn = sources.cameras
 			break
 		case SourceType.REMOTE:
-			arrayToSearchIn = sourceDefinition.remoteType === RemoteType.LIVE ? sources.lives : sources.feeds
+			arrayToSearchIn = sources.lives.concat(sources.feeds)
 			break
 		case SourceType.REPLAY:
 			arrayToSearchIn = sources.replays
@@ -109,7 +109,10 @@ export function findSourceInfo(sources: SourceMapping, sourceDefinition: SourceD
 		default:
 			return undefined
 	}
-	return _.find(arrayToSearchIn, (s) => s.id === sourceDefinition.id)
+	return _.find(
+		arrayToSearchIn,
+		(s) => s.id.toLowerCase().trim().replace(' ', '') === sourceDefinition.id.toLowerCase().replace(' ', '')
+	)
 }
 
 export function SourceInfoToSourceDefinition(


### PR DESCRIPTION
 We now allow the cues for LIVEs and FEEDs to be whatever the SuperUsers may like. Only criteria is, that the cue in iNews must match the configured name of the Live or Feed. (We strip whitespaces and ignore casing so those are the exceptions.)

Note: This makes a slight change to how we match a "RemoteCue" to a "RemoteSource". Previously we would only look in either the Feeds table or the Lives table. Since we no longer required that the Cue contains "LIVE" or "FEED", we no longer know which table to look at. So now we just always look at both tables for both Lives and Feeds. (Removing the one of the last things that made Lives and Feeds different).

In order to reduce to risk of breaking something else I haven't deleted the "REMOTE" section of `getSourceDefinition` due to the spaghetti design of the code (It would simply take to long to even get an overview). Instead I have left a comment mentioning it is deprecated. 