### PR TITLE
Support the "OVERSKRIFT=" cues used by the news

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ wallaby.conf.js
 
 # Ignore JetBrains config files
 .idea
+
+.node-version

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ wallaby.conf.js
 
 # Ignore JetBrains config files
 .idea
-
-.node-version

--- a/src/tv2-common/cueTiming.ts
+++ b/src/tv2-common/cueTiming.ts
@@ -31,7 +31,7 @@ export function CreateTimingEnable(
 
 	if (cue.end) {
 		if (cue.end.infiniteMode) {
-			result.lifespan = LifeSpan(cue.end.infiniteMode)
+			result.lifespan = LifeSpan(cue.end.infiniteMode.toUpperCase() as 'B' | 'S' | 'O')
 		} else {
 			const end = CalculateTime(cue.end)
 			result.enable.duration = end ? end - result.enable.start : undefined

--- a/src/tv2-common/helpers/graphics/timing.ts
+++ b/src/tv2-common/helpers/graphics/timing.ts
@@ -26,7 +26,7 @@ export function GetPieceLifespanForGraphic(
 		return PieceLifespan.WithinPart
 	}
 	if (parsedCue.end?.infiniteMode) {
-		return LifeSpan(parsedCue.end.infiniteMode)
+		return LifeSpan(parsedCue.end.infiniteMode.toUpperCase() as 'B' | 'S' | 'O')
 	}
 	if (parsedCue.end && CalculateTime(parsedCue.end)) {
 		return PieceLifespan.WithinPart

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -220,7 +220,7 @@ export function ParseCue(cue: UnparsedCue, config: TV2BlueprintConfig): CueDefin
 	if (/^[#* ]?kg[= ]ovl-all-out$/i.test(cue[0]) || /^[#* ]?kg[= ]altud$/i.test(cue[0])) {
 		// All out
 		return parseAllOut(cue)
-	} else if (/(?:^[*|#]?kg[ |=])|(?:^digi)/i.test(cue[0])) {
+	} else if (/^[*|#]?(?:kg|digi|overskrift)[ |=]/i.test(cue[0])) {
 		// kg (Grafik)
 		return parsekg(cue, config)
 	} else if (/^]] [a-z]\d\.\d [a-z] \d \[\[$/i.test(cue[0])) {
@@ -295,15 +295,15 @@ function parsekg(
 		cue: ''
 	}
 
-	const command = cue[0].match(/^([*|#]?kg|digi)/i)
+	const command = cue[0].match(/^([*|#]?(?:kg|digi|overskrift))/i)
 	kgCue.iNewsCommand = command ? command[1] : 'kg'
 
 	const code = cue[0]
-		.match(/^[*|#]?kg[ | =]/i)
+		.match(/^[*|#]?(?:kg|digi|overskrift)[ | =]/i)
 		?.toString()
 		?.trim()
 
-	const firstLineValues = cue[0].match(/^[*|#]?kg[ |=]([\w|\d]+)( (.+))*$/i)
+	const firstLineValues = cue[0].match(/^[*|#]?(?:kg|overskrift)[ |=](\S+)( (.+))*$/i)
 	if (firstLineValues) {
 		graphic.cue = code || ''
 		graphic.template = firstLineValues[1]

--- a/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
@@ -1943,4 +1943,126 @@ describe('Cue parser', () => {
 			expect(result!.start!.frames).toBe(10)
 		})
 	})
+
+	describe('OVERSKRIFT cues', () => {
+		test('OVERSKRIFT=OPLÆG with extended Latin characters', () => {
+			const cue = ['OVERSKRIFT=OPLÆG skal minde om kg trompet']
+			const result = ParseCue(cue, config)
+			expect(result).toEqual(
+				literal<CueDefinitionGraphic<GraphicInternal>>({
+					type: CueType.Graphic,
+					target: 'OVL',
+					graphic: {
+						type: 'internal',
+						template: 'OPLÆG',
+						cue: 'OVERSKRIFT=',
+						textFields: ['skal minde om kg trompet']
+					},
+					adlib: true,
+					iNewsCommand: 'OVERSKRIFT'
+				})
+			)
+		})
+
+		test('OVERSKRIFT with simple template and timing', () => {
+			const cue = ['OVERSKRIFT=INTRO', 'Tekst linje 1', ';0.01']
+			const result = ParseCue(cue, config)
+			expect(result).toEqual(
+				literal<CueDefinitionGraphic<GraphicInternal>>({
+					type: CueType.Graphic,
+					target: 'OVL',
+					graphic: {
+						type: 'internal',
+						template: 'INTRO',
+						cue: 'OVERSKRIFT=',
+						textFields: ['Tekst linje 1']
+					},
+					start: {
+						seconds: 1
+					},
+					iNewsCommand: 'OVERSKRIFT'
+				})
+			)
+		})
+
+		test('OVERSKRIFT with space separator', () => {
+			const cue = ['OVERSKRIFT HEADLINE', ';x.xx']
+			const result = ParseCue(cue, config)
+			expect(result).toEqual(
+				literal<CueDefinitionGraphic<GraphicInternal>>({
+					type: CueType.Graphic,
+					target: 'OVL',
+					graphic: {
+						type: 'internal',
+						template: 'HEADLINE',
+						cue: 'OVERSKRIFT',
+						textFields: []
+					},
+					adlib: true,
+					iNewsCommand: 'OVERSKRIFT'
+				})
+			)
+		})
+
+		test('OVERSKRIFT is case-insensitive', () => {
+			const cue = ['overskrift=Test', ';0.00']
+			const result = ParseCue(cue, config)
+			expect(result).toEqual(
+				literal<CueDefinitionGraphic<GraphicInternal>>({
+					type: CueType.Graphic,
+					target: 'OVL',
+					graphic: {
+						type: 'internal',
+						template: 'Test',
+						cue: 'overskrift=',
+						textFields: []
+					},
+					start: {
+						seconds: 0
+					},
+					iNewsCommand: 'overskrift'
+				})
+			)
+		})
+
+		test('OVERSKRIFT with multiple text lines', () => {
+			const cue = ['OVERSKRIFT=TEMA', 'Første linje', 'Anden linje', ';0.02']
+			const result = ParseCue(cue, config)
+			expect(result).toEqual(
+				literal<CueDefinitionGraphic<GraphicInternal>>({
+					type: CueType.Graphic,
+					target: 'OVL',
+					graphic: {
+						type: 'internal',
+						template: 'TEMA',
+						cue: 'OVERSKRIFT=',
+						textFields: ['Første linje', 'Anden linje']
+					},
+					start: {
+						seconds: 2
+					},
+					iNewsCommand: 'OVERSKRIFT'
+				})
+			)
+		})
+
+		test('OVERSKRIFT with template containing ÆØÅ characters', () => {
+			const cue = ['OVERSKRIFT=ÆRLIG', ';x.xx']
+			const result = ParseCue(cue, config)
+			expect(result).toEqual(
+				literal<CueDefinitionGraphic<GraphicInternal>>({
+					type: CueType.Graphic,
+					target: 'OVL',
+					graphic: {
+						type: 'internal',
+						template: 'ÆRLIG',
+						cue: 'OVERSKRIFT=',
+						textFields: []
+					},
+					adlib: true,
+					iNewsCommand: 'OVERSKRIFT'
+				})
+			)
+		})
+	})
 })


### PR DESCRIPTION
Tickets:  [AG-960](https://tv2cms.atlassian.net/browse/AG-960) and [AG-961](https://tv2cms.atlassian.net/browse/AG-961)

Updates in this PR:

* Added cue parsing for OVERSKRIFT to support extended Latin characters and case insensitivity. 
*  Handled  the issue with graphical elements not respecting their out method if this was written in iNews with lower casing


[AG-960]: https://tv2cms.atlassian.net/browse/AG-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-961]: https://tv2cms.atlassian.net/browse/AG-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ