### PR TITLE
SOF-2581 No longer create DSK timelineObjects in baseline for Rundown

### DIFF
--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -10,7 +10,6 @@ import {
 } from 'blueprints-integration'
 import {
 	CasparPlayerClipLoadingLoop,
-	createDskBaseline,
 	CreateDSKBaselineAdlibs,
 	CreateLYDBaseline,
 	findDskFullGfx,
@@ -511,9 +510,6 @@ function getBaseline(context: ShowStyleContext<GalleryBlueprintConfig>): Bluepri
 					url: context.config.studio.SofieHostURL + '/countdowns/studio0/presenter'
 				}
 			}),
-
-			// keyers
-			...createDskBaseline(context.config, context.videoSwitcher),
 
 			// ties the DSK for jingles to ME4 USK1 to have effects on CLEAN (ME4)
 			context.uniformConfig.switcherLLayers.jingleUskMixEffect


### PR DESCRIPTION
DSKs are now being included as `baselinePieces` in AlbaServer, so we no longer need to create them here.