### PR TITLE
fix: Sets VOSS auxiliary timeline object priority to 1.

### DIFF
--- a/src/tv2_afvd_showstyle/parts/voss.ts
+++ b/src/tv2_afvd_showstyle/parts/voss.ts
@@ -236,6 +236,7 @@ function createAuxiliaryRoutingTimelineObjects(
 	return [
 		videoSwitcher.getAuxTimelineObject({
 			layer: auxiliaryLayerId,
+			priority: 1,
 			content: {
 				input: SpecialInput.AB_PLACEHOLDER
 			},


### PR DESCRIPTION
This ensures that the active timeline object is protected from lookahead timeline objects.