### PR TITLE
implemented auxiliary mappings

### DIFF
--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -3,6 +3,7 @@ import {
 	DVEConfigInput,
 	SourceInfo,
 	SwitcherType,
+	TableConfigForAuxiliary,
 	TableConfigItemDSK,
 	TableConfigItemSourceMappingWithSisyfos
 } from 'tv2-common'
@@ -130,6 +131,7 @@ export interface TV2StudioConfigBase {
 	}
 	AtemSettings: {}
 	StudioMics: string[]
+	SourcesAuxiliary: TableConfigForAuxiliary[]
 	SourcesRM: TableConfigItemSourceMappingWithSisyfos[]
 	SourcesFeed: TableConfigItemSourceMappingWithSisyfos[]
 	SourcesCam: TableConfigItemSourceMappingWithSisyfos[]

--- a/src/tv2-common/migrations/sourceManifest.ts
+++ b/src/tv2-common/migrations/sourceManifest.ts
@@ -118,7 +118,7 @@ export function MakeConfigForAuxiliary(
 				required: true,
 				defaultVal: '',
 				rank: 2
-			},
+			}
 		]
 	}
 }

--- a/src/tv2-common/types/config.ts
+++ b/src/tv2-common/types/config.ts
@@ -5,6 +5,11 @@ export interface TableConfigItemSourceMapping {
 	SwitcherSource: number
 }
 
+export type TableConfigForAuxiliary = {
+	AuxiliaryId: string
+	LayerId: string
+} & TableConfigItemSourceMapping
+
 export type TableConfigItemSourceMappingWithSisyfos = {
 	SisyfosLayers: string[]
 	StudioMics: boolean

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -101,6 +101,7 @@ export const defaultStudioConfig: StudioConfig = {
 		'SourcesCam',
 		true
 	),
+	SourcesAuxiliary: [],
 	// TODO: prepareConfig is legacy code, refactor when refactoring FindSourceInfo
 	SourcesRM: prepareConfig(
 		[

--- a/src/tv2_afvd_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/config-manifest.spec.ts
@@ -32,6 +32,7 @@ const blankStudioConfig: StudioConfig = {
 	ClipIgnoreStatus: false,
 	AudioBedIgnoreStatus: false,
 	DVEIgnoreStatus: false,
+	SourcesAuxiliary: [],
 	SourcesCam: [],
 	SourcesRM: [],
 	SourcesFeed: [],

--- a/src/tv2_afvd_studio/config-manifests.ts
+++ b/src/tv2_afvd_studio/config-manifests.ts
@@ -197,7 +197,7 @@ export const manifestAFVDSourcesRM = MakeConfigForSources('RM', 'Live', true, tr
 
 export const manifestAFVDSourcesFeed = MakeConfigForSources('Feed', 'Feed', true, false, [])
 
-export const manifestForAxiliaryMappings = MakeConfigForAuxiliary('Auxiliary', 'Auxiliary', [])
+export const manifestForAuxiliaryMappings = MakeConfigForAuxiliary('Auxiliary', 'Auxiliary', [])
 
 export const manifestAFVDSourcesReplay = MakeConfigForSources('Replay', 'Replay', false, false, [
 	{
@@ -317,7 +317,7 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 	manifestAFVDSourcesCam,
 	manifestAFVDSourcesRM,
 	manifestAFVDSourcesFeed,
-	manifestForAxiliaryMappings,
+	manifestForAuxiliaryMappings,
 	manifestAFVDSourcesReplay,
 	manifestAFVDSourcesABMediaPlayers,
 	manifestAFVDStudioMics,

--- a/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
@@ -23,6 +23,7 @@ const blankStudioConfig: OfftubeStudioConfig = {
 	GraphicIgnoreStatus: false,
 	AudioBedIgnoreStatus: false,
 	DVEIgnoreStatus: false,
+	SourcesAuxiliary: [],
 	SourcesCam: [],
 	SourcesRM: [],
 	SourcesFeed: [],

--- a/src/tv2_offtube_studio/config-manifests.ts
+++ b/src/tv2_offtube_studio/config-manifests.ts
@@ -8,6 +8,7 @@ import {
 import {
 	DSKConfigManifest,
 	literal,
+	MakeConfigForAuxiliary,
 	MakeConfigForSources,
 	MakeConfigWithMediaFlow,
 	SwitcherType,
@@ -121,6 +122,8 @@ export const manifestOfftubeStudioMics: ConfigManifestEntry = {
 
 export const manifestOfftubeDownstreamKeyers: ConfigManifestEntryTable = DSKConfigManifest(defaultDSKConfig)
 
+export const manifestForAuxiliaryMappings = MakeConfigForAuxiliary('Auxiliary', 'Auxiliary', [])
+
 export const studioConfigManifest: ConfigManifestEntry[] = [
 	{
 		id: 'SwitcherType',
@@ -136,6 +139,7 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 	...MakeConfigWithMediaFlow('Graphic', '', 'flow2', '.png', '', false),
 	...MakeConfigWithMediaFlow('AudioBed', '', 'flow1', '.wav', 'audio', true),
 	...MakeConfigWithMediaFlow('DVE', '', 'flow1', '.png', 'dve', true),
+	manifestForAuxiliaryMappings,
 	manifestOfftubeSourcesCam,
 	manifestOfftubeSourcesRM,
 	manifestOfftubeSourcesFeed,


### PR DESCRIPTION
The PR introduces the "Auxiliary Mappings" table so we can define available auxiliaries that the code can match up against NRCS inputs for auxiliary targeting.