### PR TITLE
 Possible solution for having Headline and bundt graphics both on air at the same time

### DIFF
--- a/src/tv2-common/helpers/graphics/caspar/__tests__/htmlInternalGraphicLayers.spec.ts
+++ b/src/tv2-common/helpers/graphics/caspar/__tests__/htmlInternalGraphicLayers.spec.ts
@@ -1,0 +1,102 @@
+import { TSR } from 'blueprints-integration'
+import {
+	CreateHTMLRendererContent,
+	getHtmlGraphicBaseline,
+	GetSourceLayerForGraphic,
+	GetTimelineLayerForGraphic,
+	literal
+} from 'tv2-common'
+import { SharedGraphicLLayer, SharedSourceLayers } from 'tv2-constants'
+import { defaultShowStyleConfig, defaultStudioConfig } from '../../../../../tv2_afvd_showstyle/__tests__/configs'
+import { getConfig, parseConfig as parseShowStyleConfig } from '../../../../../tv2_afvd_showstyle/helpers/config'
+import { parseConfig as parseStudioConfig } from '../../../../../tv2_afvd_studio/helpers/config'
+import mappingsDefaults from '../../../../../tv2_afvd_studio/migrations/mappings-defaults'
+import { SegmentUserContext } from '../../../../../__mocks__/context'
+
+function makeHtmlConfig() {
+	const context = new SegmentUserContext('test', mappingsDefaults, parseStudioConfig, parseShowStyleConfig, 'rundown0')
+	context.studioConfig = {
+		...defaultStudioConfig,
+		GraphicsType: 'HTML'
+	} as any
+	context.showStyleConfig = defaultShowStyleConfig as any
+
+	return getConfig(context)
+}
+
+describe('HTML internal graphics layering', () => {
+	it('keeps headline and bundt on separate source and timeline layers', () => {
+		const config = makeHtmlConfig()
+
+		expect(GetSourceLayerForGraphic(config, 'vo')).toBe(SharedSourceLayers.PgmGraphicsHeadline)
+		expect(GetSourceLayerForGraphic(config, 'bund_right')).toBe(SharedSourceLayers.PgmGraphicsLower)
+		expect(GetTimelineLayerForGraphic(config, 'vo')).toBe(SharedGraphicLLayer.GraphicLLayerOverlayHeadline)
+		expect(GetTimelineLayerForGraphic(config, 'bund_right')).toBe(SharedGraphicLLayer.GraphicLLayerOverlayLower)
+	})
+
+	it('maps headline and bundt to separate HTML slots with bundt above headline', () => {
+		const config = makeHtmlConfig()
+		const headlineContent = CreateHTMLRendererContent(config, 'vo', literal({ text: 'Headline' }))
+		const bundtContent = CreateHTMLRendererContent(config, 'bund_right', literal({ line1: 'Line 1', line2: 'Line 2' }))
+
+		expect(headlineContent.data).toMatchObject({
+			display: 'program',
+			slots: {
+				'440_headline': {
+					display: 'program',
+					payload: {
+						type: 'vo',
+						text: 'Headline'
+					}
+				}
+			}
+		})
+		expect(bundtContent.data).toMatchObject({
+			display: 'program',
+			slots: {
+				'450_lowerThird': {
+					display: 'program',
+					payload: {
+						type: 'bund_right',
+						line1: 'Line 1',
+						line2: 'Line 2'
+					}
+				}
+			}
+		})
+	})
+
+	it('includes headline in the HTML baseline reset slots', () => {
+		const config = makeHtmlConfig()
+		const baseline = getHtmlGraphicBaseline(config)
+		const headlineBaseline = baseline.find(
+			obj => obj.layer === SharedGraphicLLayer.GraphicLLayerOverlayHeadline
+		) as TSR.TimelineObjCCGTemplate | undefined
+		const compoundBaseline = baseline.find(
+			obj => obj.layer === SharedGraphicLLayer.GraphicLLayerOverlay
+		) as TSR.TimelineObjCCGTemplate | undefined
+
+		expect(headlineBaseline?.content.data).toMatchObject({
+			slots: {
+				'440_headline': {
+					display: 'hidden',
+					payload: {}
+				}
+			},
+			partialUpdate: true
+		})
+		expect(compoundBaseline?.content.data).toMatchObject({
+			slots: {
+				'440_headline': {
+					display: 'hidden',
+					payload: {}
+				},
+				'450_lowerThird': {
+					display: 'hidden',
+					payload: {}
+				}
+			},
+			partialUpdate: true
+		})
+	})
+})

--- a/src/tv2-common/helpers/graphics/caspar/index.ts
+++ b/src/tv2-common/helpers/graphics/caspar/index.ts
@@ -177,6 +177,7 @@ export function getHtmlGraphicBaseline(config: TV2BlueprintConfig) {
 	const templateName = getHtmlTemplateName(config)
 	const partiallyUpdatableLayerMappings = [
 		SharedGraphicLLayer.GraphicLLayerOverlayIdent,
+		SharedGraphicLLayer.GraphicLLayerOverlayHeadline,
 		SharedGraphicLLayer.GraphicLLayerOverlayLower,
 		SharedGraphicLLayer.GraphicLLayerOverlayTema,
 		SharedGraphicLLayer.GraphicLLayerOverlayTopt,

--- a/src/tv2-common/helpers/graphics/caspar/slotMappings.ts
+++ b/src/tv2-common/helpers/graphics/caspar/slotMappings.ts
@@ -8,6 +8,7 @@ import { SharedGraphicLLayer } from 'tv2-constants'
 export const layerToHTMLGraphicSlot: { [slot: string]: string } = {
 	[SharedGraphicLLayer.GraphicLLayerOverlay]: '',
 	[SharedGraphicLLayer.GraphicLLayerOverlayIdent]: '650_ident',
+	[SharedGraphicLLayer.GraphicLLayerOverlayHeadline]: '440_headline',
 	[SharedGraphicLLayer.GraphicLLayerOverlayLower]: '450_lowerThird',
 	[SharedGraphicLLayer.GraphicLLayerOverlayTema]: '',
 	[SharedGraphicLLayer.GraphicLLayerOverlayTopt]: '660_topt',

--- a/src/tv2-common/helpers/graphics/layers.ts
+++ b/src/tv2-common/helpers/graphics/layers.ts
@@ -14,9 +14,6 @@ export function GetSourceLayerForGraphic(config: TV2BlueprintConfig, name: strin
 		// TODO: When adding more sourcelayers
 		// This is here to guard against bad user input
 		case SharedSourceLayers.PgmGraphicsHeadline:
-			if (config.studio.GraphicsType === 'HTML') {
-				return SharedSourceLayers.PgmGraphicsLower
-			}
 			return SharedSourceLayers.PgmGraphicsHeadline
 		case SharedSourceLayers.PgmGraphicsIdent:
 			return SharedSourceLayers.PgmGraphicsIdent
@@ -55,9 +52,6 @@ export function GetTimelineLayerForGraphic(config: TV2BlueprintConfig, name: str
 		case SharedGraphicLLayer.GraphicLLayerOverlayLower:
 			return SharedGraphicLLayer.GraphicLLayerOverlayLower
 		case SharedGraphicLLayer.GraphicLLayerOverlayHeadline:
-			if (config.studio.GraphicsType === 'HTML') {
-				return SharedGraphicLLayer.GraphicLLayerOverlayLower
-			}
 			return SharedGraphicLLayer.GraphicLLayerOverlayHeadline
 		case SharedGraphicLLayer.GraphicLLayerOverlayTema:
 			return SharedGraphicLLayer.GraphicLLayerOverlayTema


### PR DESCRIPTION
### Review Expectations

<!-- Check one and briefly explain your choice below. -->

- [ ] 🔍 **Thorough review** — Significant or high-risk changes, please review carefully
- [ ] ⚡ **Quick read-through** — Minor changes, just a sanity check
- [x] 🎯 **Focused review** — Please focus on specific areas (describe below)

<!-- Why did you choose this review type? E.g. "Config-only change, low risk" or "Core logic rewritten, needs careful review." -->

---

### What and Why?
This PR is an attempt to adding support for having both Headline and bundt graphics on air at the same time, such that a bundt can be taken on top of a headline(separate slot) while being layered on top.

The core logic is in `layers.ts`, where HTML headline graphics no longer het remapped onto the lower-third source layer or lower timeline layer. Also added the dedicated HTML headline slot in the `slotMappings.ts` and updated the HTML baseline setup in `index.ts` so the new slot is initialised and rest correctly. Some test coverage is also added to verify that the HTML headline stays on its own layer, bundt stays on the lower-third and the HTML baseline includes the new headline slot.

---

### Anything for the reviewer to know?

<!-- Edge cases, trade-offs, areas that need extra attention, etc. -->

---
