### PR TITLE
AG-551 Mix transition during breaker 'effekt'

### DIFF
--- a/src/tv2-common/content/jingle.ts
+++ b/src/tv2-common/content/jingle.ts
@@ -3,6 +3,8 @@ import {
 	findDskJingle,
 	getDskOnAirTimelineObjects,
 	getTimeFromFrames,
+	MixEffectProps,
+	PartDefinition,
 	ShowStyleContext,
 	TransitionStyle
 } from 'tv2-common'
@@ -178,5 +180,16 @@ export function getBreakerMixEffectCutEnable(
 		duration:
 			getTimeFromFrames(breakerConfig.Duration - breakerConfig.StartAlpha - breakerConfig.EndAlpha) +
 			casparPrerollDuration
+	}
+}
+
+export function getVideoMixerMixEffectPropsContentForEffekt(
+	mixerInput: number,
+	partDefinition: PartDefinition
+): MixEffectProps['content'] {
+	return {
+		input: mixerInput,
+		transition: !!partDefinition.effekt ? TransitionStyle.MIX : partDefinition.transition?.style ?? TransitionStyle.CUT,
+		transitionDuration: !!partDefinition.effekt ? 4 : partDefinition.transition?.duration
 	}
 }

--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -1,11 +1,11 @@
 import { TimelineObjectCoreExt, TSR, VTContent, WithTimeline } from 'blueprints-integration'
 import {
 	GetSisyfosTimelineObjForServer,
+	getVideoMixerMixEffectPropsContentForEffekt,
 	literal,
 	PartDefinition,
 	ShowStyleContext,
-	SpecialInput,
-	TransitionStyle
+	SpecialInput
 } from 'tv2-common'
 import { AbstractLLayer, GetEnableClassForServer } from 'tv2-constants'
 import { TV2ShowStyleConfig } from '../blueprintConfig'
@@ -130,11 +130,7 @@ export function CutToServer(
 				start: context.config.studio.CasparPrerollDuration
 			},
 			priority: 1,
-			content: {
-				input: SpecialInput.AB_PLACEHOLDER,
-				transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
-				transitionDuration: partDefinition.transition?.duration
-			},
+			content: getVideoMixerMixEffectPropsContentForEffekt(SpecialInput.AB_PLACEHOLDER, partDefinition),
 			metaData: {
 				mediaPlayerSession: mediaPlayerSessionId
 			}

--- a/src/tv2-common/cues/ekstern.ts
+++ b/src/tv2-common/cues/ekstern.ts
@@ -2,11 +2,11 @@ import { PieceLifespan, RemoteContent, TimelineObjectCoreExt, WithTimeline } fro
 import {
 	CueDefinitionEkstern,
 	EvaluateCueResult,
+	getVideoMixerMixEffectPropsContentForEffekt,
 	literal,
 	Part,
 	PartDefinition,
 	ShowStyleContext,
-	TransitionStyle,
 	TV2BlueprintConfigBase,
 	TV2StudioConfigBase
 } from 'tv2-common'
@@ -73,11 +73,7 @@ export function EvaluateEksternBase<
 				timelineObjects: literal<TimelineObjectCoreExt[]>([
 					...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						priority: 1,
-						content: {
-							input: switcherInput,
-							transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
-							transitionDuration: partDefinition.transition?.duration
-						},
+						content: getVideoMixerMixEffectPropsContentForEffekt(switcherInput, partDefinition),
 						classes: [ControlClasses.OVERRIDDEN_ON_MIX_MINUS]
 					}),
 
@@ -116,11 +112,7 @@ export function EvaluateEksternBase<
 			timelineObjects: literal<TimelineObjectCoreExt[]>([
 				...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 					priority: 1,
-					content: {
-						input: switcherInput,
-						transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
-						transitionDuration: partDefinition.transition?.duration
-					},
+					content: getVideoMixerMixEffectPropsContentForEffekt(switcherInput, partDefinition),
 					classes: [ControlClasses.OVERRIDDEN_ON_MIX_MINUS]
 				}),
 

--- a/src/tv2-common/parts/effekt.ts
+++ b/src/tv2-common/parts/effekt.ts
@@ -11,8 +11,6 @@ import {
 import {
 	ActionTakeWithTransitionVariantDip,
 	ActionTakeWithTransitionVariantMix,
-	findDskJingle,
-	getBreakerMixEffectCutEnable,
 	getDskOnAirTimelineObjects,
 	GetTagForTransition,
 	getTimeFromFrames,
@@ -112,8 +110,6 @@ export function CreateEffektForPartInner<
 
 	const fileName = joinAssetToFolder(context.config.studio.JingleFolder, file)
 
-	const jingleDsk = findDskJingle(context.config)
-
 	pieces.push({
 		externalId,
 		name: label,
@@ -152,14 +148,15 @@ export function CreateEffektForPartInner<
 						file: fileName
 					}
 				}),
-				...context.videoSwitcher.getOnAirTimelineObjects({
-					enable: getBreakerMixEffectCutEnable(effektConfig, context.config.studio.CasparPrerollDuration),
-					priority: 1,
-					content: {
-						input: jingleDsk.Fill,
-						transition: TransitionStyle.CUT
-					}
-				}),
+				// TODO: The VideoMixerOnAirTimelineObjects does seem to be needed. Leaving the code commented in case that isn't true. Should be deleted by end of 2025.
+				// ...context.videoSwitcher.getOnAirTimelineObjects({
+				// 	enable: getBreakerMixEffectCutEnable(effektConfig, context.config.studio.CasparPrerollDuration),
+				// 	priority: 1,
+				// 	content: {
+				// 		input: jingleDsk.Fill,
+				// 		transition: TransitionStyle.CUT
+				// 	}
+				// }),
 				...getDskOnAirTimelineObjects(context, DskRole.JINGLE, {
 					start: context.config.studio.CasparPrerollDuration
 				}),

--- a/src/tv2_afvd_showstyle/__tests__/transitions.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/transitions.spec.ts
@@ -156,7 +156,7 @@ describe('Primary Cue Transitions Without Config', () => {
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_2))
 
-		expect(atemCutObj.content.me.transition).toBe(undefined)
+		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.MIX)
 	})
 
 	it('Adds mix to KAM', async () => {
@@ -213,7 +213,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const atemCutObj = getATEMMEObj(piece)
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_1))
-		expect(atemCutObj.content.me.transition).toBe(undefined)
+		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.MIX)
 	})
 
 	it('Adds mix to EVS1', async () => {
@@ -270,7 +270,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const atemCutObj = getATEMMEObj(piece)
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_1))
-		expect(atemCutObj.content.me.transition).toBe(undefined)
+		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.MIX)
 	})
 
 	it('Adds mix to EVS1VO', async () => {
@@ -327,7 +327,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const atemCutObj = getATEMMEObj(piece)
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_2))
-		expect(atemCutObj.content.me.transition).toBe(undefined)
+		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.MIX)
 	})
 
 	it('Adds mix to SERVER', async () => {
@@ -384,7 +384,7 @@ describe('Primary Cue Transitions Without Config', () => {
 		const atemCutObj = getATEMMEObj(piece)
 
 		checkPartExistsWithProperties(segment, getTransitionProperties(MOCK_EFFEKT_1))
-		expect(atemCutObj.content.me.transition).toBe(undefined)
+		expect(atemCutObj.content.me.transition).toBe(TSR.AtemTransitionStyle.MIX)
 	})
 
 	it('Adds mix to VO', async () => {

--- a/src/tv2_afvd_showstyle/parts/evs.ts
+++ b/src/tv2_afvd_showstyle/parts/evs.ts
@@ -12,6 +12,7 @@ import {
 	CreatePartInvalid,
 	findSourceInfo,
 	GetSisyfosTimelineObjForReplay,
+	getVideoMixerMixEffectPropsContentForEffekt,
 	literal,
 	Part,
 	PartDefinitionEVS,
@@ -19,8 +20,7 @@ import {
 	PieceMetaData,
 	SegmentContext,
 	ShowStyleContext,
-	SourceInfo,
-	TransitionStyle
+	SourceInfo
 } from 'tv2-common'
 import { SharedOutputLayer } from 'tv2-constants'
 import { Tv2AudioMode } from '../../tv2-constants/tv2-audio.mode'
@@ -125,11 +125,7 @@ function makeContentEVS(
 		timelineObjects: literal<TimelineObjectCoreExt[]>([
 			...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 				priority: 1,
-				content: {
-					input: switcherInput,
-					transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
-					transitionDuration: partDefinition.transition?.duration
-				}
+				content: getVideoMixerMixEffectPropsContentForEffekt(switcherInput, partDefinition)
 			}),
 			...GetSisyfosTimelineObjForReplay(context.config, sourceInfoReplay, partDefinition.sourceDefinition.vo)
 		])

--- a/src/tv2_afvd_showstyle/parts/kam.ts
+++ b/src/tv2_afvd_showstyle/parts/kam.ts
@@ -15,13 +15,13 @@ import {
 	findDskJingle,
 	findSourceInfo,
 	GetSisyfosTimelineObjForCamera,
+	getVideoMixerMixEffectPropsContentForEffekt,
 	literal,
 	Part,
 	PartDefinitionKam,
 	PieceMetaData,
 	SegmentContext,
-	TimeFromINewsField,
-	TransitionStyle
+	TimeFromINewsField
 } from 'tv2-common'
 import { SharedOutputLayer } from 'tv2-constants'
 import { Tv2OutputLayer } from '../../tv2-constants/tv2-output-layer'
@@ -64,11 +64,7 @@ export async function CreatePartKam(
 				timelineObjects: [
 					...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						priority: 1,
-						content: {
-							input: jingleDsk.Fill,
-							transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
-							transitionDuration: partDefinition.transition?.duration
-						}
+						content: getVideoMixerMixEffectPropsContentForEffekt(jingleDsk.Fill, partDefinition)
 					})
 				]
 			}),
@@ -116,11 +112,7 @@ export async function CreatePartKam(
 				timelineObjects: [
 					...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						priority: 1,
-						content: {
-							input: switcherInput,
-							transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
-							transitionDuration: partDefinition.transition?.duration
-						}
+						content: getVideoMixerMixEffectPropsContentForEffekt(switcherInput, partDefinition)
 					}),
 					...GetSisyfosTimelineObjForCamera(context.config, sourceInfoCam, partDefinition.sourceDefinition.minusMic)
 				]

--- a/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
@@ -16,11 +16,11 @@ import {
 	findSourceInfo,
 	GetSisyfosTimelineObjForCamera,
 	GetTagForKam,
+	getVideoMixerMixEffectPropsContentForEffekt,
 	literal,
 	PartDefinitionKam,
 	PieceMetaData,
-	SegmentContext,
-	TransitionStyle
+	SegmentContext
 } from 'tv2-common'
 import { SharedOutputLayer, TallyTags } from 'tv2-constants'
 import { Tv2OutputLayer } from '../../tv2-constants/tv2-output-layer'
@@ -63,11 +63,7 @@ export async function OfftubeCreatePartKam(
 				path: '',
 				timelineObjects: context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 					priority: 1,
-					content: {
-						input: jingleDsk.Fill,
-						transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
-						transitionDuration: partDefinition.transition?.duration
-					}
+					content: getVideoMixerMixEffectPropsContentForEffekt(jingleDsk.Fill, partDefinition)
 				})
 			}),
 			metaData: {
@@ -113,11 +109,7 @@ export async function OfftubeCreatePartKam(
 				timelineObjects: [
 					...context.videoSwitcher.getOnAirTimelineObjectsWithLookahead({
 						priority: 1,
-						content: {
-							input: switcherInput,
-							transition: partDefinition.transition?.style ?? TransitionStyle.CUT,
-							transitionDuration: partDefinition.transition?.duration
-						}
+						content: getVideoMixerMixEffectPropsContentForEffekt(switcherInput, partDefinition)
 					}),
 					...GetSisyfosTimelineObjForCamera(context.config, sourceInfoCam, partDefinition.sourceDefinition.minusMic)
 				]


### PR DESCRIPTION
No longer cut to JingleFill for breaker effekts.
Applying a 4 frame MIX transition if the PartDefinition has an 'effekt'.