### PR TITLE
AG-559 - Set VO levels for VOSS upon part creation

### DIFF
--- a/src/tv2-common/getSegment.ts
+++ b/src/tv2-common/getSegment.ts
@@ -288,8 +288,8 @@ export async function getSegmentBase<ShowStyleConfig extends TV2ShowStyleConfig>
 				if (showStyleOptions.CreatePartVOSS) {
 					blueprintParts.push(
 						await showStyleOptions.CreatePartVOSS(context, partDefinition, partIndex, totalWords, {
-							voLayer: false,
-							voLevels: false,
+							voLayer: true,
+							voLevels: true,
 							totalTime,
 							totalWords,
 							tapeTime,


### PR DESCRIPTION
The reason Sisyfos didnt open the fader on VO is because we didn't set the VO-properties when creating the part. We now do it the exact same way we would a regular VO.