### PR TITLE
Provides better Part names

### DIFF
--- a/src/tv2-common/evaluateCues.ts
+++ b/src/tv2-common/evaluateCues.ts
@@ -20,6 +20,7 @@ import {
 	CueDefinitionTelefon,
 	IsTargetingFull,
 	IsTargetingOVL,
+	Part,
 	PartDefinition,
 	PieceMetaData,
 	ShowStyleContext
@@ -60,6 +61,7 @@ export interface EvaluateCuesShowstyleOptions {
 	EvaluateCueGraphic?: (
 		context: ShowStyleContext<TV2ShowStyleConfig>,
 		partId: string,
+		part: Part,
 		parsedCue: CueDefinitionGraphic<GraphicInternalOrPilot>,
 		partDefinition: PartDefinition,
 		rank: number,
@@ -101,6 +103,7 @@ export interface EvaluateCuesShowstyleOptions {
 	) => EvaluateCueResult
 	EvaluateCueDVE?: (
 		context: ShowStyleContext<TV2ShowStyleConfig>,
+		part: Part,
 		pieces: IBlueprintPiece[],
 		actions: IBlueprintActionManifest[],
 		partDefinition: PartDefinition,
@@ -119,16 +122,18 @@ export interface EvaluateCuesShowstyleOptions {
 	EvaluateCueTelefon?: (
 		context: ShowStyleContext<TV2ShowStyleConfig>,
 		partId: string,
+		part: Part,
 		partDefinition: PartDefinition,
 		parsedCue: CueDefinitionTelefon,
 		adlib?: Adlib
 	) => EvaluateCueResult
 	EvaluateCueJingle?: (
 		context: ShowStyleContext<TV2ShowStyleConfig>,
+		part: Part,
 		pieces: IBlueprintPiece[],
 		actions: IBlueprintActionManifest[],
 		parsedCue: CueDefinitionJingle,
-		part: PartDefinition,
+		partDefinition: PartDefinition,
 		adlib?: boolean,
 		rank?: number,
 		effekt?: boolean
@@ -222,6 +227,7 @@ export async function EvaluateCuesBase(
 							showStyleOptions.EvaluateCueGraphic(
 								context,
 								partDefinition.externalId,
+								part,
 								cue,
 								partDefinition,
 								adlibRank,
@@ -247,10 +253,10 @@ export async function EvaluateCuesBase(
 					break
 				case CueType.DVE:
 					if (showStyleOptions.EvaluateCueDVE) {
-						showStyleOptions.EvaluateCueDVE(context, pieces, actions, partDefinition, cue, shouldAdlib, adlibRank)
+						showStyleOptions.EvaluateCueDVE(context, part, pieces, actions, partDefinition, cue, shouldAdlib, adlibRank)
 						// Always make an adlib for DVEs
 						if (!shouldAdlib) {
-							showStyleOptions.EvaluateCueDVE(context, pieces, actions, partDefinition, cue, true, adlibRank)
+							showStyleOptions.EvaluateCueDVE(context, part, pieces, actions, partDefinition, cue, true, adlibRank)
 						}
 					}
 					break
@@ -269,13 +275,22 @@ export async function EvaluateCuesBase(
 				case CueType.Telefon:
 					if (showStyleOptions.EvaluateCueTelefon) {
 						result.push(
-							showStyleOptions.EvaluateCueTelefon(context, partDefinition.externalId, partDefinition, cue, adlib)
+							showStyleOptions.EvaluateCueTelefon(context, partDefinition.externalId, part, partDefinition, cue, adlib)
 						)
 					}
 					break
 				case CueType.Jingle:
 					if (showStyleOptions.EvaluateCueJingle) {
-						showStyleOptions.EvaluateCueJingle(context, pieces, actions, cue, partDefinition, shouldAdlib, adlibRank)
+						showStyleOptions.EvaluateCueJingle(
+							context,
+							part,
+							pieces,
+							actions,
+							cue,
+							partDefinition,
+							shouldAdlib,
+							adlibRank
+						)
 					}
 					break
 				case CueType.LYD:

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -16,7 +16,7 @@ import {
 	ServerPieceMetaData,
 	ShowStyleContext
 } from 'tv2-common'
-import { AdlibActionType, PartType, SharedOutputLayer, SharedSourceLayer, TallyTags } from 'tv2-constants'
+import { AdlibActionType, SharedOutputLayer, SharedSourceLayer, TallyTags } from 'tv2-constants'
 import { Tv2AudioMode } from '../../tv2-constants/tv2-audio.mode'
 import { Tv2OutputLayer } from '../../tv2-constants/tv2-output-layer'
 import { PlayoutContentType } from '../../tv2-constants/tv2-playout-content'
@@ -155,10 +155,7 @@ function getActualDuration(duration: number, sanitisedScript: string, props: Ser
 }
 
 function getDisplayTitle(partDefinition: PartDefinition): string {
-	if (partDefinition.type === PartType.VO || partDefinition.type === PartType.Server) {
-		return partDefinition.rawType
-	}
-	return 'SERVER'
+	return partDefinition.fields.videoId ?? partDefinition.storyName
 }
 
 function getScriptWithoutLineBreaks(partDefinition: PartDefinition) {

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -14,6 +14,7 @@ import {
 	GraphicPieceMetaData,
 	GraphicPilot,
 	literal,
+	Part,
 	PartDefinitionKam
 } from 'tv2-common'
 import { AdlibTags, CueType, PartType, SharedGraphicLLayer, SharedOutputLayer, SourceType } from 'tv2-constants'
@@ -107,6 +108,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -178,6 +180,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -287,6 +290,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext({ studioConfig: { PreventOverlayWithFull: false } }),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -398,6 +402,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -458,6 +463,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -486,6 +492,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -514,6 +521,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -556,6 +564,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -628,6 +637,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -699,6 +709,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -812,6 +823,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -849,6 +861,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,
@@ -881,6 +894,7 @@ describe('grafik piece', () => {
 		const result = EvaluateCueGraphic(
 			makeMockGalleryContext(),
 			partId,
+			{} as unknown as Part,
 			cue,
 			dummyPart,
 			0,

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -6,6 +6,7 @@ import {
 	GraphicInternal,
 	GraphicPieceMetaData,
 	literal,
+	Part,
 	PartDefinitionKam
 } from 'tv2-common'
 import { CueType, PartType, SharedGraphicLLayer, SharedOutputLayer, SourceType } from 'tv2-constants'
@@ -62,7 +63,7 @@ describe('telefon', () => {
 			iNewsCommand: 'TELEFON'
 		}
 		const partId = '0000000001'
-		const result = EvaluateTelefon(mockContext, partId, dummyPart, cue)
+		const result = EvaluateTelefon(mockContext, partId, {} as unknown as Part, dummyPart, cue)
 		expect(result.pieces).toEqual([
 			literal<IBlueprintPiece<GraphicPieceMetaData>>({
 				externalId: partId,

--- a/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
@@ -8,6 +8,7 @@ import {
 	GetDVETemplate,
 	getUniquenessIdDVE,
 	literal,
+	Part,
 	PartDefinition,
 	ShowStyleContext,
 	t,
@@ -22,6 +23,7 @@ import { MakeContentDVE } from '../content/dve'
 
 export function EvaluateDVE(
 	context: ShowStyleContext<GalleryBlueprintConfig>,
+	part: Part,
 	pieces: IBlueprintPiece[],
 	actions: IBlueprintActionManifest[],
 	partDefinition: PartDefinition,
@@ -32,6 +34,7 @@ export function EvaluateDVE(
 	if (!parsedCue.template) {
 		return
 	}
+	part.title = `DVE: ${parsedCue.template}`
 
 	const rawTemplate = GetDVETemplate(context.config.showStyle.DVEStyles, parsedCue.template)
 	if (!rawTemplate) {

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphic.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphic.ts
@@ -6,6 +6,7 @@ import {
 	GraphicInternalOrPilot,
 	GraphicIsInternal,
 	GraphicIsPilot,
+	Part,
 	PartDefinition,
 	ShowStyleContext
 } from 'tv2-common'
@@ -16,6 +17,7 @@ import { EvaluateCueRouting } from './routing'
 export function EvaluateCueGraphic(
 	context: ShowStyleContext<GalleryBlueprintConfig>,
 	partId: string,
+	part: Part,
 	parsedCue: CueDefinitionGraphic<GraphicInternalOrPilot>,
 	partDefinition: PartDefinition,
 	rank: number,
@@ -28,8 +30,14 @@ export function EvaluateCueGraphic(
 
 	if (GraphicIsInternal(parsedCue)) {
 		result.push(CreateInternalGraphic(context, partId, parsedCue, partDefinition, adlib))
+		if (parsedCue.target === 'FULL') {
+			part.title = parsedCue.graphic.template
+		}
 	} else if (GraphicIsPilot(parsedCue)) {
 		result.push(EvaluateCueGraphicPilot(context, partId, parsedCue, partDefinition.segmentExternalId, rank, adlib))
+		if (parsedCue.target === 'FULL') {
+			part.title = parsedCue.graphic.name
+		}
 	}
 
 	return result

--- a/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
@@ -8,6 +8,7 @@ import {
 	GetTagForJingle,
 	GetTagForJingleNext,
 	getTimeFromFrames,
+	Part,
 	PartDefinition,
 	ShowStyleContext,
 	t,
@@ -22,10 +23,11 @@ import { GalleryBlueprintConfig } from '../config'
 
 export function EvaluateJingle(
 	context: ShowStyleContext<GalleryBlueprintConfig>,
+	part: Part,
 	pieces: IBlueprintPiece[],
 	actions: IBlueprintActionManifest[],
 	parsedCue: CueDefinitionJingle,
-	part: PartDefinition,
+	partDefinition: PartDefinition,
 	adlib?: boolean,
 	rank?: number,
 	effekt?: boolean
@@ -41,12 +43,13 @@ export function EvaluateJingle(
 	} else {
 		file = jingle.ClipName.toString()
 	}
+	part.title = jingle.BreakerName
 
 	if (adlib) {
 		const userData: ActionSelectJingle = {
 			type: AdlibActionType.SELECT_JINGLE,
 			clip: parsedCue.clip,
-			segmentExternalId: part.segmentExternalId
+			segmentExternalId: partDefinition.segmentExternalId
 		}
 		actions.push({
 			externalId: generateExternalId(context.core, userData),
@@ -62,14 +65,14 @@ export function EvaluateJingle(
 					...createJingleContentAFVD(context, file, jingle)
 				},
 				tags: [AdlibTags.ADLIB_FLOW_PRODUCER],
-				currentPieceTags: [GetTagForJingle(part.segmentExternalId, parsedCue.clip)],
-				nextPieceTags: [GetTagForJingleNext(part.segmentExternalId, parsedCue.clip)]
+				currentPieceTags: [GetTagForJingle(partDefinition.segmentExternalId, parsedCue.clip)],
+				nextPieceTags: [GetTagForJingleNext(partDefinition.segmentExternalId, parsedCue.clip)]
 			}
 		})
 	} else {
 		const jingleContent: WithTimeline<VTContent> = createJingleContentAFVD(context, file, jingle)
 		pieces.push({
-			externalId: `${part.externalId}-JINGLE`,
+			externalId: `${partDefinition.externalId}-JINGLE`,
 			name: effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip,
 			enable: {
 				start: 0

--- a/src/tv2_afvd_showstyle/helpers/pieces/telefon.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/telefon.ts
@@ -3,6 +3,7 @@ import {
 	CueDefinitionTelefon,
 	EvaluateCueResult,
 	GetSisyfosTimelineObjForTelefon,
+	Part,
 	PartDefinition,
 	ShowStyleContext
 } from 'tv2-common'
@@ -14,6 +15,7 @@ import { EvaluateCueGraphic } from './graphic'
 export function EvaluateTelefon(
 	context: ShowStyleContext<GalleryBlueprintConfig>,
 	partId: string,
+	part: Part,
 	partDefinition: PartDefinition,
 	parsedCue: CueDefinitionTelefon,
 	adlib?: Adlib
@@ -22,7 +24,7 @@ export function EvaluateTelefon(
 		return new EvaluateCueResult()
 	}
 
-	const result = EvaluateCueGraphic(context, partId, parsedCue.graphic, partDefinition, adlib?.rank ?? 0, adlib)
+	const result = EvaluateCueGraphic(context, partId, part, parsedCue.graphic, partDefinition, adlib?.rank ?? 0, adlib)
 
 	if (!adlib && result.pieces.length) {
 		const graphicPiece = findTelefonPiece(result)

--- a/src/tv2_offtube_showstyle/cues/OfftubeDVE.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeDVE.ts
@@ -9,6 +9,7 @@ import {
 	GetTagForDVE,
 	GetTagForDVENext,
 	literal,
+	Part,
 	PartDefinition,
 	SegmentContext,
 	t,
@@ -23,6 +24,7 @@ import { OfftubeOutputLayers, OfftubeSourceLayer } from '../layers'
 
 export function OfftubeEvaluateDVE(
 	context: SegmentContext<OfftubeBlueprintConfig>,
+	part: Part,
 	pieces: IBlueprintPiece[],
 	actions: IBlueprintActionManifest[],
 	partDefinition: PartDefinition,
@@ -33,6 +35,7 @@ export function OfftubeEvaluateDVE(
 	if (!parsedCue.template) {
 		return
 	}
+	part.title = `DVE: ${parsedCue.template}`
 
 	const rawTemplate = GetDVETemplate(context.config.showStyle.DVEStyles, parsedCue.template)
 	if (!rawTemplate) {

--- a/src/tv2_offtube_showstyle/cues/OfftubeGraphics.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeGraphics.ts
@@ -7,6 +7,7 @@ import {
 	GraphicInternalOrPilot,
 	GraphicIsInternal,
 	GraphicIsPilot,
+	Part,
 	PartDefinition,
 	ShowStyleContext
 } from 'tv2-common'
@@ -15,6 +16,7 @@ import { OfftubeBlueprintConfig } from '../helpers/config'
 export function OfftubeEvaluateGrafikCaspar(
 	context: ShowStyleContext<OfftubeBlueprintConfig>,
 	partId: string,
+	_part: Part,
 	parsedCue: CueDefinitionGraphic<GraphicInternalOrPilot>,
 	partDefinition: PartDefinition,
 	rank: number,

--- a/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
@@ -9,6 +9,7 @@ import {
 	GetTagForJingle,
 	GetTagForJingleNext,
 	getTimeFromFrames,
+	Part,
 	PartDefinition,
 	PieceMetaData,
 	SegmentContext,
@@ -24,10 +25,11 @@ import { OfftubeOutputLayers, OfftubeSourceLayer } from '../layers'
 
 export function OfftubeEvaluateJingle(
 	context: SegmentContext<OfftubeBlueprintConfig>,
+	part: Part,
 	pieces: Array<IBlueprintPiece<PieceMetaData>>,
 	actions: IBlueprintActionManifest[],
 	parsedCue: CueDefinitionJingle,
-	part: PartDefinition,
+	partDefinition: PartDefinition,
 	_adlib?: boolean,
 	_rank?: number,
 	effekt?: boolean
@@ -43,8 +45,9 @@ export function OfftubeEvaluateJingle(
 	} else {
 		file = jingle.ClipName.toString()
 	}
+	part.title = jingle.BreakerName
 
-	const p = GetJinglePartProperties(context, part)
+	const p = GetJinglePartProperties(context, partDefinition)
 
 	if (JSON.stringify(p) === JSON.stringify({})) {
 		context.core.notifyUserWarning(`Could not create adlib for ${parsedCue.clip}`)
@@ -54,7 +57,7 @@ export function OfftubeEvaluateJingle(
 	const userData: ActionSelectJingle = {
 		type: AdlibActionType.SELECT_JINGLE,
 		clip: parsedCue.clip,
-		segmentExternalId: part.segmentExternalId
+		segmentExternalId: partDefinition.segmentExternalId
 	}
 	actions.push({
 		externalId: generateExternalId(context.core, userData),
@@ -69,14 +72,14 @@ export function OfftubeEvaluateJingle(
 				...createJingleContentOfftube(context, file, jingle)
 			},
 			tags: [AdlibTags.OFFTUBE_100pc_SERVER, AdlibTags.ADLIB_KOMMENTATOR],
-			currentPieceTags: [GetTagForJingle(part.segmentExternalId, parsedCue.clip)],
-			nextPieceTags: [GetTagForJingleNext(part.segmentExternalId, parsedCue.clip)]
+			currentPieceTags: [GetTagForJingle(partDefinition.segmentExternalId, parsedCue.clip)],
+			nextPieceTags: [GetTagForJingleNext(partDefinition.segmentExternalId, parsedCue.clip)]
 		}
 	})
 
 	const jingleContent: WithTimeline<VTContent> = createJingleContentOfftube(context, file, jingle)
 	pieces.push({
-		externalId: `${part.externalId}-JINGLE`,
+		externalId: `${partDefinition.externalId}-JINGLE`,
 		name: effekt ? `EFFEKT ${parsedCue.clip}` : parsedCue.clip,
 		enable: {
 			start: 0
@@ -87,8 +90,8 @@ export function OfftubeEvaluateJingle(
 		prerollDuration: context.config.studio.CasparPrerollDuration + getTimeFromFrames(Number(jingle.StartAlpha)),
 		content: jingleContent,
 		tags: [
-			GetTagForJingle(part.segmentExternalId, parsedCue.clip),
-			GetTagForJingleNext(part.segmentExternalId, parsedCue.clip),
+			GetTagForJingle(partDefinition.segmentExternalId, parsedCue.clip),
+			GetTagForJingleNext(partDefinition.segmentExternalId, parsedCue.clip),
 			TallyTags.JINGLE_IS_LIVE,
 			!effekt ? TallyTags.JINGLE : ''
 		],


### PR DESCRIPTION
Prior to this graphics parts would be named `Unknown -` instead of the template name. Video clips would be `SERVER` And split screens would be `DVE - `.