### PR TITLE
AG-560/ Changes queue for auxiliary routed server to be SS 

### DIFF
--- a/src/tv2-common/inewsConversion/converters/ParseBody.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseBody.ts
@@ -784,7 +784,7 @@ export function getSourceDefinition(typeStr: string, config: TV2ShowStyleConfig)
 			sourceType: SourceType.DEFAULT
 		}
 	} else if (/SERVER/i.test(typeStr)) {
-		const auxiliaryId: string | undefined = /\bAUX\s*(?<auxiliaryId>\d+)\b/i.exec(typeStr)?.groups?.auxiliaryId
+		const auxiliaryId: string | undefined = /\bSS\s*(?<auxiliaryId>\d+)\b/i.exec(typeStr)?.groups?.auxiliaryId
 		return {
 			sourceType: SourceType.SERVER,
 			...(auxiliaryId ? { additionalRouting: { auxiliaryId } } : undefined)


### PR DESCRIPTION
After talking to Jacob it was made clear that for the users sake, the identifying queue for making the server route to an auxiliary, should be "SS" just like the VOSS. 